### PR TITLE
Runs on py3.11

### DIFF
--- a/Infoplus/api/aisle_api.py
+++ b/Infoplus/api/aisle_api.py
@@ -38,18 +38,18 @@ class AisleApi(object):
 
         Inserts a new aisle using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Aisle body: Aisle to be inserted. (required)
         :return: Aisle
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_aisle_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_aisle_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class AisleApi(object):
 
         Inserts a new aisle using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Aisle body: Aisle to be inserted. (required)
         :return: Aisle
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class AisleApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type='Aisle',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class AisleApi(object):
 
         Adds an audit to an existing aisle.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle_audit(aisle_id, aisle_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle_audit(aisle_id, aisle_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to add an audit to (required)
         :param str aisle_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class AisleApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_aisle_audit_with_http_info(aisle_id, aisle_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_aisle_audit_with_http_info(aisle_id, aisle_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class AisleApi(object):
 
         Adds an audit to an existing aisle.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle_audit_with_http_info(aisle_id, aisle_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle_audit_with_http_info(aisle_id, aisle_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to add an audit to (required)
         :param str aisle_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id', 'aisle_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class AisleApi(object):
 
         Adds a file to an existing aisle.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle_file(aisle_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle_file(aisle_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class AisleApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_aisle_file_with_http_info(aisle_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_aisle_file_with_http_info(aisle_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class AisleApi(object):
 
         Adds a file to an existing aisle.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle_file_with_http_info(aisle_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle_file_with_http_info(aisle_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class AisleApi(object):
 
         Adds a file to an existing aisle by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle_file_by_url(body, aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle_file_by_url(body, aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int aisle_id: Id of the aisle to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class AisleApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_aisle_file_by_url_with_http_info(body, aisle_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_aisle_file_by_url_with_http_info(body, aisle_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class AisleApi(object):
 
         Adds a file to an existing aisle by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle_file_by_url_with_http_info(body, aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle_file_by_url_with_http_info(body, aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int aisle_id: Id of the aisle to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class AisleApi(object):
         """
 
         all_params = ['body', 'aisle_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class AisleApi(object):
 
         Adds a tag to an existing aisle.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle_tag(aisle_id, aisle_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle_tag(aisle_id, aisle_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to add a tag to (required)
         :param str aisle_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class AisleApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_aisle_tag_with_http_info(aisle_id, aisle_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_aisle_tag_with_http_info(aisle_id, aisle_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class AisleApi(object):
 
         Adds a tag to an existing aisle.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_aisle_tag_with_http_info(aisle_id, aisle_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_aisle_tag_with_http_info(aisle_id, aisle_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to add a tag to (required)
         :param str aisle_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id', 'aisle_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class AisleApi(object):
 
         Deletes the aisle identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_aisle(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_aisle(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_aisle_with_http_info(aisle_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_aisle_with_http_info(aisle_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class AisleApi(object):
 
         Deletes the aisle identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_aisle_with_http_info(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_aisle_with_http_info(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class AisleApi(object):
 
         Deletes an existing aisle file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_aisle_file(aisle_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_aisle_file(aisle_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class AisleApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_aisle_file_with_http_info(aisle_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_aisle_file_with_http_info(aisle_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class AisleApi(object):
 
         Deletes an existing aisle file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_aisle_file_with_http_info(aisle_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_aisle_file_with_http_info(aisle_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class AisleApi(object):
 
         Deletes an existing aisle tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_aisle_tag(aisle_id, aisle_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_aisle_tag(aisle_id, aisle_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to remove tag from (required)
         :param str aisle_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class AisleApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_aisle_tag_with_http_info(aisle_id, aisle_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_aisle_tag_with_http_info(aisle_id, aisle_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class AisleApi(object):
 
         Deletes an existing aisle tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_aisle_tag_with_http_info(aisle_id, aisle_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_aisle_tag_with_http_info(aisle_id, aisle_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to remove tag from (required)
         :param str aisle_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id', 'aisle_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class AisleApi(object):
 
         Returns the list of aisles that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aisle_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_aisle_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class AisleApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_aisle_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_aisle_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class AisleApi(object):
 
         Returns the list of aisles that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aisle_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_aisle_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class AisleApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type='list[Aisle]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class AisleApi(object):
 
         Returns the aisle identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aisle_by_id(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_aisle_by_id(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to be returned. (required)
         :return: Aisle
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_aisle_by_id_with_http_info(aisle_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_aisle_by_id_with_http_info(aisle_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class AisleApi(object):
 
         Returns the aisle identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aisle_by_id_with_http_info(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_aisle_by_id_with_http_info(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to be returned. (required)
         :return: Aisle
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type='Aisle',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class AisleApi(object):
 
         Get all existing aisle files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aisle_files(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_aisle_files(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_aisle_files_with_http_info(aisle_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_aisle_files_with_http_info(aisle_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class AisleApi(object):
 
         Get all existing aisle files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aisle_files_with_http_info(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_aisle_files_with_http_info(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class AisleApi(object):
 
         Get all existing aisle tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aisle_tags(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_aisle_tags(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_aisle_tags_with_http_info(aisle_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_aisle_tags_with_http_info(aisle_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class AisleApi(object):
 
         Get all existing aisle tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aisle_tags_with_http_info(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_aisle_tags_with_http_info(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class AisleApi(object):
 
         Returns a duplicated aisle identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_aisle_by_id(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_aisle_by_id(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to be duplicated. (required)
         :return: Aisle
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_aisle_by_id_with_http_info(aisle_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_aisle_by_id_with_http_info(aisle_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class AisleApi(object):
 
         Returns a duplicated aisle identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_aisle_by_id_with_http_info(aisle_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_aisle_by_id_with_http_info(aisle_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int aisle_id: Id of the aisle to be duplicated. (required)
         :return: Aisle
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class AisleApi(object):
         """
 
         all_params = ['aisle_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type='Aisle',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class AisleApi(object):
 
         Updates an existing aisle using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_aisle(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_aisle(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Aisle body: Aisle to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_aisle_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_aisle_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class AisleApi(object):
 
         Updates an existing aisle using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_aisle_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_aisle_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Aisle body: Aisle to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class AisleApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class AisleApi(object):
 
         Updates an existing aisle custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_aisle_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_aisle_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Aisle body: Aisle to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_aisle_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_aisle_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class AisleApi(object):
 
         Updates an existing aisle custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_aisle_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_aisle_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Aisle body: Aisle to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class AisleApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class AisleApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/alert_api.py
+++ b/Infoplus/api/alert_api.py
@@ -38,18 +38,18 @@ class AlertApi(object):
 
         Inserts a new alert using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Alert body: Alert to be inserted. (required)
         :return: Alert
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_alert_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_alert_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class AlertApi(object):
 
         Inserts a new alert using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Alert body: Alert to be inserted. (required)
         :return: Alert
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class AlertApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type='Alert',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class AlertApi(object):
 
         Adds an audit to an existing alert.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert_audit(alert_id, alert_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert_audit(alert_id, alert_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to add an audit to (required)
         :param str alert_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class AlertApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_alert_audit_with_http_info(alert_id, alert_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_alert_audit_with_http_info(alert_id, alert_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class AlertApi(object):
 
         Adds an audit to an existing alert.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert_audit_with_http_info(alert_id, alert_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert_audit_with_http_info(alert_id, alert_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to add an audit to (required)
         :param str alert_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class AlertApi(object):
         """
 
         all_params = ['alert_id', 'alert_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class AlertApi(object):
 
         Adds a file to an existing alert.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert_file(alert_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert_file(alert_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class AlertApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_alert_file_with_http_info(alert_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_alert_file_with_http_info(alert_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class AlertApi(object):
 
         Adds a file to an existing alert.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert_file_with_http_info(alert_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert_file_with_http_info(alert_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class AlertApi(object):
         """
 
         all_params = ['alert_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class AlertApi(object):
 
         Adds a file to an existing alert by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert_file_by_url(body, alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert_file_by_url(body, alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int alert_id: Id of the alert to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class AlertApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_alert_file_by_url_with_http_info(body, alert_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_alert_file_by_url_with_http_info(body, alert_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class AlertApi(object):
 
         Adds a file to an existing alert by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert_file_by_url_with_http_info(body, alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert_file_by_url_with_http_info(body, alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int alert_id: Id of the alert to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class AlertApi(object):
         """
 
         all_params = ['body', 'alert_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class AlertApi(object):
 
         Adds a tag to an existing alert.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert_tag(alert_id, alert_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert_tag(alert_id, alert_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to add a tag to (required)
         :param str alert_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class AlertApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_alert_tag_with_http_info(alert_id, alert_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_alert_tag_with_http_info(alert_id, alert_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class AlertApi(object):
 
         Adds a tag to an existing alert.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_alert_tag_with_http_info(alert_id, alert_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_alert_tag_with_http_info(alert_id, alert_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to add a tag to (required)
         :param str alert_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class AlertApi(object):
         """
 
         all_params = ['alert_id', 'alert_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,11 +561,11 @@ class AlertApi(object):
 
         Deletes an existing alert file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_alert_file(alert_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_alert_file(alert_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -573,7 +573,7 @@ class AlertApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_alert_file_with_http_info(alert_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_alert_file_with_http_info(alert_id, file_id, **kwargs)  # noqa: E501
@@ -584,11 +584,11 @@ class AlertApi(object):
 
         Deletes an existing alert file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_alert_file_with_http_info(alert_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_alert_file_with_http_info(alert_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -597,7 +597,7 @@ class AlertApi(object):
         """
 
         all_params = ['alert_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -653,7 +653,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -664,11 +664,11 @@ class AlertApi(object):
 
         Deletes an existing alert tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_alert_tag(alert_id, alert_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_alert_tag(alert_id, alert_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to remove tag from (required)
         :param str alert_tag: The tag to delete (required)
         :return: None
@@ -676,7 +676,7 @@ class AlertApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_alert_tag_with_http_info(alert_id, alert_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_alert_tag_with_http_info(alert_id, alert_tag, **kwargs)  # noqa: E501
@@ -687,11 +687,11 @@ class AlertApi(object):
 
         Deletes an existing alert tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_alert_tag_with_http_info(alert_id, alert_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_alert_tag_with_http_info(alert_id, alert_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to remove tag from (required)
         :param str alert_tag: The tag to delete (required)
         :return: None
@@ -700,7 +700,7 @@ class AlertApi(object):
         """
 
         all_params = ['alert_id', 'alert_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -756,7 +756,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -767,11 +767,11 @@ class AlertApi(object):
 
         Returns the list of alerts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_alert_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_alert_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -781,7 +781,7 @@ class AlertApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_alert_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_alert_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -792,11 +792,11 @@ class AlertApi(object):
 
         Returns the list of alerts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_alert_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_alert_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -807,7 +807,7 @@ class AlertApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -859,7 +859,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type='list[Alert]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -870,18 +870,18 @@ class AlertApi(object):
 
         Returns the alert identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_alert_by_id(alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_alert_by_id(alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to be returned. (required)
         :return: Alert
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_alert_by_id_with_http_info(alert_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_alert_by_id_with_http_info(alert_id, **kwargs)  # noqa: E501
@@ -892,11 +892,11 @@ class AlertApi(object):
 
         Returns the alert identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_alert_by_id_with_http_info(alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_alert_by_id_with_http_info(alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to be returned. (required)
         :return: Alert
                  If the method is called asynchronously,
@@ -904,7 +904,7 @@ class AlertApi(object):
         """
 
         all_params = ['alert_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type='Alert',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class AlertApi(object):
 
         Get all existing alert files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_alert_files(alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_alert_files(alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_alert_files_with_http_info(alert_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_alert_files_with_http_info(alert_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class AlertApi(object):
 
         Get all existing alert files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_alert_files_with_http_info(alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_alert_files_with_http_info(alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class AlertApi(object):
         """
 
         all_params = ['alert_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class AlertApi(object):
 
         Get all existing alert tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_alert_tags(alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_alert_tags(alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_alert_tags_with_http_info(alert_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_alert_tags_with_http_info(alert_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class AlertApi(object):
 
         Get all existing alert tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_alert_tags_with_http_info(alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_alert_tags_with_http_info(alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class AlertApi(object):
         """
 
         all_params = ['alert_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class AlertApi(object):
 
         Returns a duplicated alert identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_alert_by_id(alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_alert_by_id(alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to be duplicated. (required)
         :return: Alert
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_alert_by_id_with_http_info(alert_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_alert_by_id_with_http_info(alert_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class AlertApi(object):
 
         Returns a duplicated alert identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_alert_by_id_with_http_info(alert_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_alert_by_id_with_http_info(alert_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int alert_id: Id of the alert to be duplicated. (required)
         :return: Alert
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class AlertApi(object):
         """
 
         all_params = ['alert_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type='Alert',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class AlertApi(object):
 
         Updates an existing alert custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_alert_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_alert_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Alert body: Alert to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_alert_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_alert_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class AlertApi(object):
 
         Updates an existing alert custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_alert_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_alert_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Alert body: Alert to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class AlertApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class AlertApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/asn_api.py
+++ b/Infoplus/api/asn_api.py
@@ -38,18 +38,18 @@ class AsnApi(object):
 
         Inserts a new asn using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Asn body: Asn to be inserted. (required)
         :return: Asn
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_asn_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_asn_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class AsnApi(object):
 
         Inserts a new asn using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Asn body: Asn to be inserted. (required)
         :return: Asn
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class AsnApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type='Asn',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class AsnApi(object):
 
         Adds an audit to an existing asn.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn_audit(asn_id, asn_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn_audit(asn_id, asn_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to add an audit to (required)
         :param str asn_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class AsnApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_asn_audit_with_http_info(asn_id, asn_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_asn_audit_with_http_info(asn_id, asn_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class AsnApi(object):
 
         Adds an audit to an existing asn.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn_audit_with_http_info(asn_id, asn_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn_audit_with_http_info(asn_id, asn_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to add an audit to (required)
         :param str asn_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id', 'asn_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class AsnApi(object):
 
         Adds a file to an existing asn.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn_file(asn_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn_file(asn_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class AsnApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_asn_file_with_http_info(asn_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_asn_file_with_http_info(asn_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class AsnApi(object):
 
         Adds a file to an existing asn.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn_file_with_http_info(asn_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn_file_with_http_info(asn_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class AsnApi(object):
 
         Adds a file to an existing asn by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn_file_by_url(body, asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn_file_by_url(body, asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int asn_id: Id of the asn to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class AsnApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_asn_file_by_url_with_http_info(body, asn_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_asn_file_by_url_with_http_info(body, asn_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class AsnApi(object):
 
         Adds a file to an existing asn by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn_file_by_url_with_http_info(body, asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn_file_by_url_with_http_info(body, asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int asn_id: Id of the asn to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class AsnApi(object):
         """
 
         all_params = ['body', 'asn_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class AsnApi(object):
 
         Adds a tag to an existing asn.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn_tag(asn_id, asn_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn_tag(asn_id, asn_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to add a tag to (required)
         :param str asn_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class AsnApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_asn_tag_with_http_info(asn_id, asn_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_asn_tag_with_http_info(asn_id, asn_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class AsnApi(object):
 
         Adds a tag to an existing asn.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_asn_tag_with_http_info(asn_id, asn_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_asn_tag_with_http_info(asn_id, asn_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to add a tag to (required)
         :param str asn_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id', 'asn_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class AsnApi(object):
 
         Deletes the asn identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_asn(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_asn(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_asn_with_http_info(asn_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_asn_with_http_info(asn_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class AsnApi(object):
 
         Deletes the asn identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_asn_with_http_info(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_asn_with_http_info(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class AsnApi(object):
 
         Deletes an existing asn file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_asn_file(asn_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_asn_file(asn_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class AsnApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_asn_file_with_http_info(asn_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_asn_file_with_http_info(asn_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class AsnApi(object):
 
         Deletes an existing asn file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_asn_file_with_http_info(asn_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_asn_file_with_http_info(asn_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class AsnApi(object):
 
         Deletes an existing asn tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_asn_tag(asn_id, asn_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_asn_tag(asn_id, asn_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to remove tag from (required)
         :param str asn_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class AsnApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_asn_tag_with_http_info(asn_id, asn_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_asn_tag_with_http_info(asn_id, asn_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class AsnApi(object):
 
         Deletes an existing asn tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_asn_tag_with_http_info(asn_id, asn_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_asn_tag_with_http_info(asn_id, asn_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to remove tag from (required)
         :param str asn_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id', 'asn_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class AsnApi(object):
 
         Returns the list of asns that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_asn_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_asn_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class AsnApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_asn_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_asn_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class AsnApi(object):
 
         Returns the list of asns that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_asn_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_asn_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class AsnApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type='list[Asn]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class AsnApi(object):
 
         Returns the asn identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_asn_by_id(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_asn_by_id(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to be returned. (required)
         :return: Asn
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_asn_by_id_with_http_info(asn_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_asn_by_id_with_http_info(asn_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class AsnApi(object):
 
         Returns the asn identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_asn_by_id_with_http_info(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_asn_by_id_with_http_info(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to be returned. (required)
         :return: Asn
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type='Asn',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class AsnApi(object):
 
         Get all existing asn files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_asn_files(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_asn_files(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_asn_files_with_http_info(asn_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_asn_files_with_http_info(asn_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class AsnApi(object):
 
         Get all existing asn files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_asn_files_with_http_info(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_asn_files_with_http_info(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class AsnApi(object):
 
         Get all existing asn tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_asn_tags(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_asn_tags(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_asn_tags_with_http_info(asn_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_asn_tags_with_http_info(asn_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class AsnApi(object):
 
         Get all existing asn tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_asn_tags_with_http_info(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_asn_tags_with_http_info(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class AsnApi(object):
 
         Returns a duplicated asn identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_asn_by_id(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_asn_by_id(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to be duplicated. (required)
         :return: Asn
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_asn_by_id_with_http_info(asn_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_asn_by_id_with_http_info(asn_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class AsnApi(object):
 
         Returns a duplicated asn identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_asn_by_id_with_http_info(asn_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_asn_by_id_with_http_info(asn_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int asn_id: Id of the asn to be duplicated. (required)
         :return: Asn
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class AsnApi(object):
         """
 
         all_params = ['asn_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type='Asn',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class AsnApi(object):
 
         Updates an existing asn using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_asn(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_asn(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Asn body: Asn to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_asn_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_asn_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class AsnApi(object):
 
         Updates an existing asn using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_asn_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_asn_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Asn body: Asn to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class AsnApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class AsnApi(object):
 
         Updates an existing asn custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_asn_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_asn_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Asn body: Asn to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_asn_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_asn_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class AsnApi(object):
 
         Updates an existing asn custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_asn_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_asn_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Asn body: Asn to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class AsnApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class AsnApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/bill_of_lading_api.py
+++ b/Infoplus/api/bill_of_lading_api.py
@@ -38,18 +38,18 @@ class BillOfLadingApi(object):
 
         Inserts a new billOfLading using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillOfLading body: BillOfLading to be inserted. (required)
         :return: BillOfLading
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_bill_of_lading_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_bill_of_lading_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class BillOfLadingApi(object):
 
         Inserts a new billOfLading using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillOfLading body: BillOfLading to be inserted. (required)
         :return: BillOfLading
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type='BillOfLading',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class BillOfLadingApi(object):
 
         Adds an audit to an existing billOfLading.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading_audit(bill_of_lading_id, bill_of_lading_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading_audit(bill_of_lading_id, bill_of_lading_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to add an audit to (required)
         :param str bill_of_lading_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class BillOfLadingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_bill_of_lading_audit_with_http_info(bill_of_lading_id, bill_of_lading_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_bill_of_lading_audit_with_http_info(bill_of_lading_id, bill_of_lading_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class BillOfLadingApi(object):
 
         Adds an audit to an existing billOfLading.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading_audit_with_http_info(bill_of_lading_id, bill_of_lading_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading_audit_with_http_info(bill_of_lading_id, bill_of_lading_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to add an audit to (required)
         :param str bill_of_lading_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id', 'bill_of_lading_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class BillOfLadingApi(object):
 
         Adds a file to an existing billOfLading.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading_file(bill_of_lading_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading_file(bill_of_lading_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class BillOfLadingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_bill_of_lading_file_with_http_info(bill_of_lading_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_bill_of_lading_file_with_http_info(bill_of_lading_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class BillOfLadingApi(object):
 
         Adds a file to an existing billOfLading.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading_file_with_http_info(bill_of_lading_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading_file_with_http_info(bill_of_lading_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class BillOfLadingApi(object):
 
         Adds a file to an existing billOfLading by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading_file_by_url(body, bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading_file_by_url(body, bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int bill_of_lading_id: Id of the billOfLading to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class BillOfLadingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_bill_of_lading_file_by_url_with_http_info(body, bill_of_lading_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_bill_of_lading_file_by_url_with_http_info(body, bill_of_lading_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class BillOfLadingApi(object):
 
         Adds a file to an existing billOfLading by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading_file_by_url_with_http_info(body, bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading_file_by_url_with_http_info(body, bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int bill_of_lading_id: Id of the billOfLading to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['body', 'bill_of_lading_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class BillOfLadingApi(object):
 
         Adds a tag to an existing billOfLading.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading_tag(bill_of_lading_id, bill_of_lading_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading_tag(bill_of_lading_id, bill_of_lading_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to add a tag to (required)
         :param str bill_of_lading_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class BillOfLadingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_bill_of_lading_tag_with_http_info(bill_of_lading_id, bill_of_lading_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_bill_of_lading_tag_with_http_info(bill_of_lading_id, bill_of_lading_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class BillOfLadingApi(object):
 
         Adds a tag to an existing billOfLading.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_bill_of_lading_tag_with_http_info(bill_of_lading_id, bill_of_lading_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_bill_of_lading_tag_with_http_info(bill_of_lading_id, bill_of_lading_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to add a tag to (required)
         :param str bill_of_lading_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id', 'bill_of_lading_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class BillOfLadingApi(object):
 
         Deletes the billOfLading identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_bill_of_lading(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_bill_of_lading(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_bill_of_lading_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_bill_of_lading_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class BillOfLadingApi(object):
 
         Deletes the billOfLading identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_bill_of_lading_with_http_info(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_bill_of_lading_with_http_info(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class BillOfLadingApi(object):
 
         Deletes an existing billOfLading file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_bill_of_lading_file(bill_of_lading_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_bill_of_lading_file(bill_of_lading_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class BillOfLadingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_bill_of_lading_file_with_http_info(bill_of_lading_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_bill_of_lading_file_with_http_info(bill_of_lading_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class BillOfLadingApi(object):
 
         Deletes an existing billOfLading file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_bill_of_lading_file_with_http_info(bill_of_lading_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_bill_of_lading_file_with_http_info(bill_of_lading_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class BillOfLadingApi(object):
 
         Deletes an existing billOfLading tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_bill_of_lading_tag(bill_of_lading_id, bill_of_lading_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_bill_of_lading_tag(bill_of_lading_id, bill_of_lading_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to remove tag from (required)
         :param str bill_of_lading_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class BillOfLadingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_bill_of_lading_tag_with_http_info(bill_of_lading_id, bill_of_lading_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_bill_of_lading_tag_with_http_info(bill_of_lading_id, bill_of_lading_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class BillOfLadingApi(object):
 
         Deletes an existing billOfLading tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_bill_of_lading_tag_with_http_info(bill_of_lading_id, bill_of_lading_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_bill_of_lading_tag_with_http_info(bill_of_lading_id, bill_of_lading_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to remove tag from (required)
         :param str bill_of_lading_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id', 'bill_of_lading_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class BillOfLadingApi(object):
 
         Returns the list of billOfLadings that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_bill_of_lading_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_bill_of_lading_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class BillOfLadingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_bill_of_lading_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_bill_of_lading_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class BillOfLadingApi(object):
 
         Returns the list of billOfLadings that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_bill_of_lading_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_bill_of_lading_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type='list[BillOfLading]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class BillOfLadingApi(object):
 
         Returns the billOfLading identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_bill_of_lading_by_id(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_bill_of_lading_by_id(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to be returned. (required)
         :return: BillOfLading
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_bill_of_lading_by_id_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_bill_of_lading_by_id_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class BillOfLadingApi(object):
 
         Returns the billOfLading identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_bill_of_lading_by_id_with_http_info(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_bill_of_lading_by_id_with_http_info(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to be returned. (required)
         :return: BillOfLading
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type='BillOfLading',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class BillOfLadingApi(object):
 
         Get all existing billOfLading files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_bill_of_lading_files(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_bill_of_lading_files(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_bill_of_lading_files_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_bill_of_lading_files_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class BillOfLadingApi(object):
 
         Get all existing billOfLading files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_bill_of_lading_files_with_http_info(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_bill_of_lading_files_with_http_info(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class BillOfLadingApi(object):
 
         Get all existing billOfLading tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_bill_of_lading_tags(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_bill_of_lading_tags(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_bill_of_lading_tags_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_bill_of_lading_tags_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class BillOfLadingApi(object):
 
         Get all existing billOfLading tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_bill_of_lading_tags_with_http_info(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_bill_of_lading_tags_with_http_info(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class BillOfLadingApi(object):
 
         Returns a duplicated billOfLading identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_bill_of_lading_by_id(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_bill_of_lading_by_id(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to be duplicated. (required)
         :return: BillOfLading
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_bill_of_lading_by_id_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_bill_of_lading_by_id_with_http_info(bill_of_lading_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class BillOfLadingApi(object):
 
         Returns a duplicated billOfLading identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_bill_of_lading_by_id_with_http_info(bill_of_lading_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_bill_of_lading_by_id_with_http_info(bill_of_lading_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int bill_of_lading_id: Id of the billOfLading to be duplicated. (required)
         :return: BillOfLading
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['bill_of_lading_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type='BillOfLading',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class BillOfLadingApi(object):
 
         Updates an existing billOfLading using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_bill_of_lading(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_bill_of_lading(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillOfLading body: BillOfLading to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_bill_of_lading_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_bill_of_lading_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class BillOfLadingApi(object):
 
         Updates an existing billOfLading using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_bill_of_lading_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_bill_of_lading_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillOfLading body: BillOfLading to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class BillOfLadingApi(object):
 
         Updates an existing billOfLading custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_bill_of_lading_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_bill_of_lading_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillOfLading body: BillOfLading to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_bill_of_lading_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_bill_of_lading_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class BillOfLadingApi(object):
 
         Updates an existing billOfLading custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_bill_of_lading_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_bill_of_lading_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillOfLading body: BillOfLading to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class BillOfLadingApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class BillOfLadingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/billing_code_activity_api.py
+++ b/Infoplus/api/billing_code_activity_api.py
@@ -38,18 +38,18 @@ class BillingCodeActivityApi(object):
 
         Inserts a new billingCodeActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeActivity body: BillingCodeActivity to be inserted. (required)
         :return: BillingCodeActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class BillingCodeActivityApi(object):
 
         Inserts a new billingCodeActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeActivity body: BillingCodeActivity to be inserted. (required)
         :return: BillingCodeActivity
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type='BillingCodeActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class BillingCodeActivityApi(object):
 
         Adds an audit to an existing billingCodeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity_audit(billing_code_activity_id, billing_code_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity_audit(billing_code_activity_id, billing_code_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to add an audit to (required)
         :param str billing_code_activity_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class BillingCodeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_activity_audit_with_http_info(billing_code_activity_id, billing_code_activity_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_activity_audit_with_http_info(billing_code_activity_id, billing_code_activity_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class BillingCodeActivityApi(object):
 
         Adds an audit to an existing billingCodeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity_audit_with_http_info(billing_code_activity_id, billing_code_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity_audit_with_http_info(billing_code_activity_id, billing_code_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to add an audit to (required)
         :param str billing_code_activity_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id', 'billing_code_activity_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class BillingCodeActivityApi(object):
 
         Adds a file to an existing billingCodeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity_file(billing_code_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity_file(billing_code_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class BillingCodeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_activity_file_with_http_info(billing_code_activity_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_activity_file_with_http_info(billing_code_activity_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class BillingCodeActivityApi(object):
 
         Adds a file to an existing billingCodeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity_file_with_http_info(billing_code_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity_file_with_http_info(billing_code_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class BillingCodeActivityApi(object):
 
         Adds a file to an existing billingCodeActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity_file_by_url(body, billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity_file_by_url(body, billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int billing_code_activity_id: Id of the billingCodeActivity to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class BillingCodeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_activity_file_by_url_with_http_info(body, billing_code_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_activity_file_by_url_with_http_info(body, billing_code_activity_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class BillingCodeActivityApi(object):
 
         Adds a file to an existing billingCodeActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity_file_by_url_with_http_info(body, billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity_file_by_url_with_http_info(body, billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int billing_code_activity_id: Id of the billingCodeActivity to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['body', 'billing_code_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class BillingCodeActivityApi(object):
 
         Adds a tag to an existing billingCodeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity_tag(billing_code_activity_id, billing_code_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity_tag(billing_code_activity_id, billing_code_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to add a tag to (required)
         :param str billing_code_activity_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class BillingCodeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_activity_tag_with_http_info(billing_code_activity_id, billing_code_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_activity_tag_with_http_info(billing_code_activity_id, billing_code_activity_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class BillingCodeActivityApi(object):
 
         Adds a tag to an existing billingCodeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_activity_tag_with_http_info(billing_code_activity_id, billing_code_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_activity_tag_with_http_info(billing_code_activity_id, billing_code_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to add a tag to (required)
         :param str billing_code_activity_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id', 'billing_code_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class BillingCodeActivityApi(object):
 
         Deletes the billingCodeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_activity(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_activity(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_billing_code_activity_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_billing_code_activity_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class BillingCodeActivityApi(object):
 
         Deletes the billingCodeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_activity_with_http_info(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_activity_with_http_info(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class BillingCodeActivityApi(object):
 
         Deletes an existing billingCodeActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_activity_file(billing_code_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_activity_file(billing_code_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class BillingCodeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_billing_code_activity_file_with_http_info(billing_code_activity_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_billing_code_activity_file_with_http_info(billing_code_activity_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class BillingCodeActivityApi(object):
 
         Deletes an existing billingCodeActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_activity_file_with_http_info(billing_code_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_activity_file_with_http_info(billing_code_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class BillingCodeActivityApi(object):
 
         Deletes an existing billingCodeActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_activity_tag(billing_code_activity_id, billing_code_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_activity_tag(billing_code_activity_id, billing_code_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to remove tag from (required)
         :param str billing_code_activity_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class BillingCodeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_billing_code_activity_tag_with_http_info(billing_code_activity_id, billing_code_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_billing_code_activity_tag_with_http_info(billing_code_activity_id, billing_code_activity_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class BillingCodeActivityApi(object):
 
         Deletes an existing billingCodeActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_activity_tag_with_http_info(billing_code_activity_id, billing_code_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_activity_tag_with_http_info(billing_code_activity_id, billing_code_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to remove tag from (required)
         :param str billing_code_activity_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id', 'billing_code_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class BillingCodeActivityApi(object):
 
         Returns the list of billingCodeActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_activity_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_activity_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class BillingCodeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class BillingCodeActivityApi(object):
 
         Returns the list of billingCodeActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_activity_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_activity_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type='list[BillingCodeActivity]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class BillingCodeActivityApi(object):
 
         Returns the billingCodeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_activity_by_id(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_activity_by_id(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to be returned. (required)
         :return: BillingCodeActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_activity_by_id_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_activity_by_id_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class BillingCodeActivityApi(object):
 
         Returns the billingCodeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_activity_by_id_with_http_info(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_activity_by_id_with_http_info(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to be returned. (required)
         :return: BillingCodeActivity
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type='BillingCodeActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class BillingCodeActivityApi(object):
 
         Get all existing billingCodeActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_activity_files(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_activity_files(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_activity_files_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_activity_files_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class BillingCodeActivityApi(object):
 
         Get all existing billingCodeActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_activity_files_with_http_info(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_activity_files_with_http_info(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class BillingCodeActivityApi(object):
 
         Get all existing billingCodeActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_activity_tags(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_activity_tags(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_activity_tags_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_activity_tags_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class BillingCodeActivityApi(object):
 
         Get all existing billingCodeActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_activity_tags_with_http_info(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_activity_tags_with_http_info(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class BillingCodeActivityApi(object):
 
         Returns a duplicated billingCodeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_billing_code_activity_by_id(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_billing_code_activity_by_id(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to be duplicated. (required)
         :return: BillingCodeActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_billing_code_activity_by_id_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_billing_code_activity_by_id_with_http_info(billing_code_activity_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class BillingCodeActivityApi(object):
 
         Returns a duplicated billingCodeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_billing_code_activity_by_id_with_http_info(billing_code_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_billing_code_activity_by_id_with_http_info(billing_code_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_activity_id: Id of the billingCodeActivity to be duplicated. (required)
         :return: BillingCodeActivity
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['billing_code_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type='BillingCodeActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class BillingCodeActivityApi(object):
 
         Updates an existing billingCodeActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeActivity body: BillingCodeActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_billing_code_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_billing_code_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class BillingCodeActivityApi(object):
 
         Updates an existing billingCodeActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeActivity body: BillingCodeActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class BillingCodeActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class BillingCodeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/billing_code_api.py
+++ b/Infoplus/api/billing_code_api.py
@@ -38,18 +38,18 @@ class BillingCodeApi(object):
 
         Inserts a new billingCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCode body: BillingCode to be inserted. (required)
         :return: BillingCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class BillingCodeApi(object):
 
         Inserts a new billingCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCode body: BillingCode to be inserted. (required)
         :return: BillingCode
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type='BillingCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class BillingCodeApi(object):
 
         Adds an audit to an existing billingCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_audit(billing_code_id, billing_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_audit(billing_code_id, billing_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to add an audit to (required)
         :param str billing_code_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class BillingCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_audit_with_http_info(billing_code_id, billing_code_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_audit_with_http_info(billing_code_id, billing_code_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class BillingCodeApi(object):
 
         Adds an audit to an existing billingCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_audit_with_http_info(billing_code_id, billing_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_audit_with_http_info(billing_code_id, billing_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to add an audit to (required)
         :param str billing_code_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id', 'billing_code_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class BillingCodeApi(object):
 
         Adds a file to an existing billingCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_file(billing_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_file(billing_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class BillingCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_file_with_http_info(billing_code_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_file_with_http_info(billing_code_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class BillingCodeApi(object):
 
         Adds a file to an existing billingCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_file_with_http_info(billing_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_file_with_http_info(billing_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class BillingCodeApi(object):
 
         Adds a file to an existing billingCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_file_by_url(body, billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_file_by_url(body, billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int billing_code_id: Id of the billingCode to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class BillingCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_file_by_url_with_http_info(body, billing_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_file_by_url_with_http_info(body, billing_code_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class BillingCodeApi(object):
 
         Adds a file to an existing billingCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_file_by_url_with_http_info(body, billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_file_by_url_with_http_info(body, billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int billing_code_id: Id of the billingCode to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['body', 'billing_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class BillingCodeApi(object):
 
         Adds a tag to an existing billingCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_tag(billing_code_id, billing_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_tag(billing_code_id, billing_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to add a tag to (required)
         :param str billing_code_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class BillingCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_tag_with_http_info(billing_code_id, billing_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_tag_with_http_info(billing_code_id, billing_code_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class BillingCodeApi(object):
 
         Adds a tag to an existing billingCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_tag_with_http_info(billing_code_id, billing_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_tag_with_http_info(billing_code_id, billing_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to add a tag to (required)
         :param str billing_code_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id', 'billing_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class BillingCodeApi(object):
 
         Deletes the billingCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_billing_code_with_http_info(billing_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_billing_code_with_http_info(billing_code_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class BillingCodeApi(object):
 
         Deletes the billingCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_with_http_info(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_with_http_info(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class BillingCodeApi(object):
 
         Deletes an existing billingCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_file(billing_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_file(billing_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class BillingCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_billing_code_file_with_http_info(billing_code_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_billing_code_file_with_http_info(billing_code_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class BillingCodeApi(object):
 
         Deletes an existing billingCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_file_with_http_info(billing_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_file_with_http_info(billing_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class BillingCodeApi(object):
 
         Deletes an existing billingCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_tag(billing_code_id, billing_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_tag(billing_code_id, billing_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to remove tag from (required)
         :param str billing_code_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class BillingCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_billing_code_tag_with_http_info(billing_code_id, billing_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_billing_code_tag_with_http_info(billing_code_id, billing_code_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class BillingCodeApi(object):
 
         Deletes an existing billingCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_tag_with_http_info(billing_code_id, billing_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_tag_with_http_info(billing_code_id, billing_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to remove tag from (required)
         :param str billing_code_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id', 'billing_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class BillingCodeApi(object):
 
         Returns the list of billingCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class BillingCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class BillingCodeApi(object):
 
         Returns the list of billingCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type='list[BillingCode]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class BillingCodeApi(object):
 
         Returns the billingCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_by_id(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_by_id(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to be returned. (required)
         :return: BillingCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_by_id_with_http_info(billing_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_by_id_with_http_info(billing_code_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class BillingCodeApi(object):
 
         Returns the billingCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_by_id_with_http_info(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_by_id_with_http_info(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to be returned. (required)
         :return: BillingCode
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type='BillingCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class BillingCodeApi(object):
 
         Get all existing billingCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_files(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_files(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_files_with_http_info(billing_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_files_with_http_info(billing_code_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class BillingCodeApi(object):
 
         Get all existing billingCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_files_with_http_info(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_files_with_http_info(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class BillingCodeApi(object):
 
         Get all existing billingCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_tags(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_tags(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_tags_with_http_info(billing_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_tags_with_http_info(billing_code_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class BillingCodeApi(object):
 
         Get all existing billingCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_tags_with_http_info(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_tags_with_http_info(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class BillingCodeApi(object):
 
         Returns a duplicated billingCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_billing_code_by_id(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_billing_code_by_id(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to be duplicated. (required)
         :return: BillingCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_billing_code_by_id_with_http_info(billing_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_billing_code_by_id_with_http_info(billing_code_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class BillingCodeApi(object):
 
         Returns a duplicated billingCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_billing_code_by_id_with_http_info(billing_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_billing_code_by_id_with_http_info(billing_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_id: Id of the billingCode to be duplicated. (required)
         :return: BillingCode
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['billing_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type='BillingCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class BillingCodeApi(object):
 
         Updates an existing billingCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCode body: BillingCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_billing_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_billing_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class BillingCodeApi(object):
 
         Updates an existing billingCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCode body: BillingCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class BillingCodeApi(object):
 
         Updates an existing billingCode custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCode body: BillingCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_billing_code_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_billing_code_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class BillingCodeApi(object):
 
         Updates an existing billingCode custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCode body: BillingCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class BillingCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class BillingCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/billing_code_type_api.py
+++ b/Infoplus/api/billing_code_type_api.py
@@ -38,18 +38,18 @@ class BillingCodeTypeApi(object):
 
         Inserts a new billingCodeType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeType body: BillingCodeType to be inserted. (required)
         :return: BillingCodeType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class BillingCodeTypeApi(object):
 
         Inserts a new billingCodeType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeType body: BillingCodeType to be inserted. (required)
         :return: BillingCodeType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type='BillingCodeType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class BillingCodeTypeApi(object):
 
         Adds an audit to an existing billingCodeType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type_audit(billing_code_type_id, billing_code_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type_audit(billing_code_type_id, billing_code_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to add an audit to (required)
         :param str billing_code_type_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class BillingCodeTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_type_audit_with_http_info(billing_code_type_id, billing_code_type_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_type_audit_with_http_info(billing_code_type_id, billing_code_type_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class BillingCodeTypeApi(object):
 
         Adds an audit to an existing billingCodeType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type_audit_with_http_info(billing_code_type_id, billing_code_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type_audit_with_http_info(billing_code_type_id, billing_code_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to add an audit to (required)
         :param str billing_code_type_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id', 'billing_code_type_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class BillingCodeTypeApi(object):
 
         Adds a file to an existing billingCodeType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type_file(billing_code_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type_file(billing_code_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class BillingCodeTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_type_file_with_http_info(billing_code_type_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_type_file_with_http_info(billing_code_type_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class BillingCodeTypeApi(object):
 
         Adds a file to an existing billingCodeType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type_file_with_http_info(billing_code_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type_file_with_http_info(billing_code_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class BillingCodeTypeApi(object):
 
         Adds a file to an existing billingCodeType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type_file_by_url(body, billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type_file_by_url(body, billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int billing_code_type_id: Id of the billingCodeType to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class BillingCodeTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_type_file_by_url_with_http_info(body, billing_code_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_type_file_by_url_with_http_info(body, billing_code_type_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class BillingCodeTypeApi(object):
 
         Adds a file to an existing billingCodeType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type_file_by_url_with_http_info(body, billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type_file_by_url_with_http_info(body, billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int billing_code_type_id: Id of the billingCodeType to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['body', 'billing_code_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class BillingCodeTypeApi(object):
 
         Adds a tag to an existing billingCodeType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type_tag(billing_code_type_id, billing_code_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type_tag(billing_code_type_id, billing_code_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to add a tag to (required)
         :param str billing_code_type_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class BillingCodeTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_billing_code_type_tag_with_http_info(billing_code_type_id, billing_code_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_billing_code_type_tag_with_http_info(billing_code_type_id, billing_code_type_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class BillingCodeTypeApi(object):
 
         Adds a tag to an existing billingCodeType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_billing_code_type_tag_with_http_info(billing_code_type_id, billing_code_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_billing_code_type_tag_with_http_info(billing_code_type_id, billing_code_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to add a tag to (required)
         :param str billing_code_type_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id', 'billing_code_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class BillingCodeTypeApi(object):
 
         Deletes the billingCodeType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_type(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_type(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_billing_code_type_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_billing_code_type_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class BillingCodeTypeApi(object):
 
         Deletes the billingCodeType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_type_with_http_info(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_type_with_http_info(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class BillingCodeTypeApi(object):
 
         Deletes an existing billingCodeType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_type_file(billing_code_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_type_file(billing_code_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class BillingCodeTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_billing_code_type_file_with_http_info(billing_code_type_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_billing_code_type_file_with_http_info(billing_code_type_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class BillingCodeTypeApi(object):
 
         Deletes an existing billingCodeType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_type_file_with_http_info(billing_code_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_type_file_with_http_info(billing_code_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class BillingCodeTypeApi(object):
 
         Deletes an existing billingCodeType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_type_tag(billing_code_type_id, billing_code_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_type_tag(billing_code_type_id, billing_code_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to remove tag from (required)
         :param str billing_code_type_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class BillingCodeTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_billing_code_type_tag_with_http_info(billing_code_type_id, billing_code_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_billing_code_type_tag_with_http_info(billing_code_type_id, billing_code_type_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class BillingCodeTypeApi(object):
 
         Deletes an existing billingCodeType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_billing_code_type_tag_with_http_info(billing_code_type_id, billing_code_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_billing_code_type_tag_with_http_info(billing_code_type_id, billing_code_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to remove tag from (required)
         :param str billing_code_type_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id', 'billing_code_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class BillingCodeTypeApi(object):
 
         Returns the list of billingCodeTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_type_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_type_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class BillingCodeTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_type_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_type_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class BillingCodeTypeApi(object):
 
         Returns the list of billingCodeTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_type_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_type_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type='list[BillingCodeType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class BillingCodeTypeApi(object):
 
         Returns the billingCodeType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_type_by_id(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_type_by_id(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to be returned. (required)
         :return: BillingCodeType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_type_by_id_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_type_by_id_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class BillingCodeTypeApi(object):
 
         Returns the billingCodeType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_type_by_id_with_http_info(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_type_by_id_with_http_info(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to be returned. (required)
         :return: BillingCodeType
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type='BillingCodeType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class BillingCodeTypeApi(object):
 
         Get all existing billingCodeType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_type_files(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_type_files(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_type_files_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_type_files_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class BillingCodeTypeApi(object):
 
         Get all existing billingCodeType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_type_files_with_http_info(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_type_files_with_http_info(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class BillingCodeTypeApi(object):
 
         Get all existing billingCodeType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_type_tags(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_type_tags(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_billing_code_type_tags_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_billing_code_type_tags_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class BillingCodeTypeApi(object):
 
         Get all existing billingCodeType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_billing_code_type_tags_with_http_info(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_billing_code_type_tags_with_http_info(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class BillingCodeTypeApi(object):
 
         Returns a duplicated billingCodeType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_billing_code_type_by_id(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_billing_code_type_by_id(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to be duplicated. (required)
         :return: BillingCodeType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_billing_code_type_by_id_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_billing_code_type_by_id_with_http_info(billing_code_type_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class BillingCodeTypeApi(object):
 
         Returns a duplicated billingCodeType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_billing_code_type_by_id_with_http_info(billing_code_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_billing_code_type_by_id_with_http_info(billing_code_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int billing_code_type_id: Id of the billingCodeType to be duplicated. (required)
         :return: BillingCodeType
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['billing_code_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type='BillingCodeType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class BillingCodeTypeApi(object):
 
         Updates an existing billingCodeType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeType body: BillingCodeType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_billing_code_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_billing_code_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class BillingCodeTypeApi(object):
 
         Updates an existing billingCodeType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeType body: BillingCodeType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class BillingCodeTypeApi(object):
 
         Updates an existing billingCodeType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code_type_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code_type_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeType body: BillingCodeType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_billing_code_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_billing_code_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class BillingCodeTypeApi(object):
 
         Updates an existing billingCodeType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_billing_code_type_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_billing_code_type_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BillingCodeType body: BillingCodeType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class BillingCodeTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class BillingCodeTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/building_api.py
+++ b/Infoplus/api/building_api.py
@@ -38,18 +38,18 @@ class BuildingApi(object):
 
         Inserts a new building using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Building body: Building to be inserted. (required)
         :return: Building
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_building_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_building_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class BuildingApi(object):
 
         Inserts a new building using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Building body: Building to be inserted. (required)
         :return: Building
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class BuildingApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type='Building',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class BuildingApi(object):
 
         Adds an audit to an existing building.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building_audit(building_id, building_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building_audit(building_id, building_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to add an audit to (required)
         :param str building_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class BuildingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_building_audit_with_http_info(building_id, building_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_building_audit_with_http_info(building_id, building_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class BuildingApi(object):
 
         Adds an audit to an existing building.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building_audit_with_http_info(building_id, building_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building_audit_with_http_info(building_id, building_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to add an audit to (required)
         :param str building_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id', 'building_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class BuildingApi(object):
 
         Adds a file to an existing building.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building_file(building_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building_file(building_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class BuildingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_building_file_with_http_info(building_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_building_file_with_http_info(building_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class BuildingApi(object):
 
         Adds a file to an existing building.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building_file_with_http_info(building_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building_file_with_http_info(building_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class BuildingApi(object):
 
         Adds a file to an existing building by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building_file_by_url(body, building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building_file_by_url(body, building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int building_id: Id of the building to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class BuildingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_building_file_by_url_with_http_info(body, building_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_building_file_by_url_with_http_info(body, building_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class BuildingApi(object):
 
         Adds a file to an existing building by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building_file_by_url_with_http_info(body, building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building_file_by_url_with_http_info(body, building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int building_id: Id of the building to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class BuildingApi(object):
         """
 
         all_params = ['body', 'building_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class BuildingApi(object):
 
         Adds a tag to an existing building.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building_tag(building_id, building_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building_tag(building_id, building_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to add a tag to (required)
         :param str building_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class BuildingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_building_tag_with_http_info(building_id, building_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_building_tag_with_http_info(building_id, building_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class BuildingApi(object):
 
         Adds a tag to an existing building.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_building_tag_with_http_info(building_id, building_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_building_tag_with_http_info(building_id, building_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to add a tag to (required)
         :param str building_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id', 'building_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class BuildingApi(object):
 
         Deletes the building identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_building(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_building(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_building_with_http_info(building_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_building_with_http_info(building_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class BuildingApi(object):
 
         Deletes the building identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_building_with_http_info(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_building_with_http_info(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class BuildingApi(object):
 
         Deletes an existing building file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_building_file(building_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_building_file(building_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class BuildingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_building_file_with_http_info(building_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_building_file_with_http_info(building_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class BuildingApi(object):
 
         Deletes an existing building file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_building_file_with_http_info(building_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_building_file_with_http_info(building_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class BuildingApi(object):
 
         Deletes an existing building tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_building_tag(building_id, building_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_building_tag(building_id, building_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to remove tag from (required)
         :param str building_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class BuildingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_building_tag_with_http_info(building_id, building_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_building_tag_with_http_info(building_id, building_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class BuildingApi(object):
 
         Deletes an existing building tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_building_tag_with_http_info(building_id, building_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_building_tag_with_http_info(building_id, building_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to remove tag from (required)
         :param str building_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id', 'building_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class BuildingApi(object):
 
         Returns the list of buildings that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_building_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_building_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class BuildingApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_building_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_building_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class BuildingApi(object):
 
         Returns the list of buildings that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_building_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_building_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class BuildingApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type='list[Building]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class BuildingApi(object):
 
         Returns the building identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_building_by_id(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_building_by_id(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to be returned. (required)
         :return: Building
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_building_by_id_with_http_info(building_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_building_by_id_with_http_info(building_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class BuildingApi(object):
 
         Returns the building identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_building_by_id_with_http_info(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_building_by_id_with_http_info(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to be returned. (required)
         :return: Building
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type='Building',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class BuildingApi(object):
 
         Get all existing building files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_building_files(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_building_files(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_building_files_with_http_info(building_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_building_files_with_http_info(building_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class BuildingApi(object):
 
         Get all existing building files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_building_files_with_http_info(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_building_files_with_http_info(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class BuildingApi(object):
 
         Get all existing building tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_building_tags(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_building_tags(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_building_tags_with_http_info(building_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_building_tags_with_http_info(building_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class BuildingApi(object):
 
         Get all existing building tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_building_tags_with_http_info(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_building_tags_with_http_info(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class BuildingApi(object):
 
         Returns a duplicated building identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_building_by_id(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_building_by_id(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to be duplicated. (required)
         :return: Building
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_building_by_id_with_http_info(building_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_building_by_id_with_http_info(building_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class BuildingApi(object):
 
         Returns a duplicated building identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_building_by_id_with_http_info(building_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_building_by_id_with_http_info(building_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int building_id: Id of the building to be duplicated. (required)
         :return: Building
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class BuildingApi(object):
         """
 
         all_params = ['building_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type='Building',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class BuildingApi(object):
 
         Updates an existing building using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_building(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_building(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Building body: Building to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_building_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_building_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class BuildingApi(object):
 
         Updates an existing building using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_building_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_building_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Building body: Building to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class BuildingApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class BuildingApi(object):
 
         Updates an existing building custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_building_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_building_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Building body: Building to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_building_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_building_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class BuildingApi(object):
 
         Updates an existing building custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_building_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_building_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Building body: Building to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class BuildingApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class BuildingApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/business_transaction_api.py
+++ b/Infoplus/api/business_transaction_api.py
@@ -38,18 +38,18 @@ class BusinessTransactionApi(object):
 
         Inserts a new businessTransaction using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BusinessTransaction body: BusinessTransaction to be inserted. (required)
         :return: BusinessTransaction
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_business_transaction_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_business_transaction_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class BusinessTransactionApi(object):
 
         Inserts a new businessTransaction using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BusinessTransaction body: BusinessTransaction to be inserted. (required)
         :return: BusinessTransaction
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type='BusinessTransaction',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class BusinessTransactionApi(object):
 
         Adds an audit to an existing businessTransaction.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction_audit(business_transaction_id, business_transaction_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction_audit(business_transaction_id, business_transaction_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to add an audit to (required)
         :param str business_transaction_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class BusinessTransactionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_business_transaction_audit_with_http_info(business_transaction_id, business_transaction_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_business_transaction_audit_with_http_info(business_transaction_id, business_transaction_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class BusinessTransactionApi(object):
 
         Adds an audit to an existing businessTransaction.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction_audit_with_http_info(business_transaction_id, business_transaction_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction_audit_with_http_info(business_transaction_id, business_transaction_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to add an audit to (required)
         :param str business_transaction_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['business_transaction_id', 'business_transaction_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class BusinessTransactionApi(object):
 
         Adds a file to an existing businessTransaction.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction_file(business_transaction_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction_file(business_transaction_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class BusinessTransactionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_business_transaction_file_with_http_info(business_transaction_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_business_transaction_file_with_http_info(business_transaction_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class BusinessTransactionApi(object):
 
         Adds a file to an existing businessTransaction.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction_file_with_http_info(business_transaction_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction_file_with_http_info(business_transaction_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['business_transaction_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class BusinessTransactionApi(object):
 
         Adds a file to an existing businessTransaction by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction_file_by_url(body, business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction_file_by_url(body, business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int business_transaction_id: Id of the businessTransaction to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class BusinessTransactionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_business_transaction_file_by_url_with_http_info(body, business_transaction_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_business_transaction_file_by_url_with_http_info(body, business_transaction_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class BusinessTransactionApi(object):
 
         Adds a file to an existing businessTransaction by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction_file_by_url_with_http_info(body, business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction_file_by_url_with_http_info(body, business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int business_transaction_id: Id of the businessTransaction to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['body', 'business_transaction_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class BusinessTransactionApi(object):
 
         Adds a tag to an existing businessTransaction.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction_tag(business_transaction_id, business_transaction_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction_tag(business_transaction_id, business_transaction_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to add a tag to (required)
         :param str business_transaction_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class BusinessTransactionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_business_transaction_tag_with_http_info(business_transaction_id, business_transaction_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_business_transaction_tag_with_http_info(business_transaction_id, business_transaction_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class BusinessTransactionApi(object):
 
         Adds a tag to an existing businessTransaction.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_business_transaction_tag_with_http_info(business_transaction_id, business_transaction_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_business_transaction_tag_with_http_info(business_transaction_id, business_transaction_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to add a tag to (required)
         :param str business_transaction_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['business_transaction_id', 'business_transaction_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,11 +561,11 @@ class BusinessTransactionApi(object):
 
         Deletes an existing businessTransaction file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_business_transaction_file(business_transaction_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_business_transaction_file(business_transaction_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -573,7 +573,7 @@ class BusinessTransactionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_business_transaction_file_with_http_info(business_transaction_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_business_transaction_file_with_http_info(business_transaction_id, file_id, **kwargs)  # noqa: E501
@@ -584,11 +584,11 @@ class BusinessTransactionApi(object):
 
         Deletes an existing businessTransaction file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_business_transaction_file_with_http_info(business_transaction_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_business_transaction_file_with_http_info(business_transaction_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -597,7 +597,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['business_transaction_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -653,7 +653,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -664,11 +664,11 @@ class BusinessTransactionApi(object):
 
         Deletes an existing businessTransaction tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_business_transaction_tag(business_transaction_id, business_transaction_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_business_transaction_tag(business_transaction_id, business_transaction_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to remove tag from (required)
         :param str business_transaction_tag: The tag to delete (required)
         :return: None
@@ -676,7 +676,7 @@ class BusinessTransactionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_business_transaction_tag_with_http_info(business_transaction_id, business_transaction_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_business_transaction_tag_with_http_info(business_transaction_id, business_transaction_tag, **kwargs)  # noqa: E501
@@ -687,11 +687,11 @@ class BusinessTransactionApi(object):
 
         Deletes an existing businessTransaction tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_business_transaction_tag_with_http_info(business_transaction_id, business_transaction_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_business_transaction_tag_with_http_info(business_transaction_id, business_transaction_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to remove tag from (required)
         :param str business_transaction_tag: The tag to delete (required)
         :return: None
@@ -700,7 +700,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['business_transaction_id', 'business_transaction_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -756,7 +756,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -767,11 +767,11 @@ class BusinessTransactionApi(object):
 
         Returns the list of businessTransactions that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_business_transaction_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_business_transaction_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -781,7 +781,7 @@ class BusinessTransactionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_business_transaction_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_business_transaction_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -792,11 +792,11 @@ class BusinessTransactionApi(object):
 
         Returns the list of businessTransactions that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_business_transaction_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_business_transaction_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -807,7 +807,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -859,7 +859,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type='list[BusinessTransaction]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -870,18 +870,18 @@ class BusinessTransactionApi(object):
 
         Returns the businessTransaction identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_business_transaction_by_id(business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_business_transaction_by_id(business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to be returned. (required)
         :return: BusinessTransaction
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_business_transaction_by_id_with_http_info(business_transaction_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_business_transaction_by_id_with_http_info(business_transaction_id, **kwargs)  # noqa: E501
@@ -892,11 +892,11 @@ class BusinessTransactionApi(object):
 
         Returns the businessTransaction identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_business_transaction_by_id_with_http_info(business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_business_transaction_by_id_with_http_info(business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to be returned. (required)
         :return: BusinessTransaction
                  If the method is called asynchronously,
@@ -904,7 +904,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['business_transaction_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type='BusinessTransaction',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class BusinessTransactionApi(object):
 
         Get all existing businessTransaction files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_business_transaction_files(business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_business_transaction_files(business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_business_transaction_files_with_http_info(business_transaction_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_business_transaction_files_with_http_info(business_transaction_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class BusinessTransactionApi(object):
 
         Get all existing businessTransaction files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_business_transaction_files_with_http_info(business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_business_transaction_files_with_http_info(business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['business_transaction_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class BusinessTransactionApi(object):
 
         Get all existing businessTransaction tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_business_transaction_tags(business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_business_transaction_tags(business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_business_transaction_tags_with_http_info(business_transaction_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_business_transaction_tags_with_http_info(business_transaction_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class BusinessTransactionApi(object):
 
         Get all existing businessTransaction tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_business_transaction_tags_with_http_info(business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_business_transaction_tags_with_http_info(business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['business_transaction_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class BusinessTransactionApi(object):
 
         Returns a duplicated businessTransaction identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_business_transaction_by_id(business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_business_transaction_by_id(business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to be duplicated. (required)
         :return: BusinessTransaction
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_business_transaction_by_id_with_http_info(business_transaction_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_business_transaction_by_id_with_http_info(business_transaction_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class BusinessTransactionApi(object):
 
         Returns a duplicated businessTransaction identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_business_transaction_by_id_with_http_info(business_transaction_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_business_transaction_by_id_with_http_info(business_transaction_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int business_transaction_id: Id of the businessTransaction to be duplicated. (required)
         :return: BusinessTransaction
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['business_transaction_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type='BusinessTransaction',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class BusinessTransactionApi(object):
 
         Updates an existing businessTransaction using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_business_transaction(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_business_transaction(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BusinessTransaction body: BusinessTransaction to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_business_transaction_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_business_transaction_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class BusinessTransactionApi(object):
 
         Updates an existing businessTransaction using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_business_transaction_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_business_transaction_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BusinessTransaction body: BusinessTransaction to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1349,18 +1349,18 @@ class BusinessTransactionApi(object):
 
         Updates an existing businessTransaction custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_business_transaction_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_business_transaction_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BusinessTransaction body: BusinessTransaction to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_business_transaction_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_business_transaction_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1371,11 +1371,11 @@ class BusinessTransactionApi(object):
 
         Updates an existing businessTransaction custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_business_transaction_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_business_transaction_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param BusinessTransaction body: BusinessTransaction to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1383,7 +1383,7 @@ class BusinessTransactionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1437,7 +1437,7 @@ class BusinessTransactionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/carrier_api.py
+++ b/Infoplus/api/carrier_api.py
@@ -38,18 +38,18 @@ class CarrierApi(object):
 
         Returns the carrier identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carrier_by_id(carrier_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carrier_by_id(carrier_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str carrier_id: Id of carrier to be returned. (required)
         :return: Carrier
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carrier_by_id_with_http_info(carrier_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carrier_by_id_with_http_info(carrier_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CarrierApi(object):
 
         Returns the carrier identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carrier_by_id_with_http_info(carrier_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carrier_by_id_with_http_info(carrier_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str carrier_id: Id of carrier to be returned. (required)
         :return: Carrier
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CarrierApi(object):
         """
 
         all_params = ['carrier_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class CarrierApi(object):
             files=local_var_files,
             response_type='Carrier',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class CarrierApi(object):
 
         Returns the list of carriers that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carrier_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carrier_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class CarrierApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carrier_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_carrier_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class CarrierApi(object):
 
         Returns the list of carriers that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carrier_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carrier_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class CarrierApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class CarrierApi(object):
             files=local_var_files,
             response_type='list[Carrier]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/carrier_service_api.py
+++ b/Infoplus/api/carrier_service_api.py
@@ -38,18 +38,18 @@ class CarrierServiceApi(object):
 
         Returns the carrierService identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carrier_service_by_id(carrier_service_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carrier_service_by_id(carrier_service_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str carrier_service_id: Id of carrierService to be returned. (required)
         :return: CarrierService
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carrier_service_by_id_with_http_info(carrier_service_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carrier_service_by_id_with_http_info(carrier_service_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CarrierServiceApi(object):
 
         Returns the carrierService identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carrier_service_by_id_with_http_info(carrier_service_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carrier_service_by_id_with_http_info(carrier_service_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str carrier_service_id: Id of carrierService to be returned. (required)
         :return: CarrierService
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CarrierServiceApi(object):
         """
 
         all_params = ['carrier_service_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class CarrierServiceApi(object):
             files=local_var_files,
             response_type='CarrierService',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class CarrierServiceApi(object):
 
         Returns the list of carrierServices that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carrier_service_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carrier_service_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class CarrierServiceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carrier_service_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_carrier_service_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class CarrierServiceApi(object):
 
         Returns the list of carrierServices that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carrier_service_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carrier_service_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class CarrierServiceApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class CarrierServiceApi(object):
             files=local_var_files,
             response_type='list[CarrierService]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/cart_api.py
+++ b/Infoplus/api/cart_api.py
@@ -38,18 +38,18 @@ class CartApi(object):
 
         Inserts a new cart using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Cart body: Cart to be inserted. (required)
         :return: Cart
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_cart_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_cart_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CartApi(object):
 
         Inserts a new cart using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Cart body: Cart to be inserted. (required)
         :return: Cart
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CartApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class CartApi(object):
             files=local_var_files,
             response_type='Cart',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class CartApi(object):
 
         Adds an audit to an existing cart.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_audit(cart_id, cart_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_audit(cart_id, cart_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to add an audit to (required)
         :param str cart_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class CartApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_cart_audit_with_http_info(cart_id, cart_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_cart_audit_with_http_info(cart_id, cart_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class CartApi(object):
 
         Adds an audit to an existing cart.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_audit_with_http_info(cart_id, cart_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_audit_with_http_info(cart_id, cart_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to add an audit to (required)
         :param str cart_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id', 'cart_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class CartApi(object):
 
         Adds a file to an existing cart.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_file(cart_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_file(cart_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class CartApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_cart_file_with_http_info(cart_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_cart_file_with_http_info(cart_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class CartApi(object):
 
         Adds a file to an existing cart.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_file_with_http_info(cart_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_file_with_http_info(cart_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class CartApi(object):
 
         Adds a file to an existing cart by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_file_by_url(body, cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_file_by_url(body, cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int cart_id: Id of the cart to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class CartApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_cart_file_by_url_with_http_info(body, cart_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_cart_file_by_url_with_http_info(body, cart_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class CartApi(object):
 
         Adds a file to an existing cart by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_file_by_url_with_http_info(body, cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_file_by_url_with_http_info(body, cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int cart_id: Id of the cart to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class CartApi(object):
         """
 
         all_params = ['body', 'cart_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class CartApi(object):
 
         Adds a tag to an existing cart.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_tag(cart_id, cart_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_tag(cart_id, cart_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to add a tag to (required)
         :param str cart_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class CartApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_cart_tag_with_http_info(cart_id, cart_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_cart_tag_with_http_info(cart_id, cart_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class CartApi(object):
 
         Adds a tag to an existing cart.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_tag_with_http_info(cart_id, cart_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_tag_with_http_info(cart_id, cart_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to add a tag to (required)
         :param str cart_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id', 'cart_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class CartApi(object):
 
         Deletes the cart identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_cart_with_http_info(cart_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_cart_with_http_info(cart_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class CartApi(object):
 
         Deletes the cart identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart_with_http_info(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart_with_http_info(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class CartApi(object):
 
         Deletes an existing cart file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart_file(cart_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart_file(cart_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class CartApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_cart_file_with_http_info(cart_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_cart_file_with_http_info(cart_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class CartApi(object):
 
         Deletes an existing cart file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart_file_with_http_info(cart_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart_file_with_http_info(cart_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class CartApi(object):
 
         Deletes an existing cart tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart_tag(cart_id, cart_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart_tag(cart_id, cart_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to remove tag from (required)
         :param str cart_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class CartApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_cart_tag_with_http_info(cart_id, cart_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_cart_tag_with_http_info(cart_id, cart_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class CartApi(object):
 
         Deletes an existing cart tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart_tag_with_http_info(cart_id, cart_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart_tag_with_http_info(cart_id, cart_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to remove tag from (required)
         :param str cart_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id', 'cart_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class CartApi(object):
 
         Returns the list of carts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class CartApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_cart_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_cart_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class CartApi(object):
 
         Returns the list of carts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class CartApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class CartApi(object):
             files=local_var_files,
             response_type='list[Cart]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class CartApi(object):
 
         Returns the cart identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_by_id(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_by_id(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to be returned. (required)
         :return: Cart
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_cart_by_id_with_http_info(cart_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_cart_by_id_with_http_info(cart_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class CartApi(object):
 
         Returns the cart identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_by_id_with_http_info(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_by_id_with_http_info(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to be returned. (required)
         :return: Cart
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class CartApi(object):
             files=local_var_files,
             response_type='Cart',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class CartApi(object):
 
         Get all existing cart files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_files(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_files(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_cart_files_with_http_info(cart_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_cart_files_with_http_info(cart_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class CartApi(object):
 
         Get all existing cart files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_files_with_http_info(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_files_with_http_info(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class CartApi(object):
 
         Get all existing cart tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_tags(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_tags(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_cart_tags_with_http_info(cart_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_cart_tags_with_http_info(cart_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class CartApi(object):
 
         Get all existing cart tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_tags_with_http_info(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_tags_with_http_info(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class CartApi(object):
 
         Returns a duplicated cart identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_cart_by_id(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_cart_by_id(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to be duplicated. (required)
         :return: Cart
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_cart_by_id_with_http_info(cart_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_cart_by_id_with_http_info(cart_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class CartApi(object):
 
         Returns a duplicated cart identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_cart_by_id_with_http_info(cart_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_cart_by_id_with_http_info(cart_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_id: Id of the cart to be duplicated. (required)
         :return: Cart
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class CartApi(object):
         """
 
         all_params = ['cart_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class CartApi(object):
             files=local_var_files,
             response_type='Cart',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class CartApi(object):
 
         Updates an existing cart using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_cart(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_cart(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Cart body: Cart to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_cart_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_cart_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class CartApi(object):
 
         Updates an existing cart using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_cart_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_cart_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Cart body: Cart to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class CartApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class CartApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/cart_location_api.py
+++ b/Infoplus/api/cart_location_api.py
@@ -38,11 +38,11 @@ class CartLocationApi(object):
 
         Adds an audit to an existing cartLocation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_location_audit(cart_location_id, cart_location_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_location_audit(cart_location_id, cart_location_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to add an audit to (required)
         :param str cart_location_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class CartLocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_cart_location_audit_with_http_info(cart_location_id, cart_location_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_cart_location_audit_with_http_info(cart_location_id, cart_location_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class CartLocationApi(object):
 
         Adds an audit to an existing cartLocation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_location_audit_with_http_info(cart_location_id, cart_location_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_location_audit_with_http_info(cart_location_id, cart_location_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to add an audit to (required)
         :param str cart_location_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['cart_location_id', 'cart_location_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class CartLocationApi(object):
 
         Adds a file to an existing cartLocation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_location_file(cart_location_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_location_file(cart_location_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class CartLocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_cart_location_file_with_http_info(cart_location_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_cart_location_file_with_http_info(cart_location_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class CartLocationApi(object):
 
         Adds a file to an existing cartLocation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_location_file_with_http_info(cart_location_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_location_file_with_http_info(cart_location_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['cart_location_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class CartLocationApi(object):
 
         Adds a file to an existing cartLocation by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_location_file_by_url(body, cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_location_file_by_url(body, cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int cart_location_id: Id of the cartLocation to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class CartLocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_cart_location_file_by_url_with_http_info(body, cart_location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_cart_location_file_by_url_with_http_info(body, cart_location_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class CartLocationApi(object):
 
         Adds a file to an existing cartLocation by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_location_file_by_url_with_http_info(body, cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_location_file_by_url_with_http_info(body, cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int cart_location_id: Id of the cartLocation to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['body', 'cart_location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class CartLocationApi(object):
 
         Adds a tag to an existing cartLocation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_location_tag(cart_location_id, cart_location_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_location_tag(cart_location_id, cart_location_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to add a tag to (required)
         :param str cart_location_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class CartLocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_cart_location_tag_with_http_info(cart_location_id, cart_location_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_cart_location_tag_with_http_info(cart_location_id, cart_location_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class CartLocationApi(object):
 
         Adds a tag to an existing cartLocation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_cart_location_tag_with_http_info(cart_location_id, cart_location_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_cart_location_tag_with_http_info(cart_location_id, cart_location_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to add a tag to (required)
         :param str cart_location_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['cart_location_id', 'cart_location_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class CartLocationApi(object):
 
         Deletes an existing cartLocation file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart_location_file(cart_location_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart_location_file(cart_location_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class CartLocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_cart_location_file_with_http_info(cart_location_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_cart_location_file_with_http_info(cart_location_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class CartLocationApi(object):
 
         Deletes an existing cartLocation file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart_location_file_with_http_info(cart_location_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart_location_file_with_http_info(cart_location_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['cart_location_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class CartLocationApi(object):
 
         Deletes an existing cartLocation tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart_location_tag(cart_location_id, cart_location_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart_location_tag(cart_location_id, cart_location_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to remove tag from (required)
         :param str cart_location_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class CartLocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_cart_location_tag_with_http_info(cart_location_id, cart_location_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_cart_location_tag_with_http_info(cart_location_id, cart_location_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class CartLocationApi(object):
 
         Deletes an existing cartLocation tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cart_location_tag_with_http_info(cart_location_id, cart_location_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_cart_location_tag_with_http_info(cart_location_id, cart_location_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to remove tag from (required)
         :param str cart_location_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['cart_location_id', 'cart_location_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,11 +668,11 @@ class CartLocationApi(object):
 
         Returns the list of cartLocations that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_location_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_location_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -682,7 +682,7 @@ class CartLocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_cart_location_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_cart_location_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -693,11 +693,11 @@ class CartLocationApi(object):
 
         Returns the list of cartLocations that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_location_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_location_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -708,7 +708,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -760,7 +760,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type='list[CartLocation]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -771,18 +771,18 @@ class CartLocationApi(object):
 
         Returns the cartLocation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_location_by_id(cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_location_by_id(cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to be returned. (required)
         :return: CartLocation
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_cart_location_by_id_with_http_info(cart_location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_cart_location_by_id_with_http_info(cart_location_id, **kwargs)  # noqa: E501
@@ -793,11 +793,11 @@ class CartLocationApi(object):
 
         Returns the cartLocation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_location_by_id_with_http_info(cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_location_by_id_with_http_info(cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to be returned. (required)
         :return: CartLocation
                  If the method is called asynchronously,
@@ -805,7 +805,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['cart_location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type='CartLocation',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class CartLocationApi(object):
 
         Get all existing cartLocation files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_location_files(cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_location_files(cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_cart_location_files_with_http_info(cart_location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_cart_location_files_with_http_info(cart_location_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class CartLocationApi(object):
 
         Get all existing cartLocation files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_location_files_with_http_info(cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_location_files_with_http_info(cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['cart_location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class CartLocationApi(object):
 
         Get all existing cartLocation tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_location_tags(cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_location_tags(cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_cart_location_tags_with_http_info(cart_location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_cart_location_tags_with_http_info(cart_location_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class CartLocationApi(object):
 
         Get all existing cartLocation tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cart_location_tags_with_http_info(cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_cart_location_tags_with_http_info(cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['cart_location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class CartLocationApi(object):
 
         Returns a duplicated cartLocation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_cart_location_by_id(cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_cart_location_by_id(cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to be duplicated. (required)
         :return: CartLocation
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_cart_location_by_id_with_http_info(cart_location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_cart_location_by_id_with_http_info(cart_location_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class CartLocationApi(object):
 
         Returns a duplicated cartLocation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_cart_location_by_id_with_http_info(cart_location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_cart_location_by_id_with_http_info(cart_location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int cart_location_id: Id of the cartLocation to be duplicated. (required)
         :return: CartLocation
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class CartLocationApi(object):
         """
 
         all_params = ['cart_location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class CartLocationApi(object):
             files=local_var_files,
             response_type='CartLocation',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/carton_activity_api.py
+++ b/Infoplus/api/carton_activity_api.py
@@ -38,18 +38,18 @@ class CartonActivityApi(object):
 
         Inserts a new cartonActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonActivity body: CartonActivity to be inserted. (required)
         :return: CartonActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CartonActivityApi(object):
 
         Inserts a new cartonActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonActivity body: CartonActivity to be inserted. (required)
         :return: CartonActivity
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type='CartonActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class CartonActivityApi(object):
 
         Adds an audit to an existing cartonActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity_audit(carton_activity_id, carton_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity_audit(carton_activity_id, carton_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to add an audit to (required)
         :param str carton_activity_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class CartonActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_activity_audit_with_http_info(carton_activity_id, carton_activity_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_activity_audit_with_http_info(carton_activity_id, carton_activity_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class CartonActivityApi(object):
 
         Adds an audit to an existing cartonActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity_audit_with_http_info(carton_activity_id, carton_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity_audit_with_http_info(carton_activity_id, carton_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to add an audit to (required)
         :param str carton_activity_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id', 'carton_activity_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class CartonActivityApi(object):
 
         Adds a file to an existing cartonActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity_file(carton_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity_file(carton_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class CartonActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_activity_file_with_http_info(carton_activity_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_activity_file_with_http_info(carton_activity_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class CartonActivityApi(object):
 
         Adds a file to an existing cartonActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity_file_with_http_info(carton_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity_file_with_http_info(carton_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class CartonActivityApi(object):
 
         Adds a file to an existing cartonActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity_file_by_url(body, carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity_file_by_url(body, carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int carton_activity_id: Id of the cartonActivity to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class CartonActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_activity_file_by_url_with_http_info(body, carton_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_activity_file_by_url_with_http_info(body, carton_activity_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class CartonActivityApi(object):
 
         Adds a file to an existing cartonActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity_file_by_url_with_http_info(body, carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity_file_by_url_with_http_info(body, carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int carton_activity_id: Id of the cartonActivity to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['body', 'carton_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class CartonActivityApi(object):
 
         Adds a tag to an existing cartonActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity_tag(carton_activity_id, carton_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity_tag(carton_activity_id, carton_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to add a tag to (required)
         :param str carton_activity_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class CartonActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_activity_tag_with_http_info(carton_activity_id, carton_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_activity_tag_with_http_info(carton_activity_id, carton_activity_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class CartonActivityApi(object):
 
         Adds a tag to an existing cartonActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_activity_tag_with_http_info(carton_activity_id, carton_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_activity_tag_with_http_info(carton_activity_id, carton_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to add a tag to (required)
         :param str carton_activity_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id', 'carton_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class CartonActivityApi(object):
 
         Deletes the cartonActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_activity(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_activity(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_activity_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_activity_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class CartonActivityApi(object):
 
         Deletes the cartonActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_activity_with_http_info(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_activity_with_http_info(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class CartonActivityApi(object):
 
         Deletes an existing cartonActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_activity_file(carton_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_activity_file(carton_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class CartonActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_activity_file_with_http_info(carton_activity_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_activity_file_with_http_info(carton_activity_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class CartonActivityApi(object):
 
         Deletes an existing cartonActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_activity_file_with_http_info(carton_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_activity_file_with_http_info(carton_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class CartonActivityApi(object):
 
         Deletes an existing cartonActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_activity_tag(carton_activity_id, carton_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_activity_tag(carton_activity_id, carton_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to remove tag from (required)
         :param str carton_activity_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class CartonActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_activity_tag_with_http_info(carton_activity_id, carton_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_activity_tag_with_http_info(carton_activity_id, carton_activity_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class CartonActivityApi(object):
 
         Deletes an existing cartonActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_activity_tag_with_http_info(carton_activity_id, carton_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_activity_tag_with_http_info(carton_activity_id, carton_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to remove tag from (required)
         :param str carton_activity_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id', 'carton_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class CartonActivityApi(object):
 
         Returns the list of cartonActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_activity_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_activity_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class CartonActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class CartonActivityApi(object):
 
         Returns the list of cartonActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_activity_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_activity_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type='list[CartonActivity]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class CartonActivityApi(object):
 
         Returns the cartonActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_activity_by_id(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_activity_by_id(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to be returned. (required)
         :return: CartonActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_activity_by_id_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_activity_by_id_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class CartonActivityApi(object):
 
         Returns the cartonActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_activity_by_id_with_http_info(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_activity_by_id_with_http_info(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to be returned. (required)
         :return: CartonActivity
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type='CartonActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class CartonActivityApi(object):
 
         Get all existing cartonActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_activity_files(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_activity_files(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_activity_files_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_activity_files_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class CartonActivityApi(object):
 
         Get all existing cartonActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_activity_files_with_http_info(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_activity_files_with_http_info(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class CartonActivityApi(object):
 
         Get all existing cartonActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_activity_tags(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_activity_tags(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_activity_tags_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_activity_tags_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class CartonActivityApi(object):
 
         Get all existing cartonActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_activity_tags_with_http_info(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_activity_tags_with_http_info(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class CartonActivityApi(object):
 
         Returns a duplicated cartonActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_carton_activity_by_id(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_carton_activity_by_id(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to be duplicated. (required)
         :return: CartonActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_carton_activity_by_id_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_carton_activity_by_id_with_http_info(carton_activity_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class CartonActivityApi(object):
 
         Returns a duplicated cartonActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_carton_activity_by_id_with_http_info(carton_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_carton_activity_by_id_with_http_info(carton_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_activity_id: Id of the cartonActivity to be duplicated. (required)
         :return: CartonActivity
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['carton_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type='CartonActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class CartonActivityApi(object):
 
         Updates an existing cartonActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonActivity body: CartonActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_carton_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_carton_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class CartonActivityApi(object):
 
         Updates an existing cartonActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonActivity body: CartonActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class CartonActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class CartonActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/carton_api.py
+++ b/Infoplus/api/carton_api.py
@@ -38,18 +38,18 @@ class CartonApi(object):
 
         Inserts a new carton using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Carton body: Carton to be inserted. (required)
         :return: Carton
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CartonApi(object):
 
         Inserts a new carton using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Carton body: Carton to be inserted. (required)
         :return: Carton
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CartonApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type='Carton',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class CartonApi(object):
 
         Adds an audit to an existing carton.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_audit(carton_id, carton_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_audit(carton_id, carton_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to add an audit to (required)
         :param str carton_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class CartonApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_audit_with_http_info(carton_id, carton_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_audit_with_http_info(carton_id, carton_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class CartonApi(object):
 
         Adds an audit to an existing carton.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_audit_with_http_info(carton_id, carton_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_audit_with_http_info(carton_id, carton_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to add an audit to (required)
         :param str carton_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id', 'carton_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class CartonApi(object):
 
         Adds a file to an existing carton.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_file(carton_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_file(carton_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class CartonApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_file_with_http_info(carton_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_file_with_http_info(carton_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class CartonApi(object):
 
         Adds a file to an existing carton.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_file_with_http_info(carton_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_file_with_http_info(carton_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class CartonApi(object):
 
         Adds a file to an existing carton by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_file_by_url(body, carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_file_by_url(body, carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int carton_id: Id of the carton to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class CartonApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_file_by_url_with_http_info(body, carton_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_file_by_url_with_http_info(body, carton_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class CartonApi(object):
 
         Adds a file to an existing carton by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_file_by_url_with_http_info(body, carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_file_by_url_with_http_info(body, carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int carton_id: Id of the carton to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class CartonApi(object):
         """
 
         all_params = ['body', 'carton_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class CartonApi(object):
 
         Adds a tag to an existing carton.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_tag(carton_id, carton_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_tag(carton_id, carton_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to add a tag to (required)
         :param str carton_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class CartonApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_tag_with_http_info(carton_id, carton_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_tag_with_http_info(carton_id, carton_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class CartonApi(object):
 
         Adds a tag to an existing carton.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_tag_with_http_info(carton_id, carton_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_tag_with_http_info(carton_id, carton_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to add a tag to (required)
         :param str carton_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id', 'carton_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class CartonApi(object):
 
         Deletes the carton identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_with_http_info(carton_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_with_http_info(carton_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class CartonApi(object):
 
         Deletes the carton identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_with_http_info(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_with_http_info(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class CartonApi(object):
 
         Deletes an existing carton file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_file(carton_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_file(carton_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class CartonApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_file_with_http_info(carton_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_file_with_http_info(carton_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class CartonApi(object):
 
         Deletes an existing carton file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_file_with_http_info(carton_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_file_with_http_info(carton_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class CartonApi(object):
 
         Deletes an existing carton tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_tag(carton_id, carton_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_tag(carton_id, carton_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to remove tag from (required)
         :param str carton_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class CartonApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_tag_with_http_info(carton_id, carton_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_tag_with_http_info(carton_id, carton_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class CartonApi(object):
 
         Deletes an existing carton tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_tag_with_http_info(carton_id, carton_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_tag_with_http_info(carton_id, carton_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to remove tag from (required)
         :param str carton_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id', 'carton_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class CartonApi(object):
 
         Returns the list of cartons that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class CartonApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class CartonApi(object):
 
         Returns the list of cartons that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class CartonApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type='list[Carton]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class CartonApi(object):
 
         Returns the carton identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_by_id(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_by_id(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to be returned. (required)
         :return: Carton
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_by_id_with_http_info(carton_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_by_id_with_http_info(carton_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class CartonApi(object):
 
         Returns the carton identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_by_id_with_http_info(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_by_id_with_http_info(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to be returned. (required)
         :return: Carton
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type='Carton',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class CartonApi(object):
 
         Get all existing carton files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_files(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_files(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_files_with_http_info(carton_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_files_with_http_info(carton_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class CartonApi(object):
 
         Get all existing carton files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_files_with_http_info(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_files_with_http_info(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class CartonApi(object):
 
         Get all existing carton tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_tags(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_tags(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_tags_with_http_info(carton_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_tags_with_http_info(carton_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class CartonApi(object):
 
         Get all existing carton tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_tags_with_http_info(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_tags_with_http_info(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class CartonApi(object):
 
         Returns a duplicated carton identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_carton_by_id(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_carton_by_id(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to be duplicated. (required)
         :return: Carton
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_carton_by_id_with_http_info(carton_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_carton_by_id_with_http_info(carton_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class CartonApi(object):
 
         Returns a duplicated carton identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_carton_by_id_with_http_info(carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_carton_by_id_with_http_info(carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_id: Id of the carton to be duplicated. (required)
         :return: Carton
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class CartonApi(object):
         """
 
         all_params = ['carton_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type='Carton',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class CartonApi(object):
 
         Updates an existing carton using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Carton body: Carton to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_carton_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_carton_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class CartonApi(object):
 
         Updates an existing carton using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Carton body: Carton to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class CartonApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class CartonApi(object):
 
         Updates an existing carton custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Carton body: Carton to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_carton_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_carton_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class CartonApi(object):
 
         Updates an existing carton custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Carton body: Carton to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class CartonApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class CartonApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/carton_content_api.py
+++ b/Infoplus/api/carton_content_api.py
@@ -38,18 +38,18 @@ class CartonContentApi(object):
 
         Inserts a new cartonContent using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonContent body: CartonContent to be inserted. (required)
         :return: CartonContent
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_content_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_content_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CartonContentApi(object):
 
         Inserts a new cartonContent using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonContent body: CartonContent to be inserted. (required)
         :return: CartonContent
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type='CartonContent',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class CartonContentApi(object):
 
         Adds an audit to an existing cartonContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content_audit(carton_content_id, carton_content_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content_audit(carton_content_id, carton_content_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to add an audit to (required)
         :param str carton_content_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class CartonContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_content_audit_with_http_info(carton_content_id, carton_content_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_content_audit_with_http_info(carton_content_id, carton_content_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class CartonContentApi(object):
 
         Adds an audit to an existing cartonContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content_audit_with_http_info(carton_content_id, carton_content_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content_audit_with_http_info(carton_content_id, carton_content_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to add an audit to (required)
         :param str carton_content_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id', 'carton_content_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class CartonContentApi(object):
 
         Adds a file to an existing cartonContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content_file(carton_content_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content_file(carton_content_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class CartonContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_content_file_with_http_info(carton_content_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_content_file_with_http_info(carton_content_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class CartonContentApi(object):
 
         Adds a file to an existing cartonContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content_file_with_http_info(carton_content_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content_file_with_http_info(carton_content_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class CartonContentApi(object):
 
         Adds a file to an existing cartonContent by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content_file_by_url(body, carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content_file_by_url(body, carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int carton_content_id: Id of the cartonContent to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class CartonContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_content_file_by_url_with_http_info(body, carton_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_content_file_by_url_with_http_info(body, carton_content_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class CartonContentApi(object):
 
         Adds a file to an existing cartonContent by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content_file_by_url_with_http_info(body, carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content_file_by_url_with_http_info(body, carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int carton_content_id: Id of the cartonContent to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['body', 'carton_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class CartonContentApi(object):
 
         Adds a tag to an existing cartonContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content_tag(carton_content_id, carton_content_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content_tag(carton_content_id, carton_content_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to add a tag to (required)
         :param str carton_content_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class CartonContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_content_tag_with_http_info(carton_content_id, carton_content_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_content_tag_with_http_info(carton_content_id, carton_content_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class CartonContentApi(object):
 
         Adds a tag to an existing cartonContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_content_tag_with_http_info(carton_content_id, carton_content_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_content_tag_with_http_info(carton_content_id, carton_content_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to add a tag to (required)
         :param str carton_content_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id', 'carton_content_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class CartonContentApi(object):
 
         Deletes the cartonContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_content(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_content(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_content_with_http_info(carton_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_content_with_http_info(carton_content_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class CartonContentApi(object):
 
         Deletes the cartonContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_content_with_http_info(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_content_with_http_info(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class CartonContentApi(object):
 
         Deletes an existing cartonContent file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_content_file(carton_content_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_content_file(carton_content_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class CartonContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_content_file_with_http_info(carton_content_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_content_file_with_http_info(carton_content_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class CartonContentApi(object):
 
         Deletes an existing cartonContent file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_content_file_with_http_info(carton_content_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_content_file_with_http_info(carton_content_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class CartonContentApi(object):
 
         Deletes an existing cartonContent tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_content_tag(carton_content_id, carton_content_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_content_tag(carton_content_id, carton_content_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to remove tag from (required)
         :param str carton_content_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class CartonContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_content_tag_with_http_info(carton_content_id, carton_content_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_content_tag_with_http_info(carton_content_id, carton_content_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class CartonContentApi(object):
 
         Deletes an existing cartonContent tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_content_tag_with_http_info(carton_content_id, carton_content_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_content_tag_with_http_info(carton_content_id, carton_content_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to remove tag from (required)
         :param str carton_content_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id', 'carton_content_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class CartonContentApi(object):
 
         Returns the list of cartonContents that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_content_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_content_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class CartonContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_content_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_content_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class CartonContentApi(object):
 
         Returns the list of cartonContents that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_content_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_content_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type='list[CartonContent]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class CartonContentApi(object):
 
         Returns the cartonContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_content_by_id(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_content_by_id(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to be returned. (required)
         :return: CartonContent
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_content_by_id_with_http_info(carton_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_content_by_id_with_http_info(carton_content_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class CartonContentApi(object):
 
         Returns the cartonContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_content_by_id_with_http_info(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_content_by_id_with_http_info(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to be returned. (required)
         :return: CartonContent
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type='CartonContent',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class CartonContentApi(object):
 
         Get all existing cartonContent files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_content_files(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_content_files(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_content_files_with_http_info(carton_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_content_files_with_http_info(carton_content_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class CartonContentApi(object):
 
         Get all existing cartonContent files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_content_files_with_http_info(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_content_files_with_http_info(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class CartonContentApi(object):
 
         Get all existing cartonContent tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_content_tags(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_content_tags(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_content_tags_with_http_info(carton_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_content_tags_with_http_info(carton_content_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class CartonContentApi(object):
 
         Get all existing cartonContent tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_content_tags_with_http_info(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_content_tags_with_http_info(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class CartonContentApi(object):
 
         Returns a duplicated cartonContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_carton_content_by_id(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_carton_content_by_id(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to be duplicated. (required)
         :return: CartonContent
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_carton_content_by_id_with_http_info(carton_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_carton_content_by_id_with_http_info(carton_content_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class CartonContentApi(object):
 
         Returns a duplicated cartonContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_carton_content_by_id_with_http_info(carton_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_carton_content_by_id_with_http_info(carton_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_content_id: Id of the cartonContent to be duplicated. (required)
         :return: CartonContent
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['carton_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type='CartonContent',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class CartonContentApi(object):
 
         Updates an existing cartonContent using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_content(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_content(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonContent body: CartonContent to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_carton_content_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_carton_content_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class CartonContentApi(object):
 
         Updates an existing cartonContent using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_content_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_content_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonContent body: CartonContent to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class CartonContentApi(object):
 
         Updates an existing cartonContent custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_content_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_content_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonContent body: CartonContent to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_carton_content_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_carton_content_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class CartonContentApi(object):
 
         Updates an existing cartonContent custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_content_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_content_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonContent body: CartonContent to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class CartonContentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class CartonContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/carton_type_api.py
+++ b/Infoplus/api/carton_type_api.py
@@ -38,18 +38,18 @@ class CartonTypeApi(object):
 
         Inserts a new cartonType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonType body: CartonType to be inserted. (required)
         :return: CartonType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CartonTypeApi(object):
 
         Inserts a new cartonType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonType body: CartonType to be inserted. (required)
         :return: CartonType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type='CartonType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class CartonTypeApi(object):
 
         Adds an audit to an existing cartonType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type_audit(carton_type_id, carton_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type_audit(carton_type_id, carton_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to add an audit to (required)
         :param str carton_type_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class CartonTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_type_audit_with_http_info(carton_type_id, carton_type_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_type_audit_with_http_info(carton_type_id, carton_type_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class CartonTypeApi(object):
 
         Adds an audit to an existing cartonType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type_audit_with_http_info(carton_type_id, carton_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type_audit_with_http_info(carton_type_id, carton_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to add an audit to (required)
         :param str carton_type_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id', 'carton_type_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class CartonTypeApi(object):
 
         Adds a file to an existing cartonType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type_file(carton_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type_file(carton_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class CartonTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_type_file_with_http_info(carton_type_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_type_file_with_http_info(carton_type_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class CartonTypeApi(object):
 
         Adds a file to an existing cartonType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type_file_with_http_info(carton_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type_file_with_http_info(carton_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class CartonTypeApi(object):
 
         Adds a file to an existing cartonType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type_file_by_url(body, carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type_file_by_url(body, carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int carton_type_id: Id of the cartonType to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class CartonTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_type_file_by_url_with_http_info(body, carton_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_type_file_by_url_with_http_info(body, carton_type_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class CartonTypeApi(object):
 
         Adds a file to an existing cartonType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type_file_by_url_with_http_info(body, carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type_file_by_url_with_http_info(body, carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int carton_type_id: Id of the cartonType to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['body', 'carton_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class CartonTypeApi(object):
 
         Adds a tag to an existing cartonType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type_tag(carton_type_id, carton_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type_tag(carton_type_id, carton_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to add a tag to (required)
         :param str carton_type_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class CartonTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_carton_type_tag_with_http_info(carton_type_id, carton_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_carton_type_tag_with_http_info(carton_type_id, carton_type_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class CartonTypeApi(object):
 
         Adds a tag to an existing cartonType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_carton_type_tag_with_http_info(carton_type_id, carton_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_carton_type_tag_with_http_info(carton_type_id, carton_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to add a tag to (required)
         :param str carton_type_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id', 'carton_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class CartonTypeApi(object):
 
         Deletes the cartonType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_type(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_type(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_type_with_http_info(carton_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_type_with_http_info(carton_type_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class CartonTypeApi(object):
 
         Deletes the cartonType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_type_with_http_info(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_type_with_http_info(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class CartonTypeApi(object):
 
         Deletes an existing cartonType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_type_file(carton_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_type_file(carton_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class CartonTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_type_file_with_http_info(carton_type_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_type_file_with_http_info(carton_type_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class CartonTypeApi(object):
 
         Deletes an existing cartonType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_type_file_with_http_info(carton_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_type_file_with_http_info(carton_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class CartonTypeApi(object):
 
         Deletes an existing cartonType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_type_tag(carton_type_id, carton_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_type_tag(carton_type_id, carton_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to remove tag from (required)
         :param str carton_type_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class CartonTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_carton_type_tag_with_http_info(carton_type_id, carton_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_carton_type_tag_with_http_info(carton_type_id, carton_type_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class CartonTypeApi(object):
 
         Deletes an existing cartonType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_carton_type_tag_with_http_info(carton_type_id, carton_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_carton_type_tag_with_http_info(carton_type_id, carton_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to remove tag from (required)
         :param str carton_type_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id', 'carton_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class CartonTypeApi(object):
 
         Returns the list of cartonTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_type_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_type_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class CartonTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_type_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_type_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class CartonTypeApi(object):
 
         Returns the list of cartonTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_type_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_type_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type='list[CartonType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class CartonTypeApi(object):
 
         Returns the cartonType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_type_by_id(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_type_by_id(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to be returned. (required)
         :return: CartonType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_type_by_id_with_http_info(carton_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_type_by_id_with_http_info(carton_type_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class CartonTypeApi(object):
 
         Returns the cartonType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_type_by_id_with_http_info(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_type_by_id_with_http_info(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to be returned. (required)
         :return: CartonType
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type='CartonType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class CartonTypeApi(object):
 
         Get all existing cartonType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_type_files(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_type_files(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_type_files_with_http_info(carton_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_type_files_with_http_info(carton_type_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class CartonTypeApi(object):
 
         Get all existing cartonType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_type_files_with_http_info(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_type_files_with_http_info(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class CartonTypeApi(object):
 
         Get all existing cartonType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_type_tags(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_type_tags(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_carton_type_tags_with_http_info(carton_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_carton_type_tags_with_http_info(carton_type_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class CartonTypeApi(object):
 
         Get all existing cartonType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_carton_type_tags_with_http_info(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_carton_type_tags_with_http_info(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class CartonTypeApi(object):
 
         Returns a duplicated cartonType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_carton_type_by_id(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_carton_type_by_id(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to be duplicated. (required)
         :return: CartonType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_carton_type_by_id_with_http_info(carton_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_carton_type_by_id_with_http_info(carton_type_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class CartonTypeApi(object):
 
         Returns a duplicated cartonType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_carton_type_by_id_with_http_info(carton_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_carton_type_by_id_with_http_info(carton_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int carton_type_id: Id of the cartonType to be duplicated. (required)
         :return: CartonType
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['carton_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type='CartonType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class CartonTypeApi(object):
 
         Updates an existing cartonType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonType body: CartonType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_carton_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_carton_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class CartonTypeApi(object):
 
         Updates an existing cartonType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonType body: CartonType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class CartonTypeApi(object):
 
         Updates an existing cartonType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_type_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_type_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonType body: CartonType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_carton_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_carton_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class CartonTypeApi(object):
 
         Updates an existing cartonType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_carton_type_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_carton_type_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CartonType body: CartonType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class CartonTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class CartonTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/commodity_code_api.py
+++ b/Infoplus/api/commodity_code_api.py
@@ -38,11 +38,11 @@ class CommodityCodeApi(object):
 
         Adds an audit to an existing commodityCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_commodity_code_audit(commodity_code_id, commodity_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_commodity_code_audit(commodity_code_id, commodity_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to add an audit to (required)
         :param str commodity_code_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class CommodityCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_commodity_code_audit_with_http_info(commodity_code_id, commodity_code_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_commodity_code_audit_with_http_info(commodity_code_id, commodity_code_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class CommodityCodeApi(object):
 
         Adds an audit to an existing commodityCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_commodity_code_audit_with_http_info(commodity_code_id, commodity_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_commodity_code_audit_with_http_info(commodity_code_id, commodity_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to add an audit to (required)
         :param str commodity_code_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['commodity_code_id', 'commodity_code_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class CommodityCodeApi(object):
 
         Adds a file to an existing commodityCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_commodity_code_file(commodity_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_commodity_code_file(commodity_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class CommodityCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_commodity_code_file_with_http_info(commodity_code_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_commodity_code_file_with_http_info(commodity_code_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class CommodityCodeApi(object):
 
         Adds a file to an existing commodityCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_commodity_code_file_with_http_info(commodity_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_commodity_code_file_with_http_info(commodity_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['commodity_code_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class CommodityCodeApi(object):
 
         Adds a file to an existing commodityCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_commodity_code_file_by_url(body, commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_commodity_code_file_by_url(body, commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int commodity_code_id: Id of the commodityCode to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class CommodityCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_commodity_code_file_by_url_with_http_info(body, commodity_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_commodity_code_file_by_url_with_http_info(body, commodity_code_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class CommodityCodeApi(object):
 
         Adds a file to an existing commodityCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_commodity_code_file_by_url_with_http_info(body, commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_commodity_code_file_by_url_with_http_info(body, commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int commodity_code_id: Id of the commodityCode to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['body', 'commodity_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class CommodityCodeApi(object):
 
         Adds a tag to an existing commodityCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_commodity_code_tag(commodity_code_id, commodity_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_commodity_code_tag(commodity_code_id, commodity_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to add a tag to (required)
         :param str commodity_code_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class CommodityCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_commodity_code_tag_with_http_info(commodity_code_id, commodity_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_commodity_code_tag_with_http_info(commodity_code_id, commodity_code_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class CommodityCodeApi(object):
 
         Adds a tag to an existing commodityCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_commodity_code_tag_with_http_info(commodity_code_id, commodity_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_commodity_code_tag_with_http_info(commodity_code_id, commodity_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to add a tag to (required)
         :param str commodity_code_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['commodity_code_id', 'commodity_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class CommodityCodeApi(object):
 
         Deletes an existing commodityCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_commodity_code_file(commodity_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_commodity_code_file(commodity_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class CommodityCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_commodity_code_file_with_http_info(commodity_code_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_commodity_code_file_with_http_info(commodity_code_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class CommodityCodeApi(object):
 
         Deletes an existing commodityCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_commodity_code_file_with_http_info(commodity_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_commodity_code_file_with_http_info(commodity_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['commodity_code_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class CommodityCodeApi(object):
 
         Deletes an existing commodityCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_commodity_code_tag(commodity_code_id, commodity_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_commodity_code_tag(commodity_code_id, commodity_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to remove tag from (required)
         :param str commodity_code_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class CommodityCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_commodity_code_tag_with_http_info(commodity_code_id, commodity_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_commodity_code_tag_with_http_info(commodity_code_id, commodity_code_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class CommodityCodeApi(object):
 
         Deletes an existing commodityCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_commodity_code_tag_with_http_info(commodity_code_id, commodity_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_commodity_code_tag_with_http_info(commodity_code_id, commodity_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to remove tag from (required)
         :param str commodity_code_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['commodity_code_id', 'commodity_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,11 +668,11 @@ class CommodityCodeApi(object):
 
         Returns the list of commodityCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_commodity_code_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_commodity_code_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -682,7 +682,7 @@ class CommodityCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_commodity_code_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_commodity_code_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -693,11 +693,11 @@ class CommodityCodeApi(object):
 
         Returns the list of commodityCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_commodity_code_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_commodity_code_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -708,7 +708,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -760,7 +760,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type='list[CommodityCode]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -771,18 +771,18 @@ class CommodityCodeApi(object):
 
         Returns the commodityCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_commodity_code_by_id(commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_commodity_code_by_id(commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to be returned. (required)
         :return: CommodityCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_commodity_code_by_id_with_http_info(commodity_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_commodity_code_by_id_with_http_info(commodity_code_id, **kwargs)  # noqa: E501
@@ -793,11 +793,11 @@ class CommodityCodeApi(object):
 
         Returns the commodityCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_commodity_code_by_id_with_http_info(commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_commodity_code_by_id_with_http_info(commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to be returned. (required)
         :return: CommodityCode
                  If the method is called asynchronously,
@@ -805,7 +805,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['commodity_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type='CommodityCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class CommodityCodeApi(object):
 
         Get all existing commodityCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_commodity_code_files(commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_commodity_code_files(commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_commodity_code_files_with_http_info(commodity_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_commodity_code_files_with_http_info(commodity_code_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class CommodityCodeApi(object):
 
         Get all existing commodityCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_commodity_code_files_with_http_info(commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_commodity_code_files_with_http_info(commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['commodity_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class CommodityCodeApi(object):
 
         Get all existing commodityCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_commodity_code_tags(commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_commodity_code_tags(commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_commodity_code_tags_with_http_info(commodity_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_commodity_code_tags_with_http_info(commodity_code_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class CommodityCodeApi(object):
 
         Get all existing commodityCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_commodity_code_tags_with_http_info(commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_commodity_code_tags_with_http_info(commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['commodity_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class CommodityCodeApi(object):
 
         Returns a duplicated commodityCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_commodity_code_by_id(commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_commodity_code_by_id(commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to be duplicated. (required)
         :return: CommodityCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_commodity_code_by_id_with_http_info(commodity_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_commodity_code_by_id_with_http_info(commodity_code_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class CommodityCodeApi(object):
 
         Returns a duplicated commodityCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_commodity_code_by_id_with_http_info(commodity_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_commodity_code_by_id_with_http_info(commodity_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int commodity_code_id: Id of the commodityCode to be duplicated. (required)
         :return: CommodityCode
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class CommodityCodeApi(object):
         """
 
         all_params = ['commodity_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class CommodityCodeApi(object):
             files=local_var_files,
             response_type='CommodityCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/custom_field_api.py
+++ b/Infoplus/api/custom_field_api.py
@@ -38,18 +38,18 @@ class CustomFieldApi(object):
 
         Inserts a new customField using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomField body: CustomField to be inserted. (required)
         :return: CustomField
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_custom_field_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_custom_field_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CustomFieldApi(object):
 
         Inserts a new customField using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomField body: CustomField to be inserted. (required)
         :return: CustomField
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type='CustomField',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class CustomFieldApi(object):
 
         Adds an audit to an existing customField.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field_audit(custom_field_id, custom_field_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field_audit(custom_field_id, custom_field_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to add an audit to (required)
         :param str custom_field_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class CustomFieldApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_custom_field_audit_with_http_info(custom_field_id, custom_field_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_custom_field_audit_with_http_info(custom_field_id, custom_field_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class CustomFieldApi(object):
 
         Adds an audit to an existing customField.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field_audit_with_http_info(custom_field_id, custom_field_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field_audit_with_http_info(custom_field_id, custom_field_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to add an audit to (required)
         :param str custom_field_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['custom_field_id', 'custom_field_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class CustomFieldApi(object):
 
         Adds a file to an existing customField.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field_file(custom_field_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field_file(custom_field_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class CustomFieldApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_custom_field_file_with_http_info(custom_field_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_custom_field_file_with_http_info(custom_field_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class CustomFieldApi(object):
 
         Adds a file to an existing customField.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field_file_with_http_info(custom_field_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field_file_with_http_info(custom_field_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['custom_field_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class CustomFieldApi(object):
 
         Adds a file to an existing customField by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field_file_by_url(body, custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field_file_by_url(body, custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int custom_field_id: Id of the customField to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class CustomFieldApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_custom_field_file_by_url_with_http_info(body, custom_field_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_custom_field_file_by_url_with_http_info(body, custom_field_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class CustomFieldApi(object):
 
         Adds a file to an existing customField by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field_file_by_url_with_http_info(body, custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field_file_by_url_with_http_info(body, custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int custom_field_id: Id of the customField to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['body', 'custom_field_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class CustomFieldApi(object):
 
         Adds a tag to an existing customField.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field_tag(custom_field_id, custom_field_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field_tag(custom_field_id, custom_field_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to add a tag to (required)
         :param str custom_field_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class CustomFieldApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_custom_field_tag_with_http_info(custom_field_id, custom_field_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_custom_field_tag_with_http_info(custom_field_id, custom_field_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class CustomFieldApi(object):
 
         Adds a tag to an existing customField.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_custom_field_tag_with_http_info(custom_field_id, custom_field_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_custom_field_tag_with_http_info(custom_field_id, custom_field_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to add a tag to (required)
         :param str custom_field_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['custom_field_id', 'custom_field_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,11 +561,11 @@ class CustomFieldApi(object):
 
         Deletes an existing customField file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_custom_field_file(custom_field_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_custom_field_file(custom_field_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -573,7 +573,7 @@ class CustomFieldApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_custom_field_file_with_http_info(custom_field_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_custom_field_file_with_http_info(custom_field_id, file_id, **kwargs)  # noqa: E501
@@ -584,11 +584,11 @@ class CustomFieldApi(object):
 
         Deletes an existing customField file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_custom_field_file_with_http_info(custom_field_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_custom_field_file_with_http_info(custom_field_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -597,7 +597,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['custom_field_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -653,7 +653,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -664,11 +664,11 @@ class CustomFieldApi(object):
 
         Deletes an existing customField tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_custom_field_tag(custom_field_id, custom_field_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_custom_field_tag(custom_field_id, custom_field_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to remove tag from (required)
         :param str custom_field_tag: The tag to delete (required)
         :return: None
@@ -676,7 +676,7 @@ class CustomFieldApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_custom_field_tag_with_http_info(custom_field_id, custom_field_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_custom_field_tag_with_http_info(custom_field_id, custom_field_tag, **kwargs)  # noqa: E501
@@ -687,11 +687,11 @@ class CustomFieldApi(object):
 
         Deletes an existing customField tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_custom_field_tag_with_http_info(custom_field_id, custom_field_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_custom_field_tag_with_http_info(custom_field_id, custom_field_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to remove tag from (required)
         :param str custom_field_tag: The tag to delete (required)
         :return: None
@@ -700,7 +700,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['custom_field_id', 'custom_field_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -756,7 +756,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -767,11 +767,11 @@ class CustomFieldApi(object):
 
         Returns the list of customFields that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_custom_field_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_custom_field_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -781,7 +781,7 @@ class CustomFieldApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_custom_field_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_custom_field_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -792,11 +792,11 @@ class CustomFieldApi(object):
 
         Returns the list of customFields that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_custom_field_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_custom_field_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -807,7 +807,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -859,7 +859,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type='list[CustomField]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -870,18 +870,18 @@ class CustomFieldApi(object):
 
         Returns the customField identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_custom_field_by_id(custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_custom_field_by_id(custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to be returned. (required)
         :return: CustomField
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_custom_field_by_id_with_http_info(custom_field_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_custom_field_by_id_with_http_info(custom_field_id, **kwargs)  # noqa: E501
@@ -892,11 +892,11 @@ class CustomFieldApi(object):
 
         Returns the customField identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_custom_field_by_id_with_http_info(custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_custom_field_by_id_with_http_info(custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to be returned. (required)
         :return: CustomField
                  If the method is called asynchronously,
@@ -904,7 +904,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['custom_field_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type='CustomField',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class CustomFieldApi(object):
 
         Get all existing customField files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_custom_field_files(custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_custom_field_files(custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_custom_field_files_with_http_info(custom_field_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_custom_field_files_with_http_info(custom_field_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class CustomFieldApi(object):
 
         Get all existing customField files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_custom_field_files_with_http_info(custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_custom_field_files_with_http_info(custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['custom_field_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class CustomFieldApi(object):
 
         Get all existing customField tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_custom_field_tags(custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_custom_field_tags(custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_custom_field_tags_with_http_info(custom_field_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_custom_field_tags_with_http_info(custom_field_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class CustomFieldApi(object):
 
         Get all existing customField tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_custom_field_tags_with_http_info(custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_custom_field_tags_with_http_info(custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['custom_field_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class CustomFieldApi(object):
 
         Returns a duplicated customField identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_custom_field_by_id(custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_custom_field_by_id(custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to be duplicated. (required)
         :return: CustomField
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_custom_field_by_id_with_http_info(custom_field_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_custom_field_by_id_with_http_info(custom_field_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class CustomFieldApi(object):
 
         Returns a duplicated customField identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_custom_field_by_id_with_http_info(custom_field_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_custom_field_by_id_with_http_info(custom_field_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int custom_field_id: Id of the customField to be duplicated. (required)
         :return: CustomField
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['custom_field_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type='CustomField',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class CustomFieldApi(object):
 
         Updates an existing customField using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_custom_field(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_custom_field(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomField body: CustomField to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_custom_field_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_custom_field_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class CustomFieldApi(object):
 
         Updates an existing customField using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_custom_field_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_custom_field_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomField body: CustomField to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class CustomFieldApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class CustomFieldApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/customer_api.py
+++ b/Infoplus/api/customer_api.py
@@ -38,18 +38,18 @@ class CustomerApi(object):
 
         Inserts a new customer using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Customer body: Customer to be inserted. (required)
         :return: Customer
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CustomerApi(object):
 
         Inserts a new customer using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Customer body: Customer to be inserted. (required)
         :return: Customer
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CustomerApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type='Customer',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class CustomerApi(object):
 
         Adds an audit to an existing customer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_audit(customer_id, customer_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_audit(customer_id, customer_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to add an audit to (required)
         :param str customer_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class CustomerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_audit_with_http_info(customer_id, customer_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_audit_with_http_info(customer_id, customer_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class CustomerApi(object):
 
         Adds an audit to an existing customer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_audit_with_http_info(customer_id, customer_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_audit_with_http_info(customer_id, customer_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to add an audit to (required)
         :param str customer_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id', 'customer_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class CustomerApi(object):
 
         Adds a file to an existing customer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_file(customer_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_file(customer_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class CustomerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_file_with_http_info(customer_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_file_with_http_info(customer_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class CustomerApi(object):
 
         Adds a file to an existing customer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_file_with_http_info(customer_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_file_with_http_info(customer_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class CustomerApi(object):
 
         Adds a file to an existing customer by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_file_by_url(body, customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_file_by_url(body, customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int customer_id: Id of the customer to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class CustomerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_file_by_url_with_http_info(body, customer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_file_by_url_with_http_info(body, customer_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class CustomerApi(object):
 
         Adds a file to an existing customer by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_file_by_url_with_http_info(body, customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_file_by_url_with_http_info(body, customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int customer_id: Id of the customer to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class CustomerApi(object):
         """
 
         all_params = ['body', 'customer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class CustomerApi(object):
 
         Adds a tag to an existing customer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_tag(customer_id, customer_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_tag(customer_id, customer_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to add a tag to (required)
         :param str customer_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class CustomerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_tag_with_http_info(customer_id, customer_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_tag_with_http_info(customer_id, customer_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class CustomerApi(object):
 
         Adds a tag to an existing customer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_tag_with_http_info(customer_id, customer_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_tag_with_http_info(customer_id, customer_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to add a tag to (required)
         :param str customer_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id', 'customer_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class CustomerApi(object):
 
         Deletes the customer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_customer_with_http_info(customer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_customer_with_http_info(customer_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class CustomerApi(object):
 
         Deletes the customer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_with_http_info(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_with_http_info(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class CustomerApi(object):
 
         Deletes an existing customer file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_file(customer_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_file(customer_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class CustomerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_customer_file_with_http_info(customer_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_customer_file_with_http_info(customer_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class CustomerApi(object):
 
         Deletes an existing customer file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_file_with_http_info(customer_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_file_with_http_info(customer_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class CustomerApi(object):
 
         Deletes an existing customer tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_tag(customer_id, customer_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_tag(customer_id, customer_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to remove tag from (required)
         :param str customer_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class CustomerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_customer_tag_with_http_info(customer_id, customer_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_customer_tag_with_http_info(customer_id, customer_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class CustomerApi(object):
 
         Deletes an existing customer tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_tag_with_http_info(customer_id, customer_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_tag_with_http_info(customer_id, customer_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to remove tag from (required)
         :param str customer_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id', 'customer_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class CustomerApi(object):
 
         Returns the customer identified by the specified parameters.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_by_customer_no(lob_id, customer_no, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_by_customer_no(lob_id, customer_no, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int lob_id: lobId of the customer to be returned. (required)
         :param str customer_no: customerNo of the customer to be returned. (required)
         :return: Customer
@@ -874,7 +874,7 @@ class CustomerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_by_customer_no_with_http_info(lob_id, customer_no, **kwargs)  # noqa: E501
         else:
             (data) = self.get_by_customer_no_with_http_info(lob_id, customer_no, **kwargs)  # noqa: E501
@@ -885,11 +885,11 @@ class CustomerApi(object):
 
         Returns the customer identified by the specified parameters.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_by_customer_no_with_http_info(lob_id, customer_no, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_by_customer_no_with_http_info(lob_id, customer_no, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int lob_id: lobId of the customer to be returned. (required)
         :param str customer_no: customerNo of the customer to be returned. (required)
         :return: Customer
@@ -898,7 +898,7 @@ class CustomerApi(object):
         """
 
         all_params = ['lob_id', 'customer_no']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type='Customer',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,11 +965,11 @@ class CustomerApi(object):
 
         Returns the list of customers that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -979,7 +979,7 @@ class CustomerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -990,11 +990,11 @@ class CustomerApi(object):
 
         Returns the list of customers that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1005,7 +1005,7 @@ class CustomerApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1057,7 +1057,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type='list[Customer]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1068,18 +1068,18 @@ class CustomerApi(object):
 
         Returns the customer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_by_id(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_by_id(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to be returned. (required)
         :return: Customer
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_by_id_with_http_info(customer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_by_id_with_http_info(customer_id, **kwargs)  # noqa: E501
@@ -1090,11 +1090,11 @@ class CustomerApi(object):
 
         Returns the customer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_by_id_with_http_info(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_by_id_with_http_info(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to be returned. (required)
         :return: Customer
                  If the method is called asynchronously,
@@ -1102,7 +1102,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1152,7 +1152,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type='Customer',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1163,18 +1163,18 @@ class CustomerApi(object):
 
         Get all existing customer files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_files(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_files(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_files_with_http_info(customer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_files_with_http_info(customer_id, **kwargs)  # noqa: E501
@@ -1185,11 +1185,11 @@ class CustomerApi(object):
 
         Get all existing customer files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_files_with_http_info(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_files_with_http_info(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1197,7 +1197,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1247,7 +1247,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1258,18 +1258,18 @@ class CustomerApi(object):
 
         Get all existing customer tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_tags(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_tags(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_tags_with_http_info(customer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_tags_with_http_info(customer_id, **kwargs)  # noqa: E501
@@ -1280,11 +1280,11 @@ class CustomerApi(object):
 
         Get all existing customer tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_tags_with_http_info(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_tags_with_http_info(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1292,7 +1292,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1342,7 +1342,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1353,18 +1353,18 @@ class CustomerApi(object):
 
         Returns a duplicated customer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_customer_by_id(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_customer_by_id(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to be duplicated. (required)
         :return: Customer
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_customer_by_id_with_http_info(customer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_customer_by_id_with_http_info(customer_id, **kwargs)  # noqa: E501
@@ -1375,11 +1375,11 @@ class CustomerApi(object):
 
         Returns a duplicated customer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_customer_by_id_with_http_info(customer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_customer_by_id_with_http_info(customer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_id: Id of the customer to be duplicated. (required)
         :return: Customer
                  If the method is called asynchronously,
@@ -1387,7 +1387,7 @@ class CustomerApi(object):
         """
 
         all_params = ['customer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1437,7 +1437,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type='Customer',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1448,18 +1448,18 @@ class CustomerApi(object):
 
         Updates an existing customer using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_customer(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_customer(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Customer body: Customer to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_customer_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_customer_with_http_info(body, **kwargs)  # noqa: E501
@@ -1470,11 +1470,11 @@ class CustomerApi(object):
 
         Updates an existing customer using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_customer_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_customer_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Customer body: Customer to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1482,7 +1482,7 @@ class CustomerApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1536,7 +1536,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1547,18 +1547,18 @@ class CustomerApi(object):
 
         Updates an existing customer custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_customer_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_customer_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Customer body: Customer to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_customer_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_customer_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1569,11 +1569,11 @@ class CustomerApi(object):
 
         Updates an existing customer custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_customer_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_customer_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Customer body: Customer to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1581,7 +1581,7 @@ class CustomerApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1635,7 +1635,7 @@ class CustomerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/customer_invoice_template_api.py
+++ b/Infoplus/api/customer_invoice_template_api.py
@@ -38,18 +38,18 @@ class CustomerInvoiceTemplateApi(object):
 
         Inserts a new customerInvoiceTemplate using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomerInvoiceTemplate body: CustomerInvoiceTemplate to be inserted. (required)
         :return: CustomerInvoiceTemplate
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_invoice_template_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_invoice_template_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Inserts a new customerInvoiceTemplate using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomerInvoiceTemplate body: CustomerInvoiceTemplate to be inserted. (required)
         :return: CustomerInvoiceTemplate
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type='CustomerInvoiceTemplate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Adds an audit to an existing customerInvoiceTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_audit(customer_invoice_template_id, customer_invoice_template_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_audit(customer_invoice_template_id, customer_invoice_template_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to add an audit to (required)
         :param str customer_invoice_template_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class CustomerInvoiceTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_invoice_template_audit_with_http_info(customer_invoice_template_id, customer_invoice_template_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_invoice_template_audit_with_http_info(customer_invoice_template_id, customer_invoice_template_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Adds an audit to an existing customerInvoiceTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_audit_with_http_info(customer_invoice_template_id, customer_invoice_template_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_audit_with_http_info(customer_invoice_template_id, customer_invoice_template_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to add an audit to (required)
         :param str customer_invoice_template_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id', 'customer_invoice_template_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Adds a file to an existing customerInvoiceTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_file(customer_invoice_template_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_file(customer_invoice_template_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class CustomerInvoiceTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_invoice_template_file_with_http_info(customer_invoice_template_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_invoice_template_file_with_http_info(customer_invoice_template_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Adds a file to an existing customerInvoiceTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_file_with_http_info(customer_invoice_template_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_file_with_http_info(customer_invoice_template_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Adds a file to an existing customerInvoiceTemplate by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_file_by_url(body, customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_file_by_url(body, customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class CustomerInvoiceTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_invoice_template_file_by_url_with_http_info(body, customer_invoice_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_invoice_template_file_by_url_with_http_info(body, customer_invoice_template_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Adds a file to an existing customerInvoiceTemplate by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_file_by_url_with_http_info(body, customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_file_by_url_with_http_info(body, customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['body', 'customer_invoice_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Adds a tag to an existing customerInvoiceTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_tag(customer_invoice_template_id, customer_invoice_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_tag(customer_invoice_template_id, customer_invoice_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to add a tag to (required)
         :param str customer_invoice_template_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class CustomerInvoiceTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_invoice_template_tag_with_http_info(customer_invoice_template_id, customer_invoice_template_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_invoice_template_tag_with_http_info(customer_invoice_template_id, customer_invoice_template_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Adds a tag to an existing customerInvoiceTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_tag_with_http_info(customer_invoice_template_id, customer_invoice_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_tag_with_http_info(customer_invoice_template_id, customer_invoice_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to add a tag to (required)
         :param str customer_invoice_template_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id', 'customer_invoice_template_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class CustomerInvoiceTemplateApi(object):
 
         Deletes the customerInvoiceTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_customer_invoice_template_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_customer_invoice_template_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Deletes the customerInvoiceTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_with_http_info(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_with_http_info(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Deletes an existing customerInvoiceTemplate file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_file(customer_invoice_template_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_file(customer_invoice_template_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class CustomerInvoiceTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_customer_invoice_template_file_with_http_info(customer_invoice_template_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_customer_invoice_template_file_with_http_info(customer_invoice_template_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Deletes an existing customerInvoiceTemplate file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_file_with_http_info(customer_invoice_template_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_file_with_http_info(customer_invoice_template_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Deletes an existing customerInvoiceTemplate tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_tag(customer_invoice_template_id, customer_invoice_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_tag(customer_invoice_template_id, customer_invoice_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to remove tag from (required)
         :param str customer_invoice_template_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class CustomerInvoiceTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_customer_invoice_template_tag_with_http_info(customer_invoice_template_id, customer_invoice_template_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_customer_invoice_template_tag_with_http_info(customer_invoice_template_id, customer_invoice_template_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Deletes an existing customerInvoiceTemplate tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_tag_with_http_info(customer_invoice_template_id, customer_invoice_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_tag_with_http_info(customer_invoice_template_id, customer_invoice_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to remove tag from (required)
         :param str customer_invoice_template_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id', 'customer_invoice_template_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Returns the list of customerInvoiceTemplates that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class CustomerInvoiceTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_invoice_template_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_invoice_template_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Returns the list of customerInvoiceTemplates that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type='list[CustomerInvoiceTemplate]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class CustomerInvoiceTemplateApi(object):
 
         Returns the customerInvoiceTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_by_id(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_by_id(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to be returned. (required)
         :return: CustomerInvoiceTemplate
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_invoice_template_by_id_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_invoice_template_by_id_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Returns the customerInvoiceTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_by_id_with_http_info(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_by_id_with_http_info(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to be returned. (required)
         :return: CustomerInvoiceTemplate
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type='CustomerInvoiceTemplate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class CustomerInvoiceTemplateApi(object):
 
         Get all existing customerInvoiceTemplate files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_files(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_files(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_invoice_template_files_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_invoice_template_files_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Get all existing customerInvoiceTemplate files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_files_with_http_info(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_files_with_http_info(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class CustomerInvoiceTemplateApi(object):
 
         Get all existing customerInvoiceTemplate tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_tags(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_tags(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_invoice_template_tags_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_invoice_template_tags_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Get all existing customerInvoiceTemplate tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_tags_with_http_info(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_tags_with_http_info(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class CustomerInvoiceTemplateApi(object):
 
         Returns a duplicated customerInvoiceTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_customer_invoice_template_by_id(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_customer_invoice_template_by_id(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to be duplicated. (required)
         :return: CustomerInvoiceTemplate
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_customer_invoice_template_by_id_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_customer_invoice_template_by_id_with_http_info(customer_invoice_template_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Returns a duplicated customerInvoiceTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_customer_invoice_template_by_id_with_http_info(customer_invoice_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_customer_invoice_template_by_id_with_http_info(customer_invoice_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_id: Id of the customerInvoiceTemplate to be duplicated. (required)
         :return: CustomerInvoiceTemplate
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['customer_invoice_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type='CustomerInvoiceTemplate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class CustomerInvoiceTemplateApi(object):
 
         Updates an existing customerInvoiceTemplate using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_customer_invoice_template(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_customer_invoice_template(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomerInvoiceTemplate body: CustomerInvoiceTemplate to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_customer_invoice_template_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_customer_invoice_template_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class CustomerInvoiceTemplateApi(object):
 
         Updates an existing customerInvoiceTemplate using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_customer_invoice_template_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_customer_invoice_template_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomerInvoiceTemplate body: CustomerInvoiceTemplate to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class CustomerInvoiceTemplateApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class CustomerInvoiceTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/customer_invoice_template_line_api.py
+++ b/Infoplus/api/customer_invoice_template_line_api.py
@@ -38,11 +38,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Adds an audit to an existing customerInvoiceTemplateLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_line_audit(customer_invoice_template_line_id, customer_invoice_template_line_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_line_audit(customer_invoice_template_line_id, customer_invoice_template_line_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to add an audit to (required)
         :param str customer_invoice_template_line_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class CustomerInvoiceTemplateLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_invoice_template_line_audit_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_invoice_template_line_audit_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Adds an audit to an existing customerInvoiceTemplateLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_line_audit_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_line_audit_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to add an audit to (required)
         :param str customer_invoice_template_line_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id', 'customer_invoice_template_line_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Adds a file to an existing customerInvoiceTemplateLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_line_file(customer_invoice_template_line_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_line_file(customer_invoice_template_line_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class CustomerInvoiceTemplateLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_invoice_template_line_file_with_http_info(customer_invoice_template_line_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_invoice_template_line_file_with_http_info(customer_invoice_template_line_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Adds a file to an existing customerInvoiceTemplateLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_line_file_with_http_info(customer_invoice_template_line_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_line_file_with_http_info(customer_invoice_template_line_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Adds a file to an existing customerInvoiceTemplateLine by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_line_file_by_url(body, customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_line_file_by_url(body, customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class CustomerInvoiceTemplateLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_invoice_template_line_file_by_url_with_http_info(body, customer_invoice_template_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_invoice_template_line_file_by_url_with_http_info(body, customer_invoice_template_line_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Adds a file to an existing customerInvoiceTemplateLine by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_line_file_by_url_with_http_info(body, customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_line_file_by_url_with_http_info(body, customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['body', 'customer_invoice_template_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Adds a tag to an existing customerInvoiceTemplateLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_line_tag(customer_invoice_template_line_id, customer_invoice_template_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_line_tag(customer_invoice_template_line_id, customer_invoice_template_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to add a tag to (required)
         :param str customer_invoice_template_line_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class CustomerInvoiceTemplateLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_customer_invoice_template_line_tag_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_customer_invoice_template_line_tag_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Adds a tag to an existing customerInvoiceTemplateLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_customer_invoice_template_line_tag_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_customer_invoice_template_line_tag_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to add a tag to (required)
         :param str customer_invoice_template_line_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id', 'customer_invoice_template_line_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,18 +462,18 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Deletes the customerInvoiceTemplateLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_line(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_line(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_customer_invoice_template_line_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_customer_invoice_template_line_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
@@ -484,11 +484,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Deletes the customerInvoiceTemplateLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_line_with_http_info(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_line_with_http_info(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -496,7 +496,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -546,7 +546,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -557,11 +557,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Deletes an existing customerInvoiceTemplateLine file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_line_file(customer_invoice_template_line_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_line_file(customer_invoice_template_line_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -569,7 +569,7 @@ class CustomerInvoiceTemplateLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_customer_invoice_template_line_file_with_http_info(customer_invoice_template_line_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_customer_invoice_template_line_file_with_http_info(customer_invoice_template_line_id, file_id, **kwargs)  # noqa: E501
@@ -580,11 +580,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Deletes an existing customerInvoiceTemplateLine file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_line_file_with_http_info(customer_invoice_template_line_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_line_file_with_http_info(customer_invoice_template_line_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -593,7 +593,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -649,7 +649,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -660,11 +660,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Deletes an existing customerInvoiceTemplateLine tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_line_tag(customer_invoice_template_line_id, customer_invoice_template_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_line_tag(customer_invoice_template_line_id, customer_invoice_template_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to remove tag from (required)
         :param str customer_invoice_template_line_tag: The tag to delete (required)
         :return: None
@@ -672,7 +672,7 @@ class CustomerInvoiceTemplateLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_customer_invoice_template_line_tag_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_customer_invoice_template_line_tag_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_tag, **kwargs)  # noqa: E501
@@ -683,11 +683,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Deletes an existing customerInvoiceTemplateLine tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_customer_invoice_template_line_tag_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_customer_invoice_template_line_tag_with_http_info(customer_invoice_template_line_id, customer_invoice_template_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to remove tag from (required)
         :param str customer_invoice_template_line_tag: The tag to delete (required)
         :return: None
@@ -696,7 +696,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id', 'customer_invoice_template_line_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Returns the list of customerInvoiceTemplateLines that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_line_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_line_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class CustomerInvoiceTemplateLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_invoice_template_line_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_invoice_template_line_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Returns the list of customerInvoiceTemplateLines that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_line_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_line_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type='list[CustomerInvoiceTemplateLine]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Returns the customerInvoiceTemplateLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_line_by_id(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_line_by_id(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to be returned. (required)
         :return: CustomerInvoiceTemplateLine
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_invoice_template_line_by_id_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_invoice_template_line_by_id_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Returns the customerInvoiceTemplateLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_line_by_id_with_http_info(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_line_by_id_with_http_info(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to be returned. (required)
         :return: CustomerInvoiceTemplateLine
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type='CustomerInvoiceTemplateLine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Get all existing customerInvoiceTemplateLine files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_line_files(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_line_files(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_invoice_template_line_files_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_invoice_template_line_files_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Get all existing customerInvoiceTemplateLine files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_line_files_with_http_info(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_line_files_with_http_info(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Get all existing customerInvoiceTemplateLine tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_line_tags(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_line_tags(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_customer_invoice_template_line_tags_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_customer_invoice_template_line_tags_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Get all existing customerInvoiceTemplateLine tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_customer_invoice_template_line_tags_with_http_info(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_customer_invoice_template_line_tags_with_http_info(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Returns a duplicated customerInvoiceTemplateLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_customer_invoice_template_line_by_id(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_customer_invoice_template_line_by_id(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to be duplicated. (required)
         :return: CustomerInvoiceTemplateLine
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_customer_invoice_template_line_by_id_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_customer_invoice_template_line_by_id_with_http_info(customer_invoice_template_line_id, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Returns a duplicated customerInvoiceTemplateLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_customer_invoice_template_line_by_id_with_http_info(customer_invoice_template_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_customer_invoice_template_line_by_id_with_http_info(customer_invoice_template_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int customer_invoice_template_line_id: Id of the customerInvoiceTemplateLine to be duplicated. (required)
         :return: CustomerInvoiceTemplateLine
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['customer_invoice_template_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1235,7 +1235,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type='CustomerInvoiceTemplateLine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1246,18 +1246,18 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Updates an existing customerInvoiceTemplateLine using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_customer_invoice_template_line(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_customer_invoice_template_line(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomerInvoiceTemplateLine body: CustomerInvoiceTemplateLine to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_customer_invoice_template_line_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_customer_invoice_template_line_with_http_info(body, **kwargs)  # noqa: E501
@@ -1268,11 +1268,11 @@ class CustomerInvoiceTemplateLineApi(object):
 
         Updates an existing customerInvoiceTemplateLine using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_customer_invoice_template_line_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_customer_invoice_template_line_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param CustomerInvoiceTemplateLine body: CustomerInvoiceTemplateLine to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1280,7 +1280,7 @@ class CustomerInvoiceTemplateLineApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class CustomerInvoiceTemplateLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/e_di_document_type_api.py
+++ b/Infoplus/api/e_di_document_type_api.py
@@ -38,18 +38,18 @@ class EDIDocumentTypeApi(object):
 
         Returns the eDIDocumentType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_type_by_id(e_di_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_type_by_id(e_di_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str e_di_document_type_id: Id of eDIDocumentType to be returned. (required)
         :return: EDIDocumentType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_edi_document_type_by_id_with_http_info(e_di_document_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_edi_document_type_by_id_with_http_info(e_di_document_type_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class EDIDocumentTypeApi(object):
 
         Returns the eDIDocumentType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_type_by_id_with_http_info(e_di_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_type_by_id_with_http_info(e_di_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str e_di_document_type_id: Id of eDIDocumentType to be returned. (required)
         :return: EDIDocumentType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class EDIDocumentTypeApi(object):
         """
 
         all_params = ['e_di_document_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class EDIDocumentTypeApi(object):
             files=local_var_files,
             response_type='EDIDocumentType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class EDIDocumentTypeApi(object):
 
         Returns the list of eDIDocumentTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_type_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_type_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class EDIDocumentTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_edi_document_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_edi_document_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class EDIDocumentTypeApi(object):
 
         Returns the list of eDIDocumentTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_type_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_type_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class EDIDocumentTypeApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class EDIDocumentTypeApi(object):
             files=local_var_files,
             response_type='list[EDIDocumentType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/edi_document_api.py
+++ b/Infoplus/api/edi_document_api.py
@@ -38,18 +38,18 @@ class EdiDocumentApi(object):
 
         Inserts a new ediDocument using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EdiDocument body: EdiDocument to be inserted. (required)
         :return: EdiDocument
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_edi_document_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_edi_document_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class EdiDocumentApi(object):
 
         Inserts a new ediDocument using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EdiDocument body: EdiDocument to be inserted. (required)
         :return: EdiDocument
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type='EdiDocument',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class EdiDocumentApi(object):
 
         Adds an audit to an existing ediDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document_audit(edi_document_id, edi_document_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document_audit(edi_document_id, edi_document_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to add an audit to (required)
         :param str edi_document_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class EdiDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_edi_document_audit_with_http_info(edi_document_id, edi_document_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_edi_document_audit_with_http_info(edi_document_id, edi_document_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class EdiDocumentApi(object):
 
         Adds an audit to an existing ediDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document_audit_with_http_info(edi_document_id, edi_document_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document_audit_with_http_info(edi_document_id, edi_document_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to add an audit to (required)
         :param str edi_document_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['edi_document_id', 'edi_document_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class EdiDocumentApi(object):
 
         Adds a file to an existing ediDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document_file(edi_document_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document_file(edi_document_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class EdiDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_edi_document_file_with_http_info(edi_document_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_edi_document_file_with_http_info(edi_document_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class EdiDocumentApi(object):
 
         Adds a file to an existing ediDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document_file_with_http_info(edi_document_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document_file_with_http_info(edi_document_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['edi_document_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class EdiDocumentApi(object):
 
         Adds a file to an existing ediDocument by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document_file_by_url(body, edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document_file_by_url(body, edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int edi_document_id: Id of the ediDocument to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class EdiDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_edi_document_file_by_url_with_http_info(body, edi_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_edi_document_file_by_url_with_http_info(body, edi_document_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class EdiDocumentApi(object):
 
         Adds a file to an existing ediDocument by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document_file_by_url_with_http_info(body, edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document_file_by_url_with_http_info(body, edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int edi_document_id: Id of the ediDocument to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['body', 'edi_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class EdiDocumentApi(object):
 
         Adds a tag to an existing ediDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document_tag(edi_document_id, edi_document_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document_tag(edi_document_id, edi_document_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to add a tag to (required)
         :param str edi_document_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class EdiDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_edi_document_tag_with_http_info(edi_document_id, edi_document_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_edi_document_tag_with_http_info(edi_document_id, edi_document_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class EdiDocumentApi(object):
 
         Adds a tag to an existing ediDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_edi_document_tag_with_http_info(edi_document_id, edi_document_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_edi_document_tag_with_http_info(edi_document_id, edi_document_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to add a tag to (required)
         :param str edi_document_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['edi_document_id', 'edi_document_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,11 +561,11 @@ class EdiDocumentApi(object):
 
         Deletes an existing ediDocument file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_edi_document_file(edi_document_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_edi_document_file(edi_document_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -573,7 +573,7 @@ class EdiDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_edi_document_file_with_http_info(edi_document_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_edi_document_file_with_http_info(edi_document_id, file_id, **kwargs)  # noqa: E501
@@ -584,11 +584,11 @@ class EdiDocumentApi(object):
 
         Deletes an existing ediDocument file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_edi_document_file_with_http_info(edi_document_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_edi_document_file_with_http_info(edi_document_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -597,7 +597,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['edi_document_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -653,7 +653,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -664,11 +664,11 @@ class EdiDocumentApi(object):
 
         Deletes an existing ediDocument tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_edi_document_tag(edi_document_id, edi_document_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_edi_document_tag(edi_document_id, edi_document_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to remove tag from (required)
         :param str edi_document_tag: The tag to delete (required)
         :return: None
@@ -676,7 +676,7 @@ class EdiDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_edi_document_tag_with_http_info(edi_document_id, edi_document_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_edi_document_tag_with_http_info(edi_document_id, edi_document_tag, **kwargs)  # noqa: E501
@@ -687,11 +687,11 @@ class EdiDocumentApi(object):
 
         Deletes an existing ediDocument tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_edi_document_tag_with_http_info(edi_document_id, edi_document_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_edi_document_tag_with_http_info(edi_document_id, edi_document_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to remove tag from (required)
         :param str edi_document_tag: The tag to delete (required)
         :return: None
@@ -700,7 +700,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['edi_document_id', 'edi_document_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -756,7 +756,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -767,18 +767,18 @@ class EdiDocumentApi(object):
 
         Returns a duplicated ediDocument identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_edi_document_by_id(edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_edi_document_by_id(edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to be duplicated. (required)
         :return: EdiDocument
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_edi_document_by_id_with_http_info(edi_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_edi_document_by_id_with_http_info(edi_document_id, **kwargs)  # noqa: E501
@@ -789,11 +789,11 @@ class EdiDocumentApi(object):
 
         Returns a duplicated ediDocument identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_edi_document_by_id_with_http_info(edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_edi_document_by_id_with_http_info(edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to be duplicated. (required)
         :return: EdiDocument
                  If the method is called asynchronously,
@@ -801,7 +801,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['edi_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type='EdiDocument',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class EdiDocumentApi(object):
 
         Returns the list of ediDocuments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class EdiDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_edi_document_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_edi_document_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class EdiDocumentApi(object):
 
         Returns the list of ediDocuments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type='list[EdiDocument]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class EdiDocumentApi(object):
 
         Returns the ediDocument identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_by_id(edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_by_id(edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to be returned. (required)
         :return: EdiDocument
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_edi_document_by_id_with_http_info(edi_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_edi_document_by_id_with_http_info(edi_document_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class EdiDocumentApi(object):
 
         Returns the ediDocument identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_by_id_with_http_info(edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_by_id_with_http_info(edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to be returned. (required)
         :return: EdiDocument
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['edi_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type='EdiDocument',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class EdiDocumentApi(object):
 
         Get all existing ediDocument files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_files(edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_files(edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_edi_document_files_with_http_info(edi_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_edi_document_files_with_http_info(edi_document_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class EdiDocumentApi(object):
 
         Get all existing ediDocument files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_files_with_http_info(edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_files_with_http_info(edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['edi_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class EdiDocumentApi(object):
 
         Get all existing ediDocument tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_tags(edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_tags(edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_edi_document_tags_with_http_info(edi_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_edi_document_tags_with_http_info(edi_document_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class EdiDocumentApi(object):
 
         Get all existing ediDocument tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_edi_document_tags_with_http_info(edi_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_edi_document_tags_with_http_info(edi_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int edi_document_id: Id of the ediDocument to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class EdiDocumentApi(object):
         """
 
         all_params = ['edi_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class EdiDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/email_template_api.py
+++ b/Infoplus/api/email_template_api.py
@@ -38,18 +38,18 @@ class EmailTemplateApi(object):
 
         Inserts a new emailTemplate using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EmailTemplate body: EmailTemplate to be inserted. (required)
         :return: EmailTemplate
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_email_template_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_email_template_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class EmailTemplateApi(object):
 
         Inserts a new emailTemplate using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EmailTemplate body: EmailTemplate to be inserted. (required)
         :return: EmailTemplate
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type='EmailTemplate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class EmailTemplateApi(object):
 
         Adds an audit to an existing emailTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template_audit(email_template_id, email_template_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template_audit(email_template_id, email_template_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to add an audit to (required)
         :param str email_template_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class EmailTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_email_template_audit_with_http_info(email_template_id, email_template_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_email_template_audit_with_http_info(email_template_id, email_template_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class EmailTemplateApi(object):
 
         Adds an audit to an existing emailTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template_audit_with_http_info(email_template_id, email_template_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template_audit_with_http_info(email_template_id, email_template_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to add an audit to (required)
         :param str email_template_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id', 'email_template_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class EmailTemplateApi(object):
 
         Adds a file to an existing emailTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template_file(email_template_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template_file(email_template_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class EmailTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_email_template_file_with_http_info(email_template_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_email_template_file_with_http_info(email_template_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class EmailTemplateApi(object):
 
         Adds a file to an existing emailTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template_file_with_http_info(email_template_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template_file_with_http_info(email_template_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class EmailTemplateApi(object):
 
         Adds a file to an existing emailTemplate by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template_file_by_url(body, email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template_file_by_url(body, email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int email_template_id: Id of the emailTemplate to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class EmailTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_email_template_file_by_url_with_http_info(body, email_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_email_template_file_by_url_with_http_info(body, email_template_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class EmailTemplateApi(object):
 
         Adds a file to an existing emailTemplate by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template_file_by_url_with_http_info(body, email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template_file_by_url_with_http_info(body, email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int email_template_id: Id of the emailTemplate to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['body', 'email_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class EmailTemplateApi(object):
 
         Adds a tag to an existing emailTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template_tag(email_template_id, email_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template_tag(email_template_id, email_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to add a tag to (required)
         :param str email_template_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class EmailTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_email_template_tag_with_http_info(email_template_id, email_template_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_email_template_tag_with_http_info(email_template_id, email_template_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class EmailTemplateApi(object):
 
         Adds a tag to an existing emailTemplate.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_email_template_tag_with_http_info(email_template_id, email_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_email_template_tag_with_http_info(email_template_id, email_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to add a tag to (required)
         :param str email_template_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id', 'email_template_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class EmailTemplateApi(object):
 
         Deletes the emailTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_email_template(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_email_template(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_email_template_with_http_info(email_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_email_template_with_http_info(email_template_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class EmailTemplateApi(object):
 
         Deletes the emailTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_email_template_with_http_info(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_email_template_with_http_info(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class EmailTemplateApi(object):
 
         Deletes an existing emailTemplate file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_email_template_file(email_template_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_email_template_file(email_template_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class EmailTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_email_template_file_with_http_info(email_template_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_email_template_file_with_http_info(email_template_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class EmailTemplateApi(object):
 
         Deletes an existing emailTemplate file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_email_template_file_with_http_info(email_template_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_email_template_file_with_http_info(email_template_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class EmailTemplateApi(object):
 
         Deletes an existing emailTemplate tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_email_template_tag(email_template_id, email_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_email_template_tag(email_template_id, email_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to remove tag from (required)
         :param str email_template_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class EmailTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_email_template_tag_with_http_info(email_template_id, email_template_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_email_template_tag_with_http_info(email_template_id, email_template_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class EmailTemplateApi(object):
 
         Deletes an existing emailTemplate tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_email_template_tag_with_http_info(email_template_id, email_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_email_template_tag_with_http_info(email_template_id, email_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to remove tag from (required)
         :param str email_template_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id', 'email_template_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class EmailTemplateApi(object):
 
         Returns a duplicated emailTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_email_template_by_id(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_email_template_by_id(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to be duplicated. (required)
         :return: EmailTemplate
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_email_template_by_id_with_http_info(email_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_email_template_by_id_with_http_info(email_template_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class EmailTemplateApi(object):
 
         Returns a duplicated emailTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_email_template_by_id_with_http_info(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_email_template_by_id_with_http_info(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to be duplicated. (required)
         :return: EmailTemplate
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type='EmailTemplate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class EmailTemplateApi(object):
 
         Returns the list of emailTemplates that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_template_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_email_template_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class EmailTemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_email_template_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_email_template_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class EmailTemplateApi(object):
 
         Returns the list of emailTemplates that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_template_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_email_template_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type='list[EmailTemplate]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class EmailTemplateApi(object):
 
         Returns the emailTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_template_by_id(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_email_template_by_id(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to be returned. (required)
         :return: EmailTemplate
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_email_template_by_id_with_http_info(email_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_email_template_by_id_with_http_info(email_template_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class EmailTemplateApi(object):
 
         Returns the emailTemplate identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_template_by_id_with_http_info(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_email_template_by_id_with_http_info(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to be returned. (required)
         :return: EmailTemplate
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type='EmailTemplate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class EmailTemplateApi(object):
 
         Get all existing emailTemplate files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_template_files(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_email_template_files(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_email_template_files_with_http_info(email_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_email_template_files_with_http_info(email_template_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class EmailTemplateApi(object):
 
         Get all existing emailTemplate files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_template_files_with_http_info(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_email_template_files_with_http_info(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class EmailTemplateApi(object):
 
         Get all existing emailTemplate tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_template_tags(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_email_template_tags(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_email_template_tags_with_http_info(email_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_email_template_tags_with_http_info(email_template_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class EmailTemplateApi(object):
 
         Get all existing emailTemplate tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_template_tags_with_http_info(email_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_email_template_tags_with_http_info(email_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int email_template_id: Id of the emailTemplate to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['email_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class EmailTemplateApi(object):
 
         Updates an existing emailTemplate using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_email_template(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_email_template(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EmailTemplate body: EmailTemplate to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_email_template_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_email_template_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class EmailTemplateApi(object):
 
         Updates an existing emailTemplate using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_email_template_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_email_template_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EmailTemplate body: EmailTemplate to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class EmailTemplateApi(object):
 
         Updates an existing emailTemplate custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_email_template_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_email_template_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EmailTemplate body: EmailTemplate to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_email_template_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_email_template_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class EmailTemplateApi(object):
 
         Updates an existing emailTemplate custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_email_template_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_email_template_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EmailTemplate body: EmailTemplate to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class EmailTemplateApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class EmailTemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/external_shipment_api.py
+++ b/Infoplus/api/external_shipment_api.py
@@ -38,18 +38,18 @@ class ExternalShipmentApi(object):
 
         Inserts a new externalShipment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShipment body: ExternalShipment to be inserted. (required)
         :return: ExternalShipment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipment_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipment_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ExternalShipmentApi(object):
 
         Inserts a new externalShipment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShipment body: ExternalShipment to be inserted. (required)
         :return: ExternalShipment
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type='ExternalShipment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ExternalShipmentApi(object):
 
         Adds an audit to an existing externalShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment_audit(external_shipment_id, external_shipment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment_audit(external_shipment_id, external_shipment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to add an audit to (required)
         :param str external_shipment_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ExternalShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipment_audit_with_http_info(external_shipment_id, external_shipment_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipment_audit_with_http_info(external_shipment_id, external_shipment_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ExternalShipmentApi(object):
 
         Adds an audit to an existing externalShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment_audit_with_http_info(external_shipment_id, external_shipment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment_audit_with_http_info(external_shipment_id, external_shipment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to add an audit to (required)
         :param str external_shipment_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id', 'external_shipment_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ExternalShipmentApi(object):
 
         Adds a file to an existing externalShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment_file(external_shipment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment_file(external_shipment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ExternalShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipment_file_with_http_info(external_shipment_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipment_file_with_http_info(external_shipment_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ExternalShipmentApi(object):
 
         Adds a file to an existing externalShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment_file_with_http_info(external_shipment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment_file_with_http_info(external_shipment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ExternalShipmentApi(object):
 
         Adds a file to an existing externalShipment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment_file_by_url(body, external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment_file_by_url(body, external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int external_shipment_id: Id of the externalShipment to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ExternalShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipment_file_by_url_with_http_info(body, external_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipment_file_by_url_with_http_info(body, external_shipment_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ExternalShipmentApi(object):
 
         Adds a file to an existing externalShipment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment_file_by_url_with_http_info(body, external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment_file_by_url_with_http_info(body, external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int external_shipment_id: Id of the externalShipment to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['body', 'external_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ExternalShipmentApi(object):
 
         Adds a tag to an existing externalShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment_tag(external_shipment_id, external_shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment_tag(external_shipment_id, external_shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to add a tag to (required)
         :param str external_shipment_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ExternalShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipment_tag_with_http_info(external_shipment_id, external_shipment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipment_tag_with_http_info(external_shipment_id, external_shipment_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ExternalShipmentApi(object):
 
         Adds a tag to an existing externalShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipment_tag_with_http_info(external_shipment_id, external_shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipment_tag_with_http_info(external_shipment_id, external_shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to add a tag to (required)
         :param str external_shipment_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id', 'external_shipment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ExternalShipmentApi(object):
 
         Deletes the externalShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipment(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipment(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_external_shipment_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_external_shipment_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ExternalShipmentApi(object):
 
         Deletes the externalShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipment_with_http_info(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipment_with_http_info(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ExternalShipmentApi(object):
 
         Deletes an existing externalShipment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipment_file(external_shipment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipment_file(external_shipment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ExternalShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_external_shipment_file_with_http_info(external_shipment_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_external_shipment_file_with_http_info(external_shipment_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ExternalShipmentApi(object):
 
         Deletes an existing externalShipment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipment_file_with_http_info(external_shipment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipment_file_with_http_info(external_shipment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ExternalShipmentApi(object):
 
         Deletes an existing externalShipment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipment_tag(external_shipment_id, external_shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipment_tag(external_shipment_id, external_shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to remove tag from (required)
         :param str external_shipment_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ExternalShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_external_shipment_tag_with_http_info(external_shipment_id, external_shipment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_external_shipment_tag_with_http_info(external_shipment_id, external_shipment_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ExternalShipmentApi(object):
 
         Deletes an existing externalShipment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipment_tag_with_http_info(external_shipment_id, external_shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipment_tag_with_http_info(external_shipment_id, external_shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to remove tag from (required)
         :param str external_shipment_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id', 'external_shipment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ExternalShipmentApi(object):
 
         Returns a duplicated externalShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_external_shipment_by_id(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_external_shipment_by_id(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to be duplicated. (required)
         :return: ExternalShipment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_external_shipment_by_id_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_external_shipment_by_id_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ExternalShipmentApi(object):
 
         Returns a duplicated externalShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_external_shipment_by_id_with_http_info(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_external_shipment_by_id_with_http_info(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to be duplicated. (required)
         :return: ExternalShipment
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type='ExternalShipment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ExternalShipmentApi(object):
 
         Returns the list of externalShipments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipment_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipment_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ExternalShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_external_shipment_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_external_shipment_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ExternalShipmentApi(object):
 
         Returns the list of externalShipments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipment_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipment_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type='list[ExternalShipment]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ExternalShipmentApi(object):
 
         Returns the externalShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipment_by_id(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipment_by_id(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to be returned. (required)
         :return: ExternalShipment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_external_shipment_by_id_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_external_shipment_by_id_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ExternalShipmentApi(object):
 
         Returns the externalShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipment_by_id_with_http_info(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipment_by_id_with_http_info(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to be returned. (required)
         :return: ExternalShipment
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type='ExternalShipment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ExternalShipmentApi(object):
 
         Get all existing externalShipment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipment_files(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipment_files(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_external_shipment_files_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_external_shipment_files_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ExternalShipmentApi(object):
 
         Get all existing externalShipment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipment_files_with_http_info(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipment_files_with_http_info(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ExternalShipmentApi(object):
 
         Get all existing externalShipment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipment_tags(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipment_tags(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_external_shipment_tags_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_external_shipment_tags_with_http_info(external_shipment_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ExternalShipmentApi(object):
 
         Get all existing externalShipment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipment_tags_with_http_info(external_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipment_tags_with_http_info(external_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipment_id: Id of the externalShipment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['external_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ExternalShipmentApi(object):
 
         Updates an existing externalShipment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_external_shipment(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_external_shipment(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShipment body: ExternalShipment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_external_shipment_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_external_shipment_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ExternalShipmentApi(object):
 
         Updates an existing externalShipment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_external_shipment_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_external_shipment_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShipment body: ExternalShipment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class ExternalShipmentApi(object):
 
         Updates an existing externalShipment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_external_shipment_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_external_shipment_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShipment body: ExternalShipment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_external_shipment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_external_shipment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class ExternalShipmentApi(object):
 
         Updates an existing externalShipment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_external_shipment_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_external_shipment_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShipment body: ExternalShipment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class ExternalShipmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class ExternalShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/external_shipping_system_api.py
+++ b/Infoplus/api/external_shipping_system_api.py
@@ -38,18 +38,18 @@ class ExternalShippingSystemApi(object):
 
         Inserts a new externalShippingSystem using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShippingSystem body: ExternalShippingSystem to be inserted. (required)
         :return: ExternalShippingSystem
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipping_system_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipping_system_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ExternalShippingSystemApi(object):
 
         Inserts a new externalShippingSystem using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShippingSystem body: ExternalShippingSystem to be inserted. (required)
         :return: ExternalShippingSystem
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type='ExternalShippingSystem',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ExternalShippingSystemApi(object):
 
         Adds an audit to an existing externalShippingSystem.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system_audit(external_shipping_system_id, external_shipping_system_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system_audit(external_shipping_system_id, external_shipping_system_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to add an audit to (required)
         :param str external_shipping_system_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ExternalShippingSystemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipping_system_audit_with_http_info(external_shipping_system_id, external_shipping_system_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipping_system_audit_with_http_info(external_shipping_system_id, external_shipping_system_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ExternalShippingSystemApi(object):
 
         Adds an audit to an existing externalShippingSystem.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system_audit_with_http_info(external_shipping_system_id, external_shipping_system_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system_audit_with_http_info(external_shipping_system_id, external_shipping_system_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to add an audit to (required)
         :param str external_shipping_system_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id', 'external_shipping_system_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ExternalShippingSystemApi(object):
 
         Adds a file to an existing externalShippingSystem.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system_file(external_shipping_system_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system_file(external_shipping_system_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ExternalShippingSystemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipping_system_file_with_http_info(external_shipping_system_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipping_system_file_with_http_info(external_shipping_system_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ExternalShippingSystemApi(object):
 
         Adds a file to an existing externalShippingSystem.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system_file_with_http_info(external_shipping_system_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system_file_with_http_info(external_shipping_system_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ExternalShippingSystemApi(object):
 
         Adds a file to an existing externalShippingSystem by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system_file_by_url(body, external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system_file_by_url(body, external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int external_shipping_system_id: Id of the externalShippingSystem to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ExternalShippingSystemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipping_system_file_by_url_with_http_info(body, external_shipping_system_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipping_system_file_by_url_with_http_info(body, external_shipping_system_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ExternalShippingSystemApi(object):
 
         Adds a file to an existing externalShippingSystem by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system_file_by_url_with_http_info(body, external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system_file_by_url_with_http_info(body, external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int external_shipping_system_id: Id of the externalShippingSystem to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['body', 'external_shipping_system_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ExternalShippingSystemApi(object):
 
         Adds a tag to an existing externalShippingSystem.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system_tag(external_shipping_system_id, external_shipping_system_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system_tag(external_shipping_system_id, external_shipping_system_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to add a tag to (required)
         :param str external_shipping_system_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ExternalShippingSystemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_external_shipping_system_tag_with_http_info(external_shipping_system_id, external_shipping_system_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_external_shipping_system_tag_with_http_info(external_shipping_system_id, external_shipping_system_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ExternalShippingSystemApi(object):
 
         Adds a tag to an existing externalShippingSystem.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_external_shipping_system_tag_with_http_info(external_shipping_system_id, external_shipping_system_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_external_shipping_system_tag_with_http_info(external_shipping_system_id, external_shipping_system_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to add a tag to (required)
         :param str external_shipping_system_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id', 'external_shipping_system_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ExternalShippingSystemApi(object):
 
         Deletes the externalShippingSystem identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipping_system(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipping_system(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_external_shipping_system_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_external_shipping_system_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ExternalShippingSystemApi(object):
 
         Deletes the externalShippingSystem identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipping_system_with_http_info(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipping_system_with_http_info(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ExternalShippingSystemApi(object):
 
         Deletes an existing externalShippingSystem file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipping_system_file(external_shipping_system_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipping_system_file(external_shipping_system_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ExternalShippingSystemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_external_shipping_system_file_with_http_info(external_shipping_system_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_external_shipping_system_file_with_http_info(external_shipping_system_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ExternalShippingSystemApi(object):
 
         Deletes an existing externalShippingSystem file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipping_system_file_with_http_info(external_shipping_system_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipping_system_file_with_http_info(external_shipping_system_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ExternalShippingSystemApi(object):
 
         Deletes an existing externalShippingSystem tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipping_system_tag(external_shipping_system_id, external_shipping_system_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipping_system_tag(external_shipping_system_id, external_shipping_system_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to remove tag from (required)
         :param str external_shipping_system_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ExternalShippingSystemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_external_shipping_system_tag_with_http_info(external_shipping_system_id, external_shipping_system_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_external_shipping_system_tag_with_http_info(external_shipping_system_id, external_shipping_system_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ExternalShippingSystemApi(object):
 
         Deletes an existing externalShippingSystem tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_external_shipping_system_tag_with_http_info(external_shipping_system_id, external_shipping_system_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_external_shipping_system_tag_with_http_info(external_shipping_system_id, external_shipping_system_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to remove tag from (required)
         :param str external_shipping_system_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id', 'external_shipping_system_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ExternalShippingSystemApi(object):
 
         Returns a duplicated externalShippingSystem identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_external_shipping_system_by_id(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_external_shipping_system_by_id(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to be duplicated. (required)
         :return: ExternalShippingSystem
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_external_shipping_system_by_id_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_external_shipping_system_by_id_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ExternalShippingSystemApi(object):
 
         Returns a duplicated externalShippingSystem identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_external_shipping_system_by_id_with_http_info(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_external_shipping_system_by_id_with_http_info(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to be duplicated. (required)
         :return: ExternalShippingSystem
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type='ExternalShippingSystem',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ExternalShippingSystemApi(object):
 
         Returns the list of externalShippingSystems that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipping_system_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipping_system_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ExternalShippingSystemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_external_shipping_system_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_external_shipping_system_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ExternalShippingSystemApi(object):
 
         Returns the list of externalShippingSystems that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipping_system_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipping_system_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type='list[ExternalShippingSystem]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ExternalShippingSystemApi(object):
 
         Returns the externalShippingSystem identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipping_system_by_id(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipping_system_by_id(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to be returned. (required)
         :return: ExternalShippingSystem
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_external_shipping_system_by_id_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_external_shipping_system_by_id_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ExternalShippingSystemApi(object):
 
         Returns the externalShippingSystem identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipping_system_by_id_with_http_info(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipping_system_by_id_with_http_info(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to be returned. (required)
         :return: ExternalShippingSystem
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type='ExternalShippingSystem',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ExternalShippingSystemApi(object):
 
         Get all existing externalShippingSystem files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipping_system_files(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipping_system_files(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_external_shipping_system_files_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_external_shipping_system_files_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ExternalShippingSystemApi(object):
 
         Get all existing externalShippingSystem files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipping_system_files_with_http_info(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipping_system_files_with_http_info(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ExternalShippingSystemApi(object):
 
         Get all existing externalShippingSystem tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipping_system_tags(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipping_system_tags(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_external_shipping_system_tags_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_external_shipping_system_tags_with_http_info(external_shipping_system_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ExternalShippingSystemApi(object):
 
         Get all existing externalShippingSystem tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_external_shipping_system_tags_with_http_info(external_shipping_system_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_external_shipping_system_tags_with_http_info(external_shipping_system_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int external_shipping_system_id: Id of the externalShippingSystem to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['external_shipping_system_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ExternalShippingSystemApi(object):
 
         Updates an existing externalShippingSystem using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_external_shipping_system(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_external_shipping_system(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShippingSystem body: ExternalShippingSystem to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_external_shipping_system_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_external_shipping_system_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ExternalShippingSystemApi(object):
 
         Updates an existing externalShippingSystem using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_external_shipping_system_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_external_shipping_system_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShippingSystem body: ExternalShippingSystem to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class ExternalShippingSystemApi(object):
 
         Updates an existing externalShippingSystem custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_external_shipping_system_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_external_shipping_system_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShippingSystem body: ExternalShippingSystem to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_external_shipping_system_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_external_shipping_system_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class ExternalShippingSystemApi(object):
 
         Updates an existing externalShippingSystem custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_external_shipping_system_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_external_shipping_system_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExternalShippingSystem body: ExternalShippingSystem to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class ExternalShippingSystemApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class ExternalShippingSystemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/finance_system_connection_api.py
+++ b/Infoplus/api/finance_system_connection_api.py
@@ -38,18 +38,18 @@ class FinanceSystemConnectionApi(object):
 
         Inserts a new financeSystemConnection using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FinanceSystemConnection body: FinanceSystemConnection to be inserted. (required)
         :return: FinanceSystemConnection
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_finance_system_connection_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_finance_system_connection_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class FinanceSystemConnectionApi(object):
 
         Inserts a new financeSystemConnection using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FinanceSystemConnection body: FinanceSystemConnection to be inserted. (required)
         :return: FinanceSystemConnection
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type='FinanceSystemConnection',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class FinanceSystemConnectionApi(object):
 
         Adds an audit to an existing financeSystemConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_audit(finance_system_connection_id, finance_system_connection_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_audit(finance_system_connection_id, finance_system_connection_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to add an audit to (required)
         :param str finance_system_connection_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class FinanceSystemConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_finance_system_connection_audit_with_http_info(finance_system_connection_id, finance_system_connection_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_finance_system_connection_audit_with_http_info(finance_system_connection_id, finance_system_connection_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class FinanceSystemConnectionApi(object):
 
         Adds an audit to an existing financeSystemConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_audit_with_http_info(finance_system_connection_id, finance_system_connection_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_audit_with_http_info(finance_system_connection_id, finance_system_connection_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to add an audit to (required)
         :param str finance_system_connection_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id', 'finance_system_connection_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class FinanceSystemConnectionApi(object):
 
         Adds a file to an existing financeSystemConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_file(finance_system_connection_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_file(finance_system_connection_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class FinanceSystemConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_finance_system_connection_file_with_http_info(finance_system_connection_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_finance_system_connection_file_with_http_info(finance_system_connection_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class FinanceSystemConnectionApi(object):
 
         Adds a file to an existing financeSystemConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_file_with_http_info(finance_system_connection_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_file_with_http_info(finance_system_connection_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class FinanceSystemConnectionApi(object):
 
         Adds a file to an existing financeSystemConnection by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_file_by_url(body, finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_file_by_url(body, finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int finance_system_connection_id: Id of the financeSystemConnection to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class FinanceSystemConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_finance_system_connection_file_by_url_with_http_info(body, finance_system_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_finance_system_connection_file_by_url_with_http_info(body, finance_system_connection_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class FinanceSystemConnectionApi(object):
 
         Adds a file to an existing financeSystemConnection by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_file_by_url_with_http_info(body, finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_file_by_url_with_http_info(body, finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int finance_system_connection_id: Id of the financeSystemConnection to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['body', 'finance_system_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class FinanceSystemConnectionApi(object):
 
         Adds a tag to an existing financeSystemConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_tag(finance_system_connection_id, finance_system_connection_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_tag(finance_system_connection_id, finance_system_connection_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to add a tag to (required)
         :param str finance_system_connection_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class FinanceSystemConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_finance_system_connection_tag_with_http_info(finance_system_connection_id, finance_system_connection_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_finance_system_connection_tag_with_http_info(finance_system_connection_id, finance_system_connection_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class FinanceSystemConnectionApi(object):
 
         Adds a tag to an existing financeSystemConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_tag_with_http_info(finance_system_connection_id, finance_system_connection_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_tag_with_http_info(finance_system_connection_id, finance_system_connection_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to add a tag to (required)
         :param str finance_system_connection_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id', 'finance_system_connection_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class FinanceSystemConnectionApi(object):
 
         Deletes the financeSystemConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_finance_system_connection_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_finance_system_connection_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class FinanceSystemConnectionApi(object):
 
         Deletes the financeSystemConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection_with_http_info(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection_with_http_info(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class FinanceSystemConnectionApi(object):
 
         Deletes an existing financeSystemConnection file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection_file(finance_system_connection_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection_file(finance_system_connection_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class FinanceSystemConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_finance_system_connection_file_with_http_info(finance_system_connection_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_finance_system_connection_file_with_http_info(finance_system_connection_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class FinanceSystemConnectionApi(object):
 
         Deletes an existing financeSystemConnection file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection_file_with_http_info(finance_system_connection_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection_file_with_http_info(finance_system_connection_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class FinanceSystemConnectionApi(object):
 
         Deletes an existing financeSystemConnection tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection_tag(finance_system_connection_id, finance_system_connection_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection_tag(finance_system_connection_id, finance_system_connection_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to remove tag from (required)
         :param str finance_system_connection_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class FinanceSystemConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_finance_system_connection_tag_with_http_info(finance_system_connection_id, finance_system_connection_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_finance_system_connection_tag_with_http_info(finance_system_connection_id, finance_system_connection_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class FinanceSystemConnectionApi(object):
 
         Deletes an existing financeSystemConnection tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection_tag_with_http_info(finance_system_connection_id, finance_system_connection_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection_tag_with_http_info(finance_system_connection_id, finance_system_connection_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to remove tag from (required)
         :param str finance_system_connection_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id', 'finance_system_connection_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class FinanceSystemConnectionApi(object):
 
         Returns a duplicated financeSystemConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_finance_system_connection_by_id(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_finance_system_connection_by_id(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to be duplicated. (required)
         :return: FinanceSystemConnection
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_finance_system_connection_by_id_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_finance_system_connection_by_id_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class FinanceSystemConnectionApi(object):
 
         Returns a duplicated financeSystemConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_finance_system_connection_by_id_with_http_info(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_finance_system_connection_by_id_with_http_info(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to be duplicated. (required)
         :return: FinanceSystemConnection
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type='FinanceSystemConnection',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class FinanceSystemConnectionApi(object):
 
         Returns the list of financeSystemConnections that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class FinanceSystemConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_finance_system_connection_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_finance_system_connection_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class FinanceSystemConnectionApi(object):
 
         Returns the list of financeSystemConnections that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type='list[FinanceSystemConnection]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class FinanceSystemConnectionApi(object):
 
         Returns the financeSystemConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_by_id(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_by_id(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to be returned. (required)
         :return: FinanceSystemConnection
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_finance_system_connection_by_id_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_finance_system_connection_by_id_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class FinanceSystemConnectionApi(object):
 
         Returns the financeSystemConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_by_id_with_http_info(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_by_id_with_http_info(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to be returned. (required)
         :return: FinanceSystemConnection
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type='FinanceSystemConnection',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class FinanceSystemConnectionApi(object):
 
         Get all existing financeSystemConnection files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_files(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_files(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_finance_system_connection_files_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_finance_system_connection_files_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class FinanceSystemConnectionApi(object):
 
         Get all existing financeSystemConnection files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_files_with_http_info(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_files_with_http_info(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class FinanceSystemConnectionApi(object):
 
         Get all existing financeSystemConnection tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_tags(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_tags(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_finance_system_connection_tags_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_finance_system_connection_tags_with_http_info(finance_system_connection_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class FinanceSystemConnectionApi(object):
 
         Get all existing financeSystemConnection tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_tags_with_http_info(finance_system_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_tags_with_http_info(finance_system_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_id: Id of the financeSystemConnection to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['finance_system_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class FinanceSystemConnectionApi(object):
 
         Updates an existing financeSystemConnection using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_finance_system_connection(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_finance_system_connection(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FinanceSystemConnection body: FinanceSystemConnection to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_finance_system_connection_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_finance_system_connection_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class FinanceSystemConnectionApi(object):
 
         Updates an existing financeSystemConnection using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_finance_system_connection_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_finance_system_connection_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FinanceSystemConnection body: FinanceSystemConnection to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class FinanceSystemConnectionApi(object):
 
         Updates an existing financeSystemConnection custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_finance_system_connection_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_finance_system_connection_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FinanceSystemConnection body: FinanceSystemConnection to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_finance_system_connection_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_finance_system_connection_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class FinanceSystemConnectionApi(object):
 
         Updates an existing financeSystemConnection custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_finance_system_connection_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_finance_system_connection_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FinanceSystemConnection body: FinanceSystemConnection to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class FinanceSystemConnectionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class FinanceSystemConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/finance_system_connection_log_api.py
+++ b/Infoplus/api/finance_system_connection_log_api.py
@@ -38,11 +38,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Adds an audit to an existing financeSystemConnectionLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_log_audit(finance_system_connection_log_id, finance_system_connection_log_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_log_audit(finance_system_connection_log_id, finance_system_connection_log_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to add an audit to (required)
         :param str finance_system_connection_log_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class FinanceSystemConnectionLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_finance_system_connection_log_audit_with_http_info(finance_system_connection_log_id, finance_system_connection_log_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_finance_system_connection_log_audit_with_http_info(finance_system_connection_log_id, finance_system_connection_log_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Adds an audit to an existing financeSystemConnectionLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_log_audit_with_http_info(finance_system_connection_log_id, finance_system_connection_log_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_log_audit_with_http_info(finance_system_connection_log_id, finance_system_connection_log_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to add an audit to (required)
         :param str finance_system_connection_log_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['finance_system_connection_log_id', 'finance_system_connection_log_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Adds a file to an existing financeSystemConnectionLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_log_file(finance_system_connection_log_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_log_file(finance_system_connection_log_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class FinanceSystemConnectionLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_finance_system_connection_log_file_with_http_info(finance_system_connection_log_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_finance_system_connection_log_file_with_http_info(finance_system_connection_log_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Adds a file to an existing financeSystemConnectionLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_log_file_with_http_info(finance_system_connection_log_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_log_file_with_http_info(finance_system_connection_log_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['finance_system_connection_log_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Adds a file to an existing financeSystemConnectionLog by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_log_file_by_url(body, finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_log_file_by_url(body, finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class FinanceSystemConnectionLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_finance_system_connection_log_file_by_url_with_http_info(body, finance_system_connection_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_finance_system_connection_log_file_by_url_with_http_info(body, finance_system_connection_log_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Adds a file to an existing financeSystemConnectionLog by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_log_file_by_url_with_http_info(body, finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_log_file_by_url_with_http_info(body, finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['body', 'finance_system_connection_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Adds a tag to an existing financeSystemConnectionLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_log_tag(finance_system_connection_log_id, finance_system_connection_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_log_tag(finance_system_connection_log_id, finance_system_connection_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to add a tag to (required)
         :param str finance_system_connection_log_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class FinanceSystemConnectionLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_finance_system_connection_log_tag_with_http_info(finance_system_connection_log_id, finance_system_connection_log_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_finance_system_connection_log_tag_with_http_info(finance_system_connection_log_id, finance_system_connection_log_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Adds a tag to an existing financeSystemConnectionLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_finance_system_connection_log_tag_with_http_info(finance_system_connection_log_id, finance_system_connection_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_finance_system_connection_log_tag_with_http_info(finance_system_connection_log_id, finance_system_connection_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to add a tag to (required)
         :param str finance_system_connection_log_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['finance_system_connection_log_id', 'finance_system_connection_log_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Deletes an existing financeSystemConnectionLog file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection_log_file(finance_system_connection_log_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection_log_file(finance_system_connection_log_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class FinanceSystemConnectionLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_finance_system_connection_log_file_with_http_info(finance_system_connection_log_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_finance_system_connection_log_file_with_http_info(finance_system_connection_log_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Deletes an existing financeSystemConnectionLog file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection_log_file_with_http_info(finance_system_connection_log_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection_log_file_with_http_info(finance_system_connection_log_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['finance_system_connection_log_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Deletes an existing financeSystemConnectionLog tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection_log_tag(finance_system_connection_log_id, finance_system_connection_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection_log_tag(finance_system_connection_log_id, finance_system_connection_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to remove tag from (required)
         :param str finance_system_connection_log_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class FinanceSystemConnectionLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_finance_system_connection_log_tag_with_http_info(finance_system_connection_log_id, finance_system_connection_log_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_finance_system_connection_log_tag_with_http_info(finance_system_connection_log_id, finance_system_connection_log_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Deletes an existing financeSystemConnectionLog tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_finance_system_connection_log_tag_with_http_info(finance_system_connection_log_id, finance_system_connection_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_finance_system_connection_log_tag_with_http_info(finance_system_connection_log_id, finance_system_connection_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to remove tag from (required)
         :param str finance_system_connection_log_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['finance_system_connection_log_id', 'finance_system_connection_log_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class FinanceSystemConnectionLogApi(object):
 
         Returns a duplicated financeSystemConnectionLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_finance_system_connection_log_by_id(finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_finance_system_connection_log_by_id(finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to be duplicated. (required)
         :return: FinanceSystemConnectionLog
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_finance_system_connection_log_by_id_with_http_info(finance_system_connection_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_finance_system_connection_log_by_id_with_http_info(finance_system_connection_log_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Returns a duplicated financeSystemConnectionLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_finance_system_connection_log_by_id_with_http_info(finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_finance_system_connection_log_by_id_with_http_info(finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to be duplicated. (required)
         :return: FinanceSystemConnectionLog
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['finance_system_connection_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type='FinanceSystemConnectionLog',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Returns the list of financeSystemConnectionLogs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_log_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_log_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class FinanceSystemConnectionLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_finance_system_connection_log_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_finance_system_connection_log_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Returns the list of financeSystemConnectionLogs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_log_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_log_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type='list[FinanceSystemConnectionLog]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class FinanceSystemConnectionLogApi(object):
 
         Returns the financeSystemConnectionLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_log_by_id(finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_log_by_id(finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to be returned. (required)
         :return: FinanceSystemConnectionLog
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_finance_system_connection_log_by_id_with_http_info(finance_system_connection_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_finance_system_connection_log_by_id_with_http_info(finance_system_connection_log_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Returns the financeSystemConnectionLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_log_by_id_with_http_info(finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_log_by_id_with_http_info(finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to be returned. (required)
         :return: FinanceSystemConnectionLog
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['finance_system_connection_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type='FinanceSystemConnectionLog',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class FinanceSystemConnectionLogApi(object):
 
         Get all existing financeSystemConnectionLog files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_log_files(finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_log_files(finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_finance_system_connection_log_files_with_http_info(finance_system_connection_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_finance_system_connection_log_files_with_http_info(finance_system_connection_log_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Get all existing financeSystemConnectionLog files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_log_files_with_http_info(finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_log_files_with_http_info(finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['finance_system_connection_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class FinanceSystemConnectionLogApi(object):
 
         Get all existing financeSystemConnectionLog tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_log_tags(finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_log_tags(finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_finance_system_connection_log_tags_with_http_info(finance_system_connection_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_finance_system_connection_log_tags_with_http_info(finance_system_connection_log_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class FinanceSystemConnectionLogApi(object):
 
         Get all existing financeSystemConnectionLog tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_finance_system_connection_log_tags_with_http_info(finance_system_connection_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_finance_system_connection_log_tags_with_http_info(finance_system_connection_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int finance_system_connection_log_id: Id of the financeSystemConnectionLog to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class FinanceSystemConnectionLogApi(object):
         """
 
         all_params = ['finance_system_connection_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class FinanceSystemConnectionLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/fulfillment_layout_position_api.py
+++ b/Infoplus/api/fulfillment_layout_position_api.py
@@ -38,11 +38,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Adds an audit to an existing fulfillmentLayoutPosition.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_layout_position_audit(fulfillment_layout_position_id, fulfillment_layout_position_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_layout_position_audit(fulfillment_layout_position_id, fulfillment_layout_position_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to add an audit to (required)
         :param str fulfillment_layout_position_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class FulfillmentLayoutPositionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_layout_position_audit_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_layout_position_audit_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Adds an audit to an existing fulfillmentLayoutPosition.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_layout_position_audit_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_layout_position_audit_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to add an audit to (required)
         :param str fulfillment_layout_position_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['fulfillment_layout_position_id', 'fulfillment_layout_position_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Adds a file to an existing fulfillmentLayoutPosition.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_layout_position_file(fulfillment_layout_position_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_layout_position_file(fulfillment_layout_position_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class FulfillmentLayoutPositionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_layout_position_file_with_http_info(fulfillment_layout_position_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_layout_position_file_with_http_info(fulfillment_layout_position_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Adds a file to an existing fulfillmentLayoutPosition.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_layout_position_file_with_http_info(fulfillment_layout_position_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_layout_position_file_with_http_info(fulfillment_layout_position_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['fulfillment_layout_position_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Adds a file to an existing fulfillmentLayoutPosition by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_layout_position_file_by_url(body, fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_layout_position_file_by_url(body, fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class FulfillmentLayoutPositionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_layout_position_file_by_url_with_http_info(body, fulfillment_layout_position_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_layout_position_file_by_url_with_http_info(body, fulfillment_layout_position_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Adds a file to an existing fulfillmentLayoutPosition by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_layout_position_file_by_url_with_http_info(body, fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_layout_position_file_by_url_with_http_info(body, fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['body', 'fulfillment_layout_position_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Adds a tag to an existing fulfillmentLayoutPosition.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_layout_position_tag(fulfillment_layout_position_id, fulfillment_layout_position_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_layout_position_tag(fulfillment_layout_position_id, fulfillment_layout_position_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to add a tag to (required)
         :param str fulfillment_layout_position_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class FulfillmentLayoutPositionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_layout_position_tag_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_layout_position_tag_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Adds a tag to an existing fulfillmentLayoutPosition.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_layout_position_tag_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_layout_position_tag_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to add a tag to (required)
         :param str fulfillment_layout_position_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['fulfillment_layout_position_id', 'fulfillment_layout_position_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Deletes an existing fulfillmentLayoutPosition file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_layout_position_file(fulfillment_layout_position_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_layout_position_file(fulfillment_layout_position_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class FulfillmentLayoutPositionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_fulfillment_layout_position_file_with_http_info(fulfillment_layout_position_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_fulfillment_layout_position_file_with_http_info(fulfillment_layout_position_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Deletes an existing fulfillmentLayoutPosition file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_layout_position_file_with_http_info(fulfillment_layout_position_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_layout_position_file_with_http_info(fulfillment_layout_position_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['fulfillment_layout_position_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Deletes an existing fulfillmentLayoutPosition tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_layout_position_tag(fulfillment_layout_position_id, fulfillment_layout_position_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_layout_position_tag(fulfillment_layout_position_id, fulfillment_layout_position_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to remove tag from (required)
         :param str fulfillment_layout_position_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class FulfillmentLayoutPositionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_fulfillment_layout_position_tag_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_fulfillment_layout_position_tag_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Deletes an existing fulfillmentLayoutPosition tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_layout_position_tag_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_layout_position_tag_with_http_info(fulfillment_layout_position_id, fulfillment_layout_position_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to remove tag from (required)
         :param str fulfillment_layout_position_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['fulfillment_layout_position_id', 'fulfillment_layout_position_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class FulfillmentLayoutPositionApi(object):
 
         Returns a duplicated fulfillmentLayoutPosition identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_fulfillment_layout_position_by_id(fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_fulfillment_layout_position_by_id(fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to be duplicated. (required)
         :return: FulfillmentLayoutPosition
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_fulfillment_layout_position_by_id_with_http_info(fulfillment_layout_position_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_fulfillment_layout_position_by_id_with_http_info(fulfillment_layout_position_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Returns a duplicated fulfillmentLayoutPosition identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_fulfillment_layout_position_by_id_with_http_info(fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_fulfillment_layout_position_by_id_with_http_info(fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to be duplicated. (required)
         :return: FulfillmentLayoutPosition
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['fulfillment_layout_position_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type='FulfillmentLayoutPosition',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Returns the list of fulfillmentLayoutPositions that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_layout_position_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_layout_position_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class FulfillmentLayoutPositionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_layout_position_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_layout_position_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Returns the list of fulfillmentLayoutPositions that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_layout_position_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_layout_position_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type='list[FulfillmentLayoutPosition]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class FulfillmentLayoutPositionApi(object):
 
         Returns the fulfillmentLayoutPosition identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_layout_position_by_id(fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_layout_position_by_id(fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to be returned. (required)
         :return: FulfillmentLayoutPosition
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_layout_position_by_id_with_http_info(fulfillment_layout_position_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_layout_position_by_id_with_http_info(fulfillment_layout_position_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Returns the fulfillmentLayoutPosition identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_layout_position_by_id_with_http_info(fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_layout_position_by_id_with_http_info(fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to be returned. (required)
         :return: FulfillmentLayoutPosition
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['fulfillment_layout_position_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type='FulfillmentLayoutPosition',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class FulfillmentLayoutPositionApi(object):
 
         Get all existing fulfillmentLayoutPosition files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_layout_position_files(fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_layout_position_files(fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_layout_position_files_with_http_info(fulfillment_layout_position_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_layout_position_files_with_http_info(fulfillment_layout_position_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Get all existing fulfillmentLayoutPosition files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_layout_position_files_with_http_info(fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_layout_position_files_with_http_info(fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['fulfillment_layout_position_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class FulfillmentLayoutPositionApi(object):
 
         Get all existing fulfillmentLayoutPosition tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_layout_position_tags(fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_layout_position_tags(fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_layout_position_tags_with_http_info(fulfillment_layout_position_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_layout_position_tags_with_http_info(fulfillment_layout_position_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class FulfillmentLayoutPositionApi(object):
 
         Get all existing fulfillmentLayoutPosition tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_layout_position_tags_with_http_info(fulfillment_layout_position_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_layout_position_tags_with_http_info(fulfillment_layout_position_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_layout_position_id: Id of the fulfillmentLayoutPosition to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class FulfillmentLayoutPositionApi(object):
         """
 
         all_params = ['fulfillment_layout_position_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class FulfillmentLayoutPositionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/fulfillment_plan_api.py
+++ b/Infoplus/api/fulfillment_plan_api.py
@@ -38,18 +38,18 @@ class FulfillmentPlanApi(object):
 
         Inserts a new fulfillmentPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FulfillmentPlan body: FulfillmentPlan to be inserted. (required)
         :return: FulfillmentPlan
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_plan_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_plan_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class FulfillmentPlanApi(object):
 
         Inserts a new fulfillmentPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FulfillmentPlan body: FulfillmentPlan to be inserted. (required)
         :return: FulfillmentPlan
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type='FulfillmentPlan',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class FulfillmentPlanApi(object):
 
         Adds an audit to an existing fulfillmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan_audit(fulfillment_plan_id, fulfillment_plan_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan_audit(fulfillment_plan_id, fulfillment_plan_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to add an audit to (required)
         :param str fulfillment_plan_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class FulfillmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_plan_audit_with_http_info(fulfillment_plan_id, fulfillment_plan_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_plan_audit_with_http_info(fulfillment_plan_id, fulfillment_plan_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class FulfillmentPlanApi(object):
 
         Adds an audit to an existing fulfillmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan_audit_with_http_info(fulfillment_plan_id, fulfillment_plan_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan_audit_with_http_info(fulfillment_plan_id, fulfillment_plan_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to add an audit to (required)
         :param str fulfillment_plan_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id', 'fulfillment_plan_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class FulfillmentPlanApi(object):
 
         Adds a file to an existing fulfillmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan_file(fulfillment_plan_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan_file(fulfillment_plan_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class FulfillmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_plan_file_with_http_info(fulfillment_plan_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_plan_file_with_http_info(fulfillment_plan_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class FulfillmentPlanApi(object):
 
         Adds a file to an existing fulfillmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan_file_with_http_info(fulfillment_plan_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan_file_with_http_info(fulfillment_plan_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class FulfillmentPlanApi(object):
 
         Adds a file to an existing fulfillmentPlan by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan_file_by_url(body, fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan_file_by_url(body, fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class FulfillmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_plan_file_by_url_with_http_info(body, fulfillment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_plan_file_by_url_with_http_info(body, fulfillment_plan_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class FulfillmentPlanApi(object):
 
         Adds a file to an existing fulfillmentPlan by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan_file_by_url_with_http_info(body, fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan_file_by_url_with_http_info(body, fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['body', 'fulfillment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class FulfillmentPlanApi(object):
 
         Adds a tag to an existing fulfillmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan_tag(fulfillment_plan_id, fulfillment_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan_tag(fulfillment_plan_id, fulfillment_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to add a tag to (required)
         :param str fulfillment_plan_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class FulfillmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_plan_tag_with_http_info(fulfillment_plan_id, fulfillment_plan_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_plan_tag_with_http_info(fulfillment_plan_id, fulfillment_plan_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class FulfillmentPlanApi(object):
 
         Adds a tag to an existing fulfillmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_plan_tag_with_http_info(fulfillment_plan_id, fulfillment_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_plan_tag_with_http_info(fulfillment_plan_id, fulfillment_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to add a tag to (required)
         :param str fulfillment_plan_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id', 'fulfillment_plan_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class FulfillmentPlanApi(object):
 
         Deletes the fulfillmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_plan(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_plan(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_fulfillment_plan_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_fulfillment_plan_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class FulfillmentPlanApi(object):
 
         Deletes the fulfillmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_plan_with_http_info(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_plan_with_http_info(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class FulfillmentPlanApi(object):
 
         Deletes an existing fulfillmentPlan file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_plan_file(fulfillment_plan_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_plan_file(fulfillment_plan_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class FulfillmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_fulfillment_plan_file_with_http_info(fulfillment_plan_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_fulfillment_plan_file_with_http_info(fulfillment_plan_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class FulfillmentPlanApi(object):
 
         Deletes an existing fulfillmentPlan file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_plan_file_with_http_info(fulfillment_plan_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_plan_file_with_http_info(fulfillment_plan_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class FulfillmentPlanApi(object):
 
         Deletes an existing fulfillmentPlan tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_plan_tag(fulfillment_plan_id, fulfillment_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_plan_tag(fulfillment_plan_id, fulfillment_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to remove tag from (required)
         :param str fulfillment_plan_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class FulfillmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_fulfillment_plan_tag_with_http_info(fulfillment_plan_id, fulfillment_plan_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_fulfillment_plan_tag_with_http_info(fulfillment_plan_id, fulfillment_plan_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class FulfillmentPlanApi(object):
 
         Deletes an existing fulfillmentPlan tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_plan_tag_with_http_info(fulfillment_plan_id, fulfillment_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_plan_tag_with_http_info(fulfillment_plan_id, fulfillment_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to remove tag from (required)
         :param str fulfillment_plan_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id', 'fulfillment_plan_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class FulfillmentPlanApi(object):
 
         Returns a duplicated fulfillmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_fulfillment_plan_by_id(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_fulfillment_plan_by_id(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to be duplicated. (required)
         :return: FulfillmentPlan
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_fulfillment_plan_by_id_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_fulfillment_plan_by_id_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class FulfillmentPlanApi(object):
 
         Returns a duplicated fulfillmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_fulfillment_plan_by_id_with_http_info(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_fulfillment_plan_by_id_with_http_info(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to be duplicated. (required)
         :return: FulfillmentPlan
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type='FulfillmentPlan',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class FulfillmentPlanApi(object):
 
         Returns the list of fulfillmentPlans that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_plan_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_plan_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class FulfillmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_plan_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_plan_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class FulfillmentPlanApi(object):
 
         Returns the list of fulfillmentPlans that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_plan_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_plan_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type='list[FulfillmentPlan]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class FulfillmentPlanApi(object):
 
         Returns the fulfillmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_plan_by_id(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_plan_by_id(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to be returned. (required)
         :return: FulfillmentPlan
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_plan_by_id_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_plan_by_id_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class FulfillmentPlanApi(object):
 
         Returns the fulfillmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_plan_by_id_with_http_info(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_plan_by_id_with_http_info(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to be returned. (required)
         :return: FulfillmentPlan
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type='FulfillmentPlan',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class FulfillmentPlanApi(object):
 
         Get all existing fulfillmentPlan files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_plan_files(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_plan_files(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_plan_files_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_plan_files_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class FulfillmentPlanApi(object):
 
         Get all existing fulfillmentPlan files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_plan_files_with_http_info(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_plan_files_with_http_info(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class FulfillmentPlanApi(object):
 
         Get all existing fulfillmentPlan tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_plan_tags(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_plan_tags(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_plan_tags_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_plan_tags_with_http_info(fulfillment_plan_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class FulfillmentPlanApi(object):
 
         Get all existing fulfillmentPlan tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_plan_tags_with_http_info(fulfillment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_plan_tags_with_http_info(fulfillment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_plan_id: Id of the fulfillmentPlan to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['fulfillment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class FulfillmentPlanApi(object):
 
         Updates an existing fulfillmentPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_fulfillment_plan(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_fulfillment_plan(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FulfillmentPlan body: FulfillmentPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_fulfillment_plan_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_fulfillment_plan_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class FulfillmentPlanApi(object):
 
         Updates an existing fulfillmentPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_fulfillment_plan_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_fulfillment_plan_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FulfillmentPlan body: FulfillmentPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class FulfillmentPlanApi(object):
 
         Updates an existing fulfillmentPlan custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_fulfillment_plan_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_fulfillment_plan_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FulfillmentPlan body: FulfillmentPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_fulfillment_plan_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_fulfillment_plan_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class FulfillmentPlanApi(object):
 
         Updates an existing fulfillmentPlan custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_fulfillment_plan_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_fulfillment_plan_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FulfillmentPlan body: FulfillmentPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class FulfillmentPlanApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class FulfillmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/fulfillment_process_api.py
+++ b/Infoplus/api/fulfillment_process_api.py
@@ -38,11 +38,11 @@ class FulfillmentProcessApi(object):
 
         Adds an audit to an existing fulfillmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_audit(fulfillment_process_id, fulfillment_process_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_audit(fulfillment_process_id, fulfillment_process_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to add an audit to (required)
         :param str fulfillment_process_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class FulfillmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_process_audit_with_http_info(fulfillment_process_id, fulfillment_process_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_process_audit_with_http_info(fulfillment_process_id, fulfillment_process_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class FulfillmentProcessApi(object):
 
         Adds an audit to an existing fulfillmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_audit_with_http_info(fulfillment_process_id, fulfillment_process_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_audit_with_http_info(fulfillment_process_id, fulfillment_process_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to add an audit to (required)
         :param str fulfillment_process_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['fulfillment_process_id', 'fulfillment_process_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class FulfillmentProcessApi(object):
 
         Adds a file to an existing fulfillmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_file(fulfillment_process_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_file(fulfillment_process_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class FulfillmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_process_file_with_http_info(fulfillment_process_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_process_file_with_http_info(fulfillment_process_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class FulfillmentProcessApi(object):
 
         Adds a file to an existing fulfillmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_file_with_http_info(fulfillment_process_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_file_with_http_info(fulfillment_process_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['fulfillment_process_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class FulfillmentProcessApi(object):
 
         Adds a file to an existing fulfillmentProcess by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_file_by_url(body, fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_file_by_url(body, fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int fulfillment_process_id: Id of the fulfillmentProcess to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class FulfillmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_process_file_by_url_with_http_info(body, fulfillment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_process_file_by_url_with_http_info(body, fulfillment_process_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class FulfillmentProcessApi(object):
 
         Adds a file to an existing fulfillmentProcess by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_file_by_url_with_http_info(body, fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_file_by_url_with_http_info(body, fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int fulfillment_process_id: Id of the fulfillmentProcess to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['body', 'fulfillment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class FulfillmentProcessApi(object):
 
         Adds a tag to an existing fulfillmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_tag(fulfillment_process_id, fulfillment_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_tag(fulfillment_process_id, fulfillment_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to add a tag to (required)
         :param str fulfillment_process_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class FulfillmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_process_tag_with_http_info(fulfillment_process_id, fulfillment_process_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_process_tag_with_http_info(fulfillment_process_id, fulfillment_process_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class FulfillmentProcessApi(object):
 
         Adds a tag to an existing fulfillmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_tag_with_http_info(fulfillment_process_id, fulfillment_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_tag_with_http_info(fulfillment_process_id, fulfillment_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to add a tag to (required)
         :param str fulfillment_process_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['fulfillment_process_id', 'fulfillment_process_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class FulfillmentProcessApi(object):
 
         Deletes an existing fulfillmentProcess file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_process_file(fulfillment_process_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_process_file(fulfillment_process_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class FulfillmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_fulfillment_process_file_with_http_info(fulfillment_process_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_fulfillment_process_file_with_http_info(fulfillment_process_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class FulfillmentProcessApi(object):
 
         Deletes an existing fulfillmentProcess file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_process_file_with_http_info(fulfillment_process_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_process_file_with_http_info(fulfillment_process_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['fulfillment_process_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class FulfillmentProcessApi(object):
 
         Deletes an existing fulfillmentProcess tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_process_tag(fulfillment_process_id, fulfillment_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_process_tag(fulfillment_process_id, fulfillment_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to remove tag from (required)
         :param str fulfillment_process_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class FulfillmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_fulfillment_process_tag_with_http_info(fulfillment_process_id, fulfillment_process_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_fulfillment_process_tag_with_http_info(fulfillment_process_id, fulfillment_process_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class FulfillmentProcessApi(object):
 
         Deletes an existing fulfillmentProcess tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_process_tag_with_http_info(fulfillment_process_id, fulfillment_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_process_tag_with_http_info(fulfillment_process_id, fulfillment_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to remove tag from (required)
         :param str fulfillment_process_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['fulfillment_process_id', 'fulfillment_process_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class FulfillmentProcessApi(object):
 
         Returns a duplicated fulfillmentProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_fulfillment_process_by_id(fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_fulfillment_process_by_id(fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to be duplicated. (required)
         :return: FulfillmentProcess
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_fulfillment_process_by_id_with_http_info(fulfillment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_fulfillment_process_by_id_with_http_info(fulfillment_process_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class FulfillmentProcessApi(object):
 
         Returns a duplicated fulfillmentProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_fulfillment_process_by_id_with_http_info(fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_fulfillment_process_by_id_with_http_info(fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to be duplicated. (required)
         :return: FulfillmentProcess
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['fulfillment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type='FulfillmentProcess',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class FulfillmentProcessApi(object):
 
         Returns the list of fulfillmentProcesses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class FulfillmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class FulfillmentProcessApi(object):
 
         Returns the list of fulfillmentProcesses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type='list[FulfillmentProcess]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class FulfillmentProcessApi(object):
 
         Returns the fulfillmentProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_by_id(fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_by_id(fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to be returned. (required)
         :return: FulfillmentProcess
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_by_id_with_http_info(fulfillment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_by_id_with_http_info(fulfillment_process_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class FulfillmentProcessApi(object):
 
         Returns the fulfillmentProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_by_id_with_http_info(fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_by_id_with_http_info(fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to be returned. (required)
         :return: FulfillmentProcess
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['fulfillment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type='FulfillmentProcess',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class FulfillmentProcessApi(object):
 
         Get all existing fulfillmentProcess files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_files(fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_files(fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_files_with_http_info(fulfillment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_files_with_http_info(fulfillment_process_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class FulfillmentProcessApi(object):
 
         Get all existing fulfillmentProcess files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_files_with_http_info(fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_files_with_http_info(fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['fulfillment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class FulfillmentProcessApi(object):
 
         Get all existing fulfillmentProcess tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_tags(fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_tags(fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_tags_with_http_info(fulfillment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_tags_with_http_info(fulfillment_process_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class FulfillmentProcessApi(object):
 
         Get all existing fulfillmentProcess tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_tags_with_http_info(fulfillment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_tags_with_http_info(fulfillment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_id: Id of the fulfillmentProcess to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['fulfillment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class FulfillmentProcessApi(object):
 
         Updates an existing fulfillmentProcess custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_fulfillment_process_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_fulfillment_process_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FulfillmentProcess body: FulfillmentProcess to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_fulfillment_process_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_fulfillment_process_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class FulfillmentProcessApi(object):
 
         Updates an existing fulfillmentProcess custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_fulfillment_process_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_fulfillment_process_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param FulfillmentProcess body: FulfillmentProcess to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class FulfillmentProcessApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class FulfillmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/fulfillment_process_log_api.py
+++ b/Infoplus/api/fulfillment_process_log_api.py
@@ -38,11 +38,11 @@ class FulfillmentProcessLogApi(object):
 
         Adds an audit to an existing fulfillmentProcessLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_log_audit(fulfillment_process_log_id, fulfillment_process_log_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_log_audit(fulfillment_process_log_id, fulfillment_process_log_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to add an audit to (required)
         :param str fulfillment_process_log_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class FulfillmentProcessLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_process_log_audit_with_http_info(fulfillment_process_log_id, fulfillment_process_log_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_process_log_audit_with_http_info(fulfillment_process_log_id, fulfillment_process_log_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class FulfillmentProcessLogApi(object):
 
         Adds an audit to an existing fulfillmentProcessLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_log_audit_with_http_info(fulfillment_process_log_id, fulfillment_process_log_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_log_audit_with_http_info(fulfillment_process_log_id, fulfillment_process_log_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to add an audit to (required)
         :param str fulfillment_process_log_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['fulfillment_process_log_id', 'fulfillment_process_log_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class FulfillmentProcessLogApi(object):
 
         Adds a file to an existing fulfillmentProcessLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_log_file(fulfillment_process_log_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_log_file(fulfillment_process_log_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class FulfillmentProcessLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_process_log_file_with_http_info(fulfillment_process_log_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_process_log_file_with_http_info(fulfillment_process_log_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class FulfillmentProcessLogApi(object):
 
         Adds a file to an existing fulfillmentProcessLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_log_file_with_http_info(fulfillment_process_log_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_log_file_with_http_info(fulfillment_process_log_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['fulfillment_process_log_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class FulfillmentProcessLogApi(object):
 
         Adds a file to an existing fulfillmentProcessLog by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_log_file_by_url(body, fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_log_file_by_url(body, fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class FulfillmentProcessLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_process_log_file_by_url_with_http_info(body, fulfillment_process_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_process_log_file_by_url_with_http_info(body, fulfillment_process_log_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class FulfillmentProcessLogApi(object):
 
         Adds a file to an existing fulfillmentProcessLog by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_log_file_by_url_with_http_info(body, fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_log_file_by_url_with_http_info(body, fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['body', 'fulfillment_process_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class FulfillmentProcessLogApi(object):
 
         Adds a tag to an existing fulfillmentProcessLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_log_tag(fulfillment_process_log_id, fulfillment_process_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_log_tag(fulfillment_process_log_id, fulfillment_process_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to add a tag to (required)
         :param str fulfillment_process_log_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class FulfillmentProcessLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_fulfillment_process_log_tag_with_http_info(fulfillment_process_log_id, fulfillment_process_log_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_fulfillment_process_log_tag_with_http_info(fulfillment_process_log_id, fulfillment_process_log_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class FulfillmentProcessLogApi(object):
 
         Adds a tag to an existing fulfillmentProcessLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_fulfillment_process_log_tag_with_http_info(fulfillment_process_log_id, fulfillment_process_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_fulfillment_process_log_tag_with_http_info(fulfillment_process_log_id, fulfillment_process_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to add a tag to (required)
         :param str fulfillment_process_log_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['fulfillment_process_log_id', 'fulfillment_process_log_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class FulfillmentProcessLogApi(object):
 
         Deletes an existing fulfillmentProcessLog file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_process_log_file(fulfillment_process_log_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_process_log_file(fulfillment_process_log_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class FulfillmentProcessLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_fulfillment_process_log_file_with_http_info(fulfillment_process_log_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_fulfillment_process_log_file_with_http_info(fulfillment_process_log_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class FulfillmentProcessLogApi(object):
 
         Deletes an existing fulfillmentProcessLog file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_process_log_file_with_http_info(fulfillment_process_log_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_process_log_file_with_http_info(fulfillment_process_log_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['fulfillment_process_log_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class FulfillmentProcessLogApi(object):
 
         Deletes an existing fulfillmentProcessLog tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_process_log_tag(fulfillment_process_log_id, fulfillment_process_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_process_log_tag(fulfillment_process_log_id, fulfillment_process_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to remove tag from (required)
         :param str fulfillment_process_log_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class FulfillmentProcessLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_fulfillment_process_log_tag_with_http_info(fulfillment_process_log_id, fulfillment_process_log_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_fulfillment_process_log_tag_with_http_info(fulfillment_process_log_id, fulfillment_process_log_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class FulfillmentProcessLogApi(object):
 
         Deletes an existing fulfillmentProcessLog tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_fulfillment_process_log_tag_with_http_info(fulfillment_process_log_id, fulfillment_process_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_fulfillment_process_log_tag_with_http_info(fulfillment_process_log_id, fulfillment_process_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to remove tag from (required)
         :param str fulfillment_process_log_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['fulfillment_process_log_id', 'fulfillment_process_log_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class FulfillmentProcessLogApi(object):
 
         Returns a duplicated fulfillmentProcessLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_fulfillment_process_log_by_id(fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_fulfillment_process_log_by_id(fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to be duplicated. (required)
         :return: FulfillmentProcessLog
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_fulfillment_process_log_by_id_with_http_info(fulfillment_process_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_fulfillment_process_log_by_id_with_http_info(fulfillment_process_log_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class FulfillmentProcessLogApi(object):
 
         Returns a duplicated fulfillmentProcessLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_fulfillment_process_log_by_id_with_http_info(fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_fulfillment_process_log_by_id_with_http_info(fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to be duplicated. (required)
         :return: FulfillmentProcessLog
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['fulfillment_process_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type='FulfillmentProcessLog',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class FulfillmentProcessLogApi(object):
 
         Returns the list of fulfillmentProcessLogs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_log_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_log_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class FulfillmentProcessLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_log_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_log_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class FulfillmentProcessLogApi(object):
 
         Returns the list of fulfillmentProcessLogs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_log_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_log_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type='list[FulfillmentProcessLog]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class FulfillmentProcessLogApi(object):
 
         Returns the fulfillmentProcessLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_log_by_id(fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_log_by_id(fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to be returned. (required)
         :return: FulfillmentProcessLog
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_log_by_id_with_http_info(fulfillment_process_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_log_by_id_with_http_info(fulfillment_process_log_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class FulfillmentProcessLogApi(object):
 
         Returns the fulfillmentProcessLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_log_by_id_with_http_info(fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_log_by_id_with_http_info(fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to be returned. (required)
         :return: FulfillmentProcessLog
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['fulfillment_process_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type='FulfillmentProcessLog',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class FulfillmentProcessLogApi(object):
 
         Get all existing fulfillmentProcessLog files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_log_files(fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_log_files(fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_log_files_with_http_info(fulfillment_process_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_log_files_with_http_info(fulfillment_process_log_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class FulfillmentProcessLogApi(object):
 
         Get all existing fulfillmentProcessLog files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_log_files_with_http_info(fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_log_files_with_http_info(fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['fulfillment_process_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class FulfillmentProcessLogApi(object):
 
         Get all existing fulfillmentProcessLog tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_log_tags(fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_log_tags(fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_log_tags_with_http_info(fulfillment_process_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_log_tags_with_http_info(fulfillment_process_log_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class FulfillmentProcessLogApi(object):
 
         Get all existing fulfillmentProcessLog tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_log_tags_with_http_info(fulfillment_process_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_log_tags_with_http_info(fulfillment_process_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int fulfillment_process_log_id: Id of the fulfillmentProcessLog to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class FulfillmentProcessLogApi(object):
         """
 
         all_params = ['fulfillment_process_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class FulfillmentProcessLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/fulfillment_process_pick_batch_group_api.py
+++ b/Infoplus/api/fulfillment_process_pick_batch_group_api.py
@@ -38,18 +38,18 @@ class FulfillmentProcessPickBatchGroupApi(object):
 
         Returns the fulfillmentProcessPickBatchGroup identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_group_picks_by_by_id(fulfillment_process_pick_batch_group_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_group_picks_by_by_id(fulfillment_process_pick_batch_group_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str fulfillment_process_pick_batch_group_id: Id of fulfillmentProcessPickBatchGroup to be returned. (required)
         :return: FulfillmentProcessPickBatchGroup
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_group_picks_by_by_id_with_http_info(fulfillment_process_pick_batch_group_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_group_picks_by_by_id_with_http_info(fulfillment_process_pick_batch_group_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class FulfillmentProcessPickBatchGroupApi(object):
 
         Returns the fulfillmentProcessPickBatchGroup identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_group_picks_by_by_id_with_http_info(fulfillment_process_pick_batch_group_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_group_picks_by_by_id_with_http_info(fulfillment_process_pick_batch_group_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str fulfillment_process_pick_batch_group_id: Id of fulfillmentProcessPickBatchGroup to be returned. (required)
         :return: FulfillmentProcessPickBatchGroup
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class FulfillmentProcessPickBatchGroupApi(object):
         """
 
         all_params = ['fulfillment_process_pick_batch_group_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class FulfillmentProcessPickBatchGroupApi(object):
             files=local_var_files,
             response_type='FulfillmentProcessPickBatchGroup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class FulfillmentProcessPickBatchGroupApi(object):
 
         Returns the list of fulfillmentProcessPickBatchGroups that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_pick_batch_group_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_pick_batch_group_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class FulfillmentProcessPickBatchGroupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_fulfillment_process_pick_batch_group_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_fulfillment_process_pick_batch_group_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class FulfillmentProcessPickBatchGroupApi(object):
 
         Returns the list of fulfillmentProcessPickBatchGroups that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_fulfillment_process_pick_batch_group_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_fulfillment_process_pick_batch_group_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class FulfillmentProcessPickBatchGroupApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class FulfillmentProcessPickBatchGroupApi(object):
             files=local_var_files,
             response_type='list[FulfillmentProcessPickBatchGroup]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/gs1128_label_api.py
+++ b/Infoplus/api/gs1128_label_api.py
@@ -38,11 +38,11 @@ class Gs1128LabelApi(object):
 
         Adds an audit to an existing gs1128Label.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_label_audit(gs1128_label_id, gs1128_label_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_label_audit(gs1128_label_id, gs1128_label_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to add an audit to (required)
         :param str gs1128_label_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class Gs1128LabelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_gs1128_label_audit_with_http_info(gs1128_label_id, gs1128_label_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_gs1128_label_audit_with_http_info(gs1128_label_id, gs1128_label_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class Gs1128LabelApi(object):
 
         Adds an audit to an existing gs1128Label.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_label_audit_with_http_info(gs1128_label_id, gs1128_label_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_label_audit_with_http_info(gs1128_label_id, gs1128_label_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to add an audit to (required)
         :param str gs1128_label_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id', 'gs1128_label_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class Gs1128LabelApi(object):
 
         Adds a file to an existing gs1128Label.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_label_file(gs1128_label_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_label_file(gs1128_label_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class Gs1128LabelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_gs1128_label_file_with_http_info(gs1128_label_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_gs1128_label_file_with_http_info(gs1128_label_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class Gs1128LabelApi(object):
 
         Adds a file to an existing gs1128Label.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_label_file_with_http_info(gs1128_label_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_label_file_with_http_info(gs1128_label_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class Gs1128LabelApi(object):
 
         Adds a file to an existing gs1128Label by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_label_file_by_url(body, gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_label_file_by_url(body, gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int gs1128_label_id: Id of the gs1128Label to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class Gs1128LabelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_gs1128_label_file_by_url_with_http_info(body, gs1128_label_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_gs1128_label_file_by_url_with_http_info(body, gs1128_label_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class Gs1128LabelApi(object):
 
         Adds a file to an existing gs1128Label by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_label_file_by_url_with_http_info(body, gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_label_file_by_url_with_http_info(body, gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int gs1128_label_id: Id of the gs1128Label to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['body', 'gs1128_label_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class Gs1128LabelApi(object):
 
         Adds a tag to an existing gs1128Label.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_label_tag(gs1128_label_id, gs1128_label_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_label_tag(gs1128_label_id, gs1128_label_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to add a tag to (required)
         :param str gs1128_label_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class Gs1128LabelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_gs1128_label_tag_with_http_info(gs1128_label_id, gs1128_label_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_gs1128_label_tag_with_http_info(gs1128_label_id, gs1128_label_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class Gs1128LabelApi(object):
 
         Adds a tag to an existing gs1128Label.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_label_tag_with_http_info(gs1128_label_id, gs1128_label_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_label_tag_with_http_info(gs1128_label_id, gs1128_label_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to add a tag to (required)
         :param str gs1128_label_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id', 'gs1128_label_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,18 +462,18 @@ class Gs1128LabelApi(object):
 
         Deletes the gs1128Label identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_label(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_label(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_gs1128_label_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_gs1128_label_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
@@ -484,11 +484,11 @@ class Gs1128LabelApi(object):
 
         Deletes the gs1128Label identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_label_with_http_info(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_label_with_http_info(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -496,7 +496,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -546,7 +546,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -557,11 +557,11 @@ class Gs1128LabelApi(object):
 
         Deletes an existing gs1128Label file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_label_file(gs1128_label_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_label_file(gs1128_label_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -569,7 +569,7 @@ class Gs1128LabelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_gs1128_label_file_with_http_info(gs1128_label_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_gs1128_label_file_with_http_info(gs1128_label_id, file_id, **kwargs)  # noqa: E501
@@ -580,11 +580,11 @@ class Gs1128LabelApi(object):
 
         Deletes an existing gs1128Label file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_label_file_with_http_info(gs1128_label_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_label_file_with_http_info(gs1128_label_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -593,7 +593,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -649,7 +649,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -660,11 +660,11 @@ class Gs1128LabelApi(object):
 
         Deletes an existing gs1128Label tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_label_tag(gs1128_label_id, gs1128_label_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_label_tag(gs1128_label_id, gs1128_label_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to remove tag from (required)
         :param str gs1128_label_tag: The tag to delete (required)
         :return: None
@@ -672,7 +672,7 @@ class Gs1128LabelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_gs1128_label_tag_with_http_info(gs1128_label_id, gs1128_label_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_gs1128_label_tag_with_http_info(gs1128_label_id, gs1128_label_tag, **kwargs)  # noqa: E501
@@ -683,11 +683,11 @@ class Gs1128LabelApi(object):
 
         Deletes an existing gs1128Label tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_label_tag_with_http_info(gs1128_label_id, gs1128_label_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_label_tag_with_http_info(gs1128_label_id, gs1128_label_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to remove tag from (required)
         :param str gs1128_label_tag: The tag to delete (required)
         :return: None
@@ -696,7 +696,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id', 'gs1128_label_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,18 +763,18 @@ class Gs1128LabelApi(object):
 
         Returns a duplicated gs1128Label identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_gs1128_label_by_id(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_gs1128_label_by_id(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to be duplicated. (required)
         :return: Gs1128Label
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_gs1128_label_by_id_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_gs1128_label_by_id_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
@@ -785,11 +785,11 @@ class Gs1128LabelApi(object):
 
         Returns a duplicated gs1128Label identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_gs1128_label_by_id_with_http_info(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_gs1128_label_by_id_with_http_info(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to be duplicated. (required)
         :return: Gs1128Label
                  If the method is called asynchronously,
@@ -797,7 +797,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -847,7 +847,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type='Gs1128Label',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -858,11 +858,11 @@ class Gs1128LabelApi(object):
 
         Returns the list of gs1128Labels that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_label_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_label_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -872,7 +872,7 @@ class Gs1128LabelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_gs1128_label_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_gs1128_label_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -883,11 +883,11 @@ class Gs1128LabelApi(object):
 
         Returns the list of gs1128Labels that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_label_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_label_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -898,7 +898,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type='list[Gs1128Label]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class Gs1128LabelApi(object):
 
         Returns the gs1128Label identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_label_by_id(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_label_by_id(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to be returned. (required)
         :return: Gs1128Label
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_gs1128_label_by_id_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_gs1128_label_by_id_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class Gs1128LabelApi(object):
 
         Returns the gs1128Label identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_label_by_id_with_http_info(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_label_by_id_with_http_info(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to be returned. (required)
         :return: Gs1128Label
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type='Gs1128Label',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class Gs1128LabelApi(object):
 
         Get all existing gs1128Label files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_label_files(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_label_files(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_gs1128_label_files_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_gs1128_label_files_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class Gs1128LabelApi(object):
 
         Get all existing gs1128Label files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_label_files_with_http_info(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_label_files_with_http_info(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class Gs1128LabelApi(object):
 
         Get all existing gs1128Label tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_label_tags(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_label_tags(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_gs1128_label_tags_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_gs1128_label_tags_with_http_info(gs1128_label_id, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class Gs1128LabelApi(object):
 
         Get all existing gs1128Label tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_label_tags_with_http_info(gs1128_label_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_label_tags_with_http_info(gs1128_label_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_label_id: Id of the gs1128Label to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['gs1128_label_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1235,7 +1235,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1246,18 +1246,18 @@ class Gs1128LabelApi(object):
 
         Updates an existing gs1128Label custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_gs1128_label_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_gs1128_label_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Gs1128Label body: Gs1128Label to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_gs1128_label_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_gs1128_label_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1268,11 +1268,11 @@ class Gs1128LabelApi(object):
 
         Updates an existing gs1128Label custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_gs1128_label_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_gs1128_label_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Gs1128Label body: Gs1128Label to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1280,7 +1280,7 @@ class Gs1128LabelApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class Gs1128LabelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/gs1128_template_api.py
+++ b/Infoplus/api/gs1128_template_api.py
@@ -38,18 +38,18 @@ class Gs1128TemplateApi(object):
 
         Inserts a new gs1128Template using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Gs1128Template body: Gs1128Template to be inserted. (required)
         :return: Gs1128Template
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_gs1128_template_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_gs1128_template_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class Gs1128TemplateApi(object):
 
         Inserts a new gs1128Template using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Gs1128Template body: Gs1128Template to be inserted. (required)
         :return: Gs1128Template
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type='Gs1128Template',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class Gs1128TemplateApi(object):
 
         Adds an audit to an existing gs1128Template.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template_audit(gs1128_template_id, gs1128_template_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template_audit(gs1128_template_id, gs1128_template_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to add an audit to (required)
         :param str gs1128_template_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class Gs1128TemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_gs1128_template_audit_with_http_info(gs1128_template_id, gs1128_template_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_gs1128_template_audit_with_http_info(gs1128_template_id, gs1128_template_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class Gs1128TemplateApi(object):
 
         Adds an audit to an existing gs1128Template.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template_audit_with_http_info(gs1128_template_id, gs1128_template_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template_audit_with_http_info(gs1128_template_id, gs1128_template_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to add an audit to (required)
         :param str gs1128_template_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id', 'gs1128_template_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class Gs1128TemplateApi(object):
 
         Adds a file to an existing gs1128Template.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template_file(gs1128_template_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template_file(gs1128_template_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class Gs1128TemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_gs1128_template_file_with_http_info(gs1128_template_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_gs1128_template_file_with_http_info(gs1128_template_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class Gs1128TemplateApi(object):
 
         Adds a file to an existing gs1128Template.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template_file_with_http_info(gs1128_template_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template_file_with_http_info(gs1128_template_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class Gs1128TemplateApi(object):
 
         Adds a file to an existing gs1128Template by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template_file_by_url(body, gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template_file_by_url(body, gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int gs1128_template_id: Id of the gs1128Template to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class Gs1128TemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_gs1128_template_file_by_url_with_http_info(body, gs1128_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_gs1128_template_file_by_url_with_http_info(body, gs1128_template_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class Gs1128TemplateApi(object):
 
         Adds a file to an existing gs1128Template by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template_file_by_url_with_http_info(body, gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template_file_by_url_with_http_info(body, gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int gs1128_template_id: Id of the gs1128Template to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['body', 'gs1128_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class Gs1128TemplateApi(object):
 
         Adds a tag to an existing gs1128Template.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template_tag(gs1128_template_id, gs1128_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template_tag(gs1128_template_id, gs1128_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to add a tag to (required)
         :param str gs1128_template_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class Gs1128TemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_gs1128_template_tag_with_http_info(gs1128_template_id, gs1128_template_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_gs1128_template_tag_with_http_info(gs1128_template_id, gs1128_template_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class Gs1128TemplateApi(object):
 
         Adds a tag to an existing gs1128Template.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_gs1128_template_tag_with_http_info(gs1128_template_id, gs1128_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_gs1128_template_tag_with_http_info(gs1128_template_id, gs1128_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to add a tag to (required)
         :param str gs1128_template_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id', 'gs1128_template_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class Gs1128TemplateApi(object):
 
         Deletes the gs1128Template identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_template(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_template(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_gs1128_template_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_gs1128_template_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class Gs1128TemplateApi(object):
 
         Deletes the gs1128Template identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_template_with_http_info(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_template_with_http_info(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class Gs1128TemplateApi(object):
 
         Deletes an existing gs1128Template file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_template_file(gs1128_template_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_template_file(gs1128_template_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class Gs1128TemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_gs1128_template_file_with_http_info(gs1128_template_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_gs1128_template_file_with_http_info(gs1128_template_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class Gs1128TemplateApi(object):
 
         Deletes an existing gs1128Template file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_template_file_with_http_info(gs1128_template_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_template_file_with_http_info(gs1128_template_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class Gs1128TemplateApi(object):
 
         Deletes an existing gs1128Template tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_template_tag(gs1128_template_id, gs1128_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_template_tag(gs1128_template_id, gs1128_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to remove tag from (required)
         :param str gs1128_template_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class Gs1128TemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_gs1128_template_tag_with_http_info(gs1128_template_id, gs1128_template_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_gs1128_template_tag_with_http_info(gs1128_template_id, gs1128_template_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class Gs1128TemplateApi(object):
 
         Deletes an existing gs1128Template tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_gs1128_template_tag_with_http_info(gs1128_template_id, gs1128_template_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_gs1128_template_tag_with_http_info(gs1128_template_id, gs1128_template_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to remove tag from (required)
         :param str gs1128_template_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id', 'gs1128_template_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class Gs1128TemplateApi(object):
 
         Returns a duplicated gs1128Template identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_gs1128_template_by_id(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_gs1128_template_by_id(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to be duplicated. (required)
         :return: Gs1128Template
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_gs1128_template_by_id_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_gs1128_template_by_id_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class Gs1128TemplateApi(object):
 
         Returns a duplicated gs1128Template identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_gs1128_template_by_id_with_http_info(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_gs1128_template_by_id_with_http_info(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to be duplicated. (required)
         :return: Gs1128Template
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type='Gs1128Template',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class Gs1128TemplateApi(object):
 
         Returns the list of gs1128Templates that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_template_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_template_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class Gs1128TemplateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_gs1128_template_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_gs1128_template_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class Gs1128TemplateApi(object):
 
         Returns the list of gs1128Templates that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_template_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_template_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type='list[Gs1128Template]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class Gs1128TemplateApi(object):
 
         Returns the gs1128Template identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_template_by_id(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_template_by_id(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to be returned. (required)
         :return: Gs1128Template
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_gs1128_template_by_id_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_gs1128_template_by_id_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class Gs1128TemplateApi(object):
 
         Returns the gs1128Template identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_template_by_id_with_http_info(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_template_by_id_with_http_info(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to be returned. (required)
         :return: Gs1128Template
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type='Gs1128Template',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class Gs1128TemplateApi(object):
 
         Get all existing gs1128Template files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_template_files(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_template_files(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_gs1128_template_files_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_gs1128_template_files_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class Gs1128TemplateApi(object):
 
         Get all existing gs1128Template files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_template_files_with_http_info(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_template_files_with_http_info(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class Gs1128TemplateApi(object):
 
         Get all existing gs1128Template tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_template_tags(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_template_tags(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_gs1128_template_tags_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_gs1128_template_tags_with_http_info(gs1128_template_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class Gs1128TemplateApi(object):
 
         Get all existing gs1128Template tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_gs1128_template_tags_with_http_info(gs1128_template_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_gs1128_template_tags_with_http_info(gs1128_template_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int gs1128_template_id: Id of the gs1128Template to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['gs1128_template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class Gs1128TemplateApi(object):
 
         Updates an existing gs1128Template using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_gs1128_template(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_gs1128_template(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Gs1128Template body: Gs1128Template to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_gs1128_template_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_gs1128_template_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class Gs1128TemplateApi(object):
 
         Updates an existing gs1128Template using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_gs1128_template_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_gs1128_template_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Gs1128Template body: Gs1128Template to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class Gs1128TemplateApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class Gs1128TemplateApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/integration_partner_api.py
+++ b/Infoplus/api/integration_partner_api.py
@@ -38,18 +38,18 @@ class IntegrationPartnerApi(object):
 
         Returns the integrationPartner identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_integration_partner_by_id(integration_partner_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_integration_partner_by_id(integration_partner_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str integration_partner_id: Id of integrationPartner to be returned. (required)
         :return: IntegrationPartner
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_integration_partner_by_id_with_http_info(integration_partner_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_integration_partner_by_id_with_http_info(integration_partner_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class IntegrationPartnerApi(object):
 
         Returns the integrationPartner identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_integration_partner_by_id_with_http_info(integration_partner_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_integration_partner_by_id_with_http_info(integration_partner_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str integration_partner_id: Id of integrationPartner to be returned. (required)
         :return: IntegrationPartner
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class IntegrationPartnerApi(object):
         """
 
         all_params = ['integration_partner_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class IntegrationPartnerApi(object):
             files=local_var_files,
             response_type='IntegrationPartner',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class IntegrationPartnerApi(object):
 
         Returns the list of integrationPartners that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_integration_partner_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_integration_partner_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class IntegrationPartnerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_integration_partner_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_integration_partner_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class IntegrationPartnerApi(object):
 
         Returns the list of integrationPartners that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_integration_partner_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_integration_partner_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class IntegrationPartnerApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class IntegrationPartnerApi(object):
             files=local_var_files,
             response_type='list[IntegrationPartner]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/inventory_adjustment_api.py
+++ b/Infoplus/api/inventory_adjustment_api.py
@@ -38,11 +38,11 @@ class InventoryAdjustmentApi(object):
 
         Adds an audit to an existing inventoryAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_adjustment_audit(inventory_adjustment_id, inventory_adjustment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_adjustment_audit(inventory_adjustment_id, inventory_adjustment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to add an audit to (required)
         :param str inventory_adjustment_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class InventoryAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_adjustment_audit_with_http_info(inventory_adjustment_id, inventory_adjustment_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_adjustment_audit_with_http_info(inventory_adjustment_id, inventory_adjustment_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class InventoryAdjustmentApi(object):
 
         Adds an audit to an existing inventoryAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_adjustment_audit_with_http_info(inventory_adjustment_id, inventory_adjustment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_adjustment_audit_with_http_info(inventory_adjustment_id, inventory_adjustment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to add an audit to (required)
         :param str inventory_adjustment_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['inventory_adjustment_id', 'inventory_adjustment_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class InventoryAdjustmentApi(object):
 
         Adds a file to an existing inventoryAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_adjustment_file(inventory_adjustment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_adjustment_file(inventory_adjustment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class InventoryAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_adjustment_file_with_http_info(inventory_adjustment_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_adjustment_file_with_http_info(inventory_adjustment_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class InventoryAdjustmentApi(object):
 
         Adds a file to an existing inventoryAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_adjustment_file_with_http_info(inventory_adjustment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_adjustment_file_with_http_info(inventory_adjustment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['inventory_adjustment_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class InventoryAdjustmentApi(object):
 
         Adds a file to an existing inventoryAdjustment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_adjustment_file_by_url(body, inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_adjustment_file_by_url(body, inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class InventoryAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_adjustment_file_by_url_with_http_info(body, inventory_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_adjustment_file_by_url_with_http_info(body, inventory_adjustment_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class InventoryAdjustmentApi(object):
 
         Adds a file to an existing inventoryAdjustment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_adjustment_file_by_url_with_http_info(body, inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_adjustment_file_by_url_with_http_info(body, inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['body', 'inventory_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class InventoryAdjustmentApi(object):
 
         Adds a tag to an existing inventoryAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_adjustment_tag(inventory_adjustment_id, inventory_adjustment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_adjustment_tag(inventory_adjustment_id, inventory_adjustment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to add a tag to (required)
         :param str inventory_adjustment_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class InventoryAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_adjustment_tag_with_http_info(inventory_adjustment_id, inventory_adjustment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_adjustment_tag_with_http_info(inventory_adjustment_id, inventory_adjustment_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class InventoryAdjustmentApi(object):
 
         Adds a tag to an existing inventoryAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_adjustment_tag_with_http_info(inventory_adjustment_id, inventory_adjustment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_adjustment_tag_with_http_info(inventory_adjustment_id, inventory_adjustment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to add a tag to (required)
         :param str inventory_adjustment_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['inventory_adjustment_id', 'inventory_adjustment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class InventoryAdjustmentApi(object):
 
         Deletes an existing inventoryAdjustment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_adjustment_file(inventory_adjustment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_adjustment_file(inventory_adjustment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class InventoryAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_inventory_adjustment_file_with_http_info(inventory_adjustment_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_inventory_adjustment_file_with_http_info(inventory_adjustment_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class InventoryAdjustmentApi(object):
 
         Deletes an existing inventoryAdjustment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_adjustment_file_with_http_info(inventory_adjustment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_adjustment_file_with_http_info(inventory_adjustment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['inventory_adjustment_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class InventoryAdjustmentApi(object):
 
         Deletes an existing inventoryAdjustment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_adjustment_tag(inventory_adjustment_id, inventory_adjustment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_adjustment_tag(inventory_adjustment_id, inventory_adjustment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to remove tag from (required)
         :param str inventory_adjustment_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class InventoryAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_inventory_adjustment_tag_with_http_info(inventory_adjustment_id, inventory_adjustment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_inventory_adjustment_tag_with_http_info(inventory_adjustment_id, inventory_adjustment_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class InventoryAdjustmentApi(object):
 
         Deletes an existing inventoryAdjustment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_adjustment_tag_with_http_info(inventory_adjustment_id, inventory_adjustment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_adjustment_tag_with_http_info(inventory_adjustment_id, inventory_adjustment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to remove tag from (required)
         :param str inventory_adjustment_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['inventory_adjustment_id', 'inventory_adjustment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class InventoryAdjustmentApi(object):
 
         Returns a duplicated inventoryAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_inventory_adjustment_by_id(inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_inventory_adjustment_by_id(inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to be duplicated. (required)
         :return: InventoryAdjustment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_inventory_adjustment_by_id_with_http_info(inventory_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_inventory_adjustment_by_id_with_http_info(inventory_adjustment_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class InventoryAdjustmentApi(object):
 
         Returns a duplicated inventoryAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_inventory_adjustment_by_id_with_http_info(inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_inventory_adjustment_by_id_with_http_info(inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to be duplicated. (required)
         :return: InventoryAdjustment
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['inventory_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type='InventoryAdjustment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class InventoryAdjustmentApi(object):
 
         Returns the list of inventoryAdjustments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_adjustment_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_adjustment_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class InventoryAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_adjustment_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_adjustment_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class InventoryAdjustmentApi(object):
 
         Returns the list of inventoryAdjustments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_adjustment_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_adjustment_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type='list[InventoryAdjustment]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class InventoryAdjustmentApi(object):
 
         Returns the inventoryAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_adjustment_by_id(inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_adjustment_by_id(inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to be returned. (required)
         :return: InventoryAdjustment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_adjustment_by_id_with_http_info(inventory_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_adjustment_by_id_with_http_info(inventory_adjustment_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class InventoryAdjustmentApi(object):
 
         Returns the inventoryAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_adjustment_by_id_with_http_info(inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_adjustment_by_id_with_http_info(inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to be returned. (required)
         :return: InventoryAdjustment
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['inventory_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type='InventoryAdjustment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class InventoryAdjustmentApi(object):
 
         Get all existing inventoryAdjustment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_adjustment_files(inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_adjustment_files(inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_adjustment_files_with_http_info(inventory_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_adjustment_files_with_http_info(inventory_adjustment_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class InventoryAdjustmentApi(object):
 
         Get all existing inventoryAdjustment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_adjustment_files_with_http_info(inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_adjustment_files_with_http_info(inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['inventory_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class InventoryAdjustmentApi(object):
 
         Get all existing inventoryAdjustment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_adjustment_tags(inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_adjustment_tags(inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_adjustment_tags_with_http_info(inventory_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_adjustment_tags_with_http_info(inventory_adjustment_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class InventoryAdjustmentApi(object):
 
         Get all existing inventoryAdjustment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_adjustment_tags_with_http_info(inventory_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_adjustment_tags_with_http_info(inventory_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_adjustment_id: Id of the inventoryAdjustment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['inventory_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class InventoryAdjustmentApi(object):
 
         Updates an existing inventoryAdjustment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_inventory_adjustment_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_inventory_adjustment_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InventoryAdjustment body: InventoryAdjustment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_inventory_adjustment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_inventory_adjustment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class InventoryAdjustmentApi(object):
 
         Updates an existing inventoryAdjustment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_inventory_adjustment_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_inventory_adjustment_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InventoryAdjustment body: InventoryAdjustment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class InventoryAdjustmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class InventoryAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/inventory_detail_api.py
+++ b/Infoplus/api/inventory_detail_api.py
@@ -38,11 +38,11 @@ class InventoryDetailApi(object):
 
         Adds an audit to an existing inventoryDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_detail_audit(inventory_detail_id, inventory_detail_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_detail_audit(inventory_detail_id, inventory_detail_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to add an audit to (required)
         :param str inventory_detail_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class InventoryDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_detail_audit_with_http_info(inventory_detail_id, inventory_detail_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_detail_audit_with_http_info(inventory_detail_id, inventory_detail_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class InventoryDetailApi(object):
 
         Adds an audit to an existing inventoryDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_detail_audit_with_http_info(inventory_detail_id, inventory_detail_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_detail_audit_with_http_info(inventory_detail_id, inventory_detail_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to add an audit to (required)
         :param str inventory_detail_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['inventory_detail_id', 'inventory_detail_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class InventoryDetailApi(object):
 
         Adds a file to an existing inventoryDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_detail_file(inventory_detail_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_detail_file(inventory_detail_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class InventoryDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_detail_file_with_http_info(inventory_detail_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_detail_file_with_http_info(inventory_detail_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class InventoryDetailApi(object):
 
         Adds a file to an existing inventoryDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_detail_file_with_http_info(inventory_detail_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_detail_file_with_http_info(inventory_detail_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['inventory_detail_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class InventoryDetailApi(object):
 
         Adds a file to an existing inventoryDetail by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_detail_file_by_url(body, inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_detail_file_by_url(body, inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int inventory_detail_id: Id of the inventoryDetail to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class InventoryDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_detail_file_by_url_with_http_info(body, inventory_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_detail_file_by_url_with_http_info(body, inventory_detail_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class InventoryDetailApi(object):
 
         Adds a file to an existing inventoryDetail by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_detail_file_by_url_with_http_info(body, inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_detail_file_by_url_with_http_info(body, inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int inventory_detail_id: Id of the inventoryDetail to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['body', 'inventory_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class InventoryDetailApi(object):
 
         Adds a tag to an existing inventoryDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_detail_tag(inventory_detail_id, inventory_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_detail_tag(inventory_detail_id, inventory_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to add a tag to (required)
         :param str inventory_detail_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class InventoryDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_detail_tag_with_http_info(inventory_detail_id, inventory_detail_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_detail_tag_with_http_info(inventory_detail_id, inventory_detail_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class InventoryDetailApi(object):
 
         Adds a tag to an existing inventoryDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_detail_tag_with_http_info(inventory_detail_id, inventory_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_detail_tag_with_http_info(inventory_detail_id, inventory_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to add a tag to (required)
         :param str inventory_detail_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['inventory_detail_id', 'inventory_detail_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class InventoryDetailApi(object):
 
         Deletes an existing inventoryDetail file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_detail_file(inventory_detail_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_detail_file(inventory_detail_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class InventoryDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_inventory_detail_file_with_http_info(inventory_detail_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_inventory_detail_file_with_http_info(inventory_detail_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class InventoryDetailApi(object):
 
         Deletes an existing inventoryDetail file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_detail_file_with_http_info(inventory_detail_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_detail_file_with_http_info(inventory_detail_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['inventory_detail_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class InventoryDetailApi(object):
 
         Deletes an existing inventoryDetail tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_detail_tag(inventory_detail_id, inventory_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_detail_tag(inventory_detail_id, inventory_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to remove tag from (required)
         :param str inventory_detail_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class InventoryDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_inventory_detail_tag_with_http_info(inventory_detail_id, inventory_detail_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_inventory_detail_tag_with_http_info(inventory_detail_id, inventory_detail_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class InventoryDetailApi(object):
 
         Deletes an existing inventoryDetail tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_detail_tag_with_http_info(inventory_detail_id, inventory_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_detail_tag_with_http_info(inventory_detail_id, inventory_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to remove tag from (required)
         :param str inventory_detail_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['inventory_detail_id', 'inventory_detail_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class InventoryDetailApi(object):
 
         Returns a duplicated inventoryDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_inventory_detail_by_id(inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_inventory_detail_by_id(inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to be duplicated. (required)
         :return: InventoryDetail
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_inventory_detail_by_id_with_http_info(inventory_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_inventory_detail_by_id_with_http_info(inventory_detail_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class InventoryDetailApi(object):
 
         Returns a duplicated inventoryDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_inventory_detail_by_id_with_http_info(inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_inventory_detail_by_id_with_http_info(inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to be duplicated. (required)
         :return: InventoryDetail
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['inventory_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type='InventoryDetail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class InventoryDetailApi(object):
 
         Returns the list of inventoryDetails that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_detail_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_detail_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class InventoryDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_detail_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_detail_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class InventoryDetailApi(object):
 
         Returns the list of inventoryDetails that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_detail_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_detail_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type='list[InventoryDetail]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class InventoryDetailApi(object):
 
         Returns the inventoryDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_detail_by_id(inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_detail_by_id(inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to be returned. (required)
         :return: InventoryDetail
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_detail_by_id_with_http_info(inventory_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_detail_by_id_with_http_info(inventory_detail_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class InventoryDetailApi(object):
 
         Returns the inventoryDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_detail_by_id_with_http_info(inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_detail_by_id_with_http_info(inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to be returned. (required)
         :return: InventoryDetail
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['inventory_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type='InventoryDetail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class InventoryDetailApi(object):
 
         Get all existing inventoryDetail files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_detail_files(inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_detail_files(inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_detail_files_with_http_info(inventory_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_detail_files_with_http_info(inventory_detail_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class InventoryDetailApi(object):
 
         Get all existing inventoryDetail files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_detail_files_with_http_info(inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_detail_files_with_http_info(inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['inventory_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class InventoryDetailApi(object):
 
         Get all existing inventoryDetail tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_detail_tags(inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_detail_tags(inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_detail_tags_with_http_info(inventory_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_detail_tags_with_http_info(inventory_detail_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class InventoryDetailApi(object):
 
         Get all existing inventoryDetail tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_detail_tags_with_http_info(inventory_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_detail_tags_with_http_info(inventory_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_detail_id: Id of the inventoryDetail to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['inventory_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class InventoryDetailApi(object):
 
         Updates an existing inventoryDetail custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_inventory_detail_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_inventory_detail_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InventoryDetail body: InventoryDetail to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_inventory_detail_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_inventory_detail_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class InventoryDetailApi(object):
 
         Updates an existing inventoryDetail custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_inventory_detail_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_inventory_detail_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InventoryDetail body: InventoryDetail to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class InventoryDetailApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class InventoryDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/inventory_snapshot_api.py
+++ b/Infoplus/api/inventory_snapshot_api.py
@@ -38,11 +38,11 @@ class InventorySnapshotApi(object):
 
         Adds an audit to an existing inventorySnapshot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_snapshot_audit(inventory_snapshot_id, inventory_snapshot_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_snapshot_audit(inventory_snapshot_id, inventory_snapshot_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to add an audit to (required)
         :param str inventory_snapshot_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class InventorySnapshotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_snapshot_audit_with_http_info(inventory_snapshot_id, inventory_snapshot_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_snapshot_audit_with_http_info(inventory_snapshot_id, inventory_snapshot_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class InventorySnapshotApi(object):
 
         Adds an audit to an existing inventorySnapshot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_snapshot_audit_with_http_info(inventory_snapshot_id, inventory_snapshot_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_snapshot_audit_with_http_info(inventory_snapshot_id, inventory_snapshot_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to add an audit to (required)
         :param str inventory_snapshot_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['inventory_snapshot_id', 'inventory_snapshot_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class InventorySnapshotApi(object):
 
         Adds a file to an existing inventorySnapshot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_snapshot_file(inventory_snapshot_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_snapshot_file(inventory_snapshot_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class InventorySnapshotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_snapshot_file_with_http_info(inventory_snapshot_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_snapshot_file_with_http_info(inventory_snapshot_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class InventorySnapshotApi(object):
 
         Adds a file to an existing inventorySnapshot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_snapshot_file_with_http_info(inventory_snapshot_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_snapshot_file_with_http_info(inventory_snapshot_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['inventory_snapshot_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class InventorySnapshotApi(object):
 
         Adds a file to an existing inventorySnapshot by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_snapshot_file_by_url(body, inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_snapshot_file_by_url(body, inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int inventory_snapshot_id: Id of the inventorySnapshot to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class InventorySnapshotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_snapshot_file_by_url_with_http_info(body, inventory_snapshot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_snapshot_file_by_url_with_http_info(body, inventory_snapshot_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class InventorySnapshotApi(object):
 
         Adds a file to an existing inventorySnapshot by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_snapshot_file_by_url_with_http_info(body, inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_snapshot_file_by_url_with_http_info(body, inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int inventory_snapshot_id: Id of the inventorySnapshot to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['body', 'inventory_snapshot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class InventorySnapshotApi(object):
 
         Adds a tag to an existing inventorySnapshot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_snapshot_tag(inventory_snapshot_id, inventory_snapshot_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_snapshot_tag(inventory_snapshot_id, inventory_snapshot_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to add a tag to (required)
         :param str inventory_snapshot_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class InventorySnapshotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_snapshot_tag_with_http_info(inventory_snapshot_id, inventory_snapshot_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_snapshot_tag_with_http_info(inventory_snapshot_id, inventory_snapshot_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class InventorySnapshotApi(object):
 
         Adds a tag to an existing inventorySnapshot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_snapshot_tag_with_http_info(inventory_snapshot_id, inventory_snapshot_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_snapshot_tag_with_http_info(inventory_snapshot_id, inventory_snapshot_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to add a tag to (required)
         :param str inventory_snapshot_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['inventory_snapshot_id', 'inventory_snapshot_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class InventorySnapshotApi(object):
 
         Deletes an existing inventorySnapshot file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_snapshot_file(inventory_snapshot_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_snapshot_file(inventory_snapshot_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class InventorySnapshotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_inventory_snapshot_file_with_http_info(inventory_snapshot_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_inventory_snapshot_file_with_http_info(inventory_snapshot_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class InventorySnapshotApi(object):
 
         Deletes an existing inventorySnapshot file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_snapshot_file_with_http_info(inventory_snapshot_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_snapshot_file_with_http_info(inventory_snapshot_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['inventory_snapshot_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class InventorySnapshotApi(object):
 
         Deletes an existing inventorySnapshot tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_snapshot_tag(inventory_snapshot_id, inventory_snapshot_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_snapshot_tag(inventory_snapshot_id, inventory_snapshot_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to remove tag from (required)
         :param str inventory_snapshot_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class InventorySnapshotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_inventory_snapshot_tag_with_http_info(inventory_snapshot_id, inventory_snapshot_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_inventory_snapshot_tag_with_http_info(inventory_snapshot_id, inventory_snapshot_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class InventorySnapshotApi(object):
 
         Deletes an existing inventorySnapshot tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_snapshot_tag_with_http_info(inventory_snapshot_id, inventory_snapshot_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_snapshot_tag_with_http_info(inventory_snapshot_id, inventory_snapshot_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to remove tag from (required)
         :param str inventory_snapshot_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['inventory_snapshot_id', 'inventory_snapshot_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class InventorySnapshotApi(object):
 
         Returns a duplicated inventorySnapshot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_inventory_snapshot_by_id(inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_inventory_snapshot_by_id(inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to be duplicated. (required)
         :return: InventorySnapshot
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_inventory_snapshot_by_id_with_http_info(inventory_snapshot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_inventory_snapshot_by_id_with_http_info(inventory_snapshot_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class InventorySnapshotApi(object):
 
         Returns a duplicated inventorySnapshot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_inventory_snapshot_by_id_with_http_info(inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_inventory_snapshot_by_id_with_http_info(inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to be duplicated. (required)
         :return: InventorySnapshot
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['inventory_snapshot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type='InventorySnapshot',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class InventorySnapshotApi(object):
 
         Returns the list of inventorySnapshots that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_snapshot_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_snapshot_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class InventorySnapshotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_snapshot_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_snapshot_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class InventorySnapshotApi(object):
 
         Returns the list of inventorySnapshots that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_snapshot_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_snapshot_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type='list[InventorySnapshot]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class InventorySnapshotApi(object):
 
         Returns the inventorySnapshot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_snapshot_by_id(inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_snapshot_by_id(inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to be returned. (required)
         :return: InventorySnapshot
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_snapshot_by_id_with_http_info(inventory_snapshot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_snapshot_by_id_with_http_info(inventory_snapshot_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class InventorySnapshotApi(object):
 
         Returns the inventorySnapshot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_snapshot_by_id_with_http_info(inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_snapshot_by_id_with_http_info(inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to be returned. (required)
         :return: InventorySnapshot
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['inventory_snapshot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type='InventorySnapshot',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class InventorySnapshotApi(object):
 
         Get all existing inventorySnapshot files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_snapshot_files(inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_snapshot_files(inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_snapshot_files_with_http_info(inventory_snapshot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_snapshot_files_with_http_info(inventory_snapshot_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class InventorySnapshotApi(object):
 
         Get all existing inventorySnapshot files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_snapshot_files_with_http_info(inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_snapshot_files_with_http_info(inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['inventory_snapshot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class InventorySnapshotApi(object):
 
         Get all existing inventorySnapshot tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_snapshot_tags(inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_snapshot_tags(inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_snapshot_tags_with_http_info(inventory_snapshot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_snapshot_tags_with_http_info(inventory_snapshot_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class InventorySnapshotApi(object):
 
         Get all existing inventorySnapshot tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_snapshot_tags_with_http_info(inventory_snapshot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_snapshot_tags_with_http_info(inventory_snapshot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_snapshot_id: Id of the inventorySnapshot to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class InventorySnapshotApi(object):
         """
 
         all_params = ['inventory_snapshot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class InventorySnapshotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/inventory_storage_activity_api.py
+++ b/Infoplus/api/inventory_storage_activity_api.py
@@ -38,18 +38,18 @@ class InventoryStorageActivityApi(object):
 
         Inserts a new inventoryStorageActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InventoryStorageActivity body: InventoryStorageActivity to be inserted. (required)
         :return: InventoryStorageActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_storage_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_storage_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class InventoryStorageActivityApi(object):
 
         Inserts a new inventoryStorageActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InventoryStorageActivity body: InventoryStorageActivity to be inserted. (required)
         :return: InventoryStorageActivity
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type='InventoryStorageActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class InventoryStorageActivityApi(object):
 
         Adds an audit to an existing inventoryStorageActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity_audit(inventory_storage_activity_id, inventory_storage_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity_audit(inventory_storage_activity_id, inventory_storage_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to add an audit to (required)
         :param str inventory_storage_activity_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class InventoryStorageActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_storage_activity_audit_with_http_info(inventory_storage_activity_id, inventory_storage_activity_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_storage_activity_audit_with_http_info(inventory_storage_activity_id, inventory_storage_activity_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class InventoryStorageActivityApi(object):
 
         Adds an audit to an existing inventoryStorageActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity_audit_with_http_info(inventory_storage_activity_id, inventory_storage_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity_audit_with_http_info(inventory_storage_activity_id, inventory_storage_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to add an audit to (required)
         :param str inventory_storage_activity_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id', 'inventory_storage_activity_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class InventoryStorageActivityApi(object):
 
         Adds a file to an existing inventoryStorageActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity_file(inventory_storage_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity_file(inventory_storage_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class InventoryStorageActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_storage_activity_file_with_http_info(inventory_storage_activity_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_storage_activity_file_with_http_info(inventory_storage_activity_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class InventoryStorageActivityApi(object):
 
         Adds a file to an existing inventoryStorageActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity_file_with_http_info(inventory_storage_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity_file_with_http_info(inventory_storage_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class InventoryStorageActivityApi(object):
 
         Adds a file to an existing inventoryStorageActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity_file_by_url(body, inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity_file_by_url(body, inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class InventoryStorageActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_storage_activity_file_by_url_with_http_info(body, inventory_storage_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_storage_activity_file_by_url_with_http_info(body, inventory_storage_activity_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class InventoryStorageActivityApi(object):
 
         Adds a file to an existing inventoryStorageActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity_file_by_url_with_http_info(body, inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity_file_by_url_with_http_info(body, inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['body', 'inventory_storage_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class InventoryStorageActivityApi(object):
 
         Adds a tag to an existing inventoryStorageActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity_tag(inventory_storage_activity_id, inventory_storage_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity_tag(inventory_storage_activity_id, inventory_storage_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to add a tag to (required)
         :param str inventory_storage_activity_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class InventoryStorageActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_inventory_storage_activity_tag_with_http_info(inventory_storage_activity_id, inventory_storage_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_inventory_storage_activity_tag_with_http_info(inventory_storage_activity_id, inventory_storage_activity_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class InventoryStorageActivityApi(object):
 
         Adds a tag to an existing inventoryStorageActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_inventory_storage_activity_tag_with_http_info(inventory_storage_activity_id, inventory_storage_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_inventory_storage_activity_tag_with_http_info(inventory_storage_activity_id, inventory_storage_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to add a tag to (required)
         :param str inventory_storage_activity_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id', 'inventory_storage_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class InventoryStorageActivityApi(object):
 
         Deletes the inventoryStorageActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_storage_activity(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_storage_activity(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_inventory_storage_activity_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_inventory_storage_activity_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class InventoryStorageActivityApi(object):
 
         Deletes the inventoryStorageActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_storage_activity_with_http_info(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_storage_activity_with_http_info(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class InventoryStorageActivityApi(object):
 
         Deletes an existing inventoryStorageActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_storage_activity_file(inventory_storage_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_storage_activity_file(inventory_storage_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class InventoryStorageActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_inventory_storage_activity_file_with_http_info(inventory_storage_activity_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_inventory_storage_activity_file_with_http_info(inventory_storage_activity_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class InventoryStorageActivityApi(object):
 
         Deletes an existing inventoryStorageActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_storage_activity_file_with_http_info(inventory_storage_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_storage_activity_file_with_http_info(inventory_storage_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class InventoryStorageActivityApi(object):
 
         Deletes an existing inventoryStorageActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_storage_activity_tag(inventory_storage_activity_id, inventory_storage_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_storage_activity_tag(inventory_storage_activity_id, inventory_storage_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to remove tag from (required)
         :param str inventory_storage_activity_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class InventoryStorageActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_inventory_storage_activity_tag_with_http_info(inventory_storage_activity_id, inventory_storage_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_inventory_storage_activity_tag_with_http_info(inventory_storage_activity_id, inventory_storage_activity_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class InventoryStorageActivityApi(object):
 
         Deletes an existing inventoryStorageActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_inventory_storage_activity_tag_with_http_info(inventory_storage_activity_id, inventory_storage_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_inventory_storage_activity_tag_with_http_info(inventory_storage_activity_id, inventory_storage_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to remove tag from (required)
         :param str inventory_storage_activity_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id', 'inventory_storage_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class InventoryStorageActivityApi(object):
 
         Returns a duplicated inventoryStorageActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_inventory_storage_activity_by_id(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_inventory_storage_activity_by_id(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to be duplicated. (required)
         :return: InventoryStorageActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_inventory_storage_activity_by_id_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_inventory_storage_activity_by_id_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class InventoryStorageActivityApi(object):
 
         Returns a duplicated inventoryStorageActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_inventory_storage_activity_by_id_with_http_info(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_inventory_storage_activity_by_id_with_http_info(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to be duplicated. (required)
         :return: InventoryStorageActivity
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type='InventoryStorageActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class InventoryStorageActivityApi(object):
 
         Returns the list of inventoryStorageActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_storage_activity_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_storage_activity_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class InventoryStorageActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_storage_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_storage_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class InventoryStorageActivityApi(object):
 
         Returns the list of inventoryStorageActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_storage_activity_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_storage_activity_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type='list[InventoryStorageActivity]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class InventoryStorageActivityApi(object):
 
         Returns the inventoryStorageActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_storage_activity_by_id(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_storage_activity_by_id(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to be returned. (required)
         :return: InventoryStorageActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_storage_activity_by_id_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_storage_activity_by_id_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class InventoryStorageActivityApi(object):
 
         Returns the inventoryStorageActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_storage_activity_by_id_with_http_info(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_storage_activity_by_id_with_http_info(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to be returned. (required)
         :return: InventoryStorageActivity
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type='InventoryStorageActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class InventoryStorageActivityApi(object):
 
         Get all existing inventoryStorageActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_storage_activity_files(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_storage_activity_files(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_storage_activity_files_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_storage_activity_files_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class InventoryStorageActivityApi(object):
 
         Get all existing inventoryStorageActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_storage_activity_files_with_http_info(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_storage_activity_files_with_http_info(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class InventoryStorageActivityApi(object):
 
         Get all existing inventoryStorageActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_storage_activity_tags(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_storage_activity_tags(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_inventory_storage_activity_tags_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_inventory_storage_activity_tags_with_http_info(inventory_storage_activity_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class InventoryStorageActivityApi(object):
 
         Get all existing inventoryStorageActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_inventory_storage_activity_tags_with_http_info(inventory_storage_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_inventory_storage_activity_tags_with_http_info(inventory_storage_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int inventory_storage_activity_id: Id of the inventoryStorageActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['inventory_storage_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class InventoryStorageActivityApi(object):
 
         Updates an existing inventoryStorageActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_inventory_storage_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_inventory_storage_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InventoryStorageActivity body: InventoryStorageActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_inventory_storage_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_inventory_storage_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class InventoryStorageActivityApi(object):
 
         Updates an existing inventoryStorageActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_inventory_storage_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_inventory_storage_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InventoryStorageActivity body: InventoryStorageActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class InventoryStorageActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class InventoryStorageActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/invoice_worksheet_api.py
+++ b/Infoplus/api/invoice_worksheet_api.py
@@ -38,18 +38,18 @@ class InvoiceWorksheetApi(object):
 
         Inserts a new invoiceWorksheet using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheet body: InvoiceWorksheet to be inserted. (required)
         :return: InvoiceWorksheet
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class InvoiceWorksheetApi(object):
 
         Inserts a new invoiceWorksheet using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheet body: InvoiceWorksheet to be inserted. (required)
         :return: InvoiceWorksheet
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type='InvoiceWorksheet',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class InvoiceWorksheetApi(object):
 
         Adds an audit to an existing invoiceWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_audit(invoice_worksheet_id, invoice_worksheet_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_audit(invoice_worksheet_id, invoice_worksheet_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to add an audit to (required)
         :param str invoice_worksheet_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class InvoiceWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_audit_with_http_info(invoice_worksheet_id, invoice_worksheet_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_audit_with_http_info(invoice_worksheet_id, invoice_worksheet_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class InvoiceWorksheetApi(object):
 
         Adds an audit to an existing invoiceWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_audit_with_http_info(invoice_worksheet_id, invoice_worksheet_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_audit_with_http_info(invoice_worksheet_id, invoice_worksheet_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to add an audit to (required)
         :param str invoice_worksheet_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id', 'invoice_worksheet_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class InvoiceWorksheetApi(object):
 
         Adds a file to an existing invoiceWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_file(invoice_worksheet_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_file(invoice_worksheet_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class InvoiceWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_file_with_http_info(invoice_worksheet_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_file_with_http_info(invoice_worksheet_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class InvoiceWorksheetApi(object):
 
         Adds a file to an existing invoiceWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_file_with_http_info(invoice_worksheet_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_file_with_http_info(invoice_worksheet_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class InvoiceWorksheetApi(object):
 
         Adds a file to an existing invoiceWorksheet by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_file_by_url(body, invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_file_by_url(body, invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class InvoiceWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_file_by_url_with_http_info(body, invoice_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_file_by_url_with_http_info(body, invoice_worksheet_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class InvoiceWorksheetApi(object):
 
         Adds a file to an existing invoiceWorksheet by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_file_by_url_with_http_info(body, invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_file_by_url_with_http_info(body, invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['body', 'invoice_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class InvoiceWorksheetApi(object):
 
         Adds a tag to an existing invoiceWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_tag(invoice_worksheet_id, invoice_worksheet_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_tag(invoice_worksheet_id, invoice_worksheet_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to add a tag to (required)
         :param str invoice_worksheet_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class InvoiceWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_tag_with_http_info(invoice_worksheet_id, invoice_worksheet_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_tag_with_http_info(invoice_worksheet_id, invoice_worksheet_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class InvoiceWorksheetApi(object):
 
         Adds a tag to an existing invoiceWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_tag_with_http_info(invoice_worksheet_id, invoice_worksheet_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_tag_with_http_info(invoice_worksheet_id, invoice_worksheet_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to add a tag to (required)
         :param str invoice_worksheet_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id', 'invoice_worksheet_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class InvoiceWorksheetApi(object):
 
         Deletes the invoiceWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_invoice_worksheet_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_invoice_worksheet_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class InvoiceWorksheetApi(object):
 
         Deletes the invoiceWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_with_http_info(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_with_http_info(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class InvoiceWorksheetApi(object):
 
         Deletes an existing invoiceWorksheet file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_file(invoice_worksheet_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_file(invoice_worksheet_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class InvoiceWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_invoice_worksheet_file_with_http_info(invoice_worksheet_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_invoice_worksheet_file_with_http_info(invoice_worksheet_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class InvoiceWorksheetApi(object):
 
         Deletes an existing invoiceWorksheet file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_file_with_http_info(invoice_worksheet_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_file_with_http_info(invoice_worksheet_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class InvoiceWorksheetApi(object):
 
         Deletes an existing invoiceWorksheet tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_tag(invoice_worksheet_id, invoice_worksheet_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_tag(invoice_worksheet_id, invoice_worksheet_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to remove tag from (required)
         :param str invoice_worksheet_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class InvoiceWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_invoice_worksheet_tag_with_http_info(invoice_worksheet_id, invoice_worksheet_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_invoice_worksheet_tag_with_http_info(invoice_worksheet_id, invoice_worksheet_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class InvoiceWorksheetApi(object):
 
         Deletes an existing invoiceWorksheet tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_tag_with_http_info(invoice_worksheet_id, invoice_worksheet_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_tag_with_http_info(invoice_worksheet_id, invoice_worksheet_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to remove tag from (required)
         :param str invoice_worksheet_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id', 'invoice_worksheet_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class InvoiceWorksheetApi(object):
 
         Returns a duplicated invoiceWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_invoice_worksheet_by_id(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_invoice_worksheet_by_id(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to be duplicated. (required)
         :return: InvoiceWorksheet
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_invoice_worksheet_by_id_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_invoice_worksheet_by_id_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class InvoiceWorksheetApi(object):
 
         Returns a duplicated invoiceWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_invoice_worksheet_by_id_with_http_info(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_invoice_worksheet_by_id_with_http_info(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to be duplicated. (required)
         :return: InvoiceWorksheet
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type='InvoiceWorksheet',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class InvoiceWorksheetApi(object):
 
         Returns the list of invoiceWorksheets that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class InvoiceWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class InvoiceWorksheetApi(object):
 
         Returns the list of invoiceWorksheets that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type='list[InvoiceWorksheet]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class InvoiceWorksheetApi(object):
 
         Returns the invoiceWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_by_id(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_by_id(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to be returned. (required)
         :return: InvoiceWorksheet
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_by_id_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_by_id_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class InvoiceWorksheetApi(object):
 
         Returns the invoiceWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_by_id_with_http_info(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_by_id_with_http_info(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to be returned. (required)
         :return: InvoiceWorksheet
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type='InvoiceWorksheet',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class InvoiceWorksheetApi(object):
 
         Get all existing invoiceWorksheet files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_files(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_files(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_files_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_files_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class InvoiceWorksheetApi(object):
 
         Get all existing invoiceWorksheet files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_files_with_http_info(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_files_with_http_info(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class InvoiceWorksheetApi(object):
 
         Get all existing invoiceWorksheet tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_tags(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_tags(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_tags_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_tags_with_http_info(invoice_worksheet_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class InvoiceWorksheetApi(object):
 
         Get all existing invoiceWorksheet tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_tags_with_http_info(invoice_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_tags_with_http_info(invoice_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_id: Id of the invoiceWorksheet to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['invoice_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class InvoiceWorksheetApi(object):
 
         Updates an existing invoiceWorksheet using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_invoice_worksheet(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_invoice_worksheet(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheet body: InvoiceWorksheet to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_invoice_worksheet_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_invoice_worksheet_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class InvoiceWorksheetApi(object):
 
         Updates an existing invoiceWorksheet using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_invoice_worksheet_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_invoice_worksheet_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheet body: InvoiceWorksheet to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class InvoiceWorksheetApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class InvoiceWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/invoice_worksheet_line_api.py
+++ b/Infoplus/api/invoice_worksheet_line_api.py
@@ -38,18 +38,18 @@ class InvoiceWorksheetLineApi(object):
 
         Inserts a new invoiceWorksheetLine using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheetLine body: InvoiceWorksheetLine to be inserted. (required)
         :return: InvoiceWorksheetLine
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_line_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_line_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class InvoiceWorksheetLineApi(object):
 
         Inserts a new invoiceWorksheetLine using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheetLine body: InvoiceWorksheetLine to be inserted. (required)
         :return: InvoiceWorksheetLine
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type='InvoiceWorksheetLine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class InvoiceWorksheetLineApi(object):
 
         Adds an audit to an existing invoiceWorksheetLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_audit(invoice_worksheet_line_id, invoice_worksheet_line_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_audit(invoice_worksheet_line_id, invoice_worksheet_line_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to add an audit to (required)
         :param str invoice_worksheet_line_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class InvoiceWorksheetLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_line_audit_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_line_audit_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class InvoiceWorksheetLineApi(object):
 
         Adds an audit to an existing invoiceWorksheetLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_audit_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_audit_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to add an audit to (required)
         :param str invoice_worksheet_line_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id', 'invoice_worksheet_line_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class InvoiceWorksheetLineApi(object):
 
         Adds a file to an existing invoiceWorksheetLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_file(invoice_worksheet_line_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_file(invoice_worksheet_line_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class InvoiceWorksheetLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_line_file_with_http_info(invoice_worksheet_line_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_line_file_with_http_info(invoice_worksheet_line_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class InvoiceWorksheetLineApi(object):
 
         Adds a file to an existing invoiceWorksheetLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_file_with_http_info(invoice_worksheet_line_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_file_with_http_info(invoice_worksheet_line_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class InvoiceWorksheetLineApi(object):
 
         Adds a file to an existing invoiceWorksheetLine by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_file_by_url(body, invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_file_by_url(body, invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class InvoiceWorksheetLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_line_file_by_url_with_http_info(body, invoice_worksheet_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_line_file_by_url_with_http_info(body, invoice_worksheet_line_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class InvoiceWorksheetLineApi(object):
 
         Adds a file to an existing invoiceWorksheetLine by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_file_by_url_with_http_info(body, invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_file_by_url_with_http_info(body, invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['body', 'invoice_worksheet_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class InvoiceWorksheetLineApi(object):
 
         Adds a tag to an existing invoiceWorksheetLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_tag(invoice_worksheet_line_id, invoice_worksheet_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_tag(invoice_worksheet_line_id, invoice_worksheet_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to add a tag to (required)
         :param str invoice_worksheet_line_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class InvoiceWorksheetLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_line_tag_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_line_tag_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class InvoiceWorksheetLineApi(object):
 
         Adds a tag to an existing invoiceWorksheetLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_tag_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_tag_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to add a tag to (required)
         :param str invoice_worksheet_line_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id', 'invoice_worksheet_line_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class InvoiceWorksheetLineApi(object):
 
         Deletes the invoiceWorksheetLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_invoice_worksheet_line_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_invoice_worksheet_line_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class InvoiceWorksheetLineApi(object):
 
         Deletes the invoiceWorksheetLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line_with_http_info(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line_with_http_info(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class InvoiceWorksheetLineApi(object):
 
         Deletes an existing invoiceWorksheetLine file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line_file(invoice_worksheet_line_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line_file(invoice_worksheet_line_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class InvoiceWorksheetLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_invoice_worksheet_line_file_with_http_info(invoice_worksheet_line_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_invoice_worksheet_line_file_with_http_info(invoice_worksheet_line_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class InvoiceWorksheetLineApi(object):
 
         Deletes an existing invoiceWorksheetLine file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line_file_with_http_info(invoice_worksheet_line_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line_file_with_http_info(invoice_worksheet_line_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class InvoiceWorksheetLineApi(object):
 
         Deletes an existing invoiceWorksheetLine tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line_tag(invoice_worksheet_line_id, invoice_worksheet_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line_tag(invoice_worksheet_line_id, invoice_worksheet_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to remove tag from (required)
         :param str invoice_worksheet_line_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class InvoiceWorksheetLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_invoice_worksheet_line_tag_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_invoice_worksheet_line_tag_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class InvoiceWorksheetLineApi(object):
 
         Deletes an existing invoiceWorksheetLine tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line_tag_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line_tag_with_http_info(invoice_worksheet_line_id, invoice_worksheet_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to remove tag from (required)
         :param str invoice_worksheet_line_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id', 'invoice_worksheet_line_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class InvoiceWorksheetLineApi(object):
 
         Returns a duplicated invoiceWorksheetLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_invoice_worksheet_line_by_id(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_invoice_worksheet_line_by_id(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to be duplicated. (required)
         :return: InvoiceWorksheetLine
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_invoice_worksheet_line_by_id_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_invoice_worksheet_line_by_id_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class InvoiceWorksheetLineApi(object):
 
         Returns a duplicated invoiceWorksheetLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_invoice_worksheet_line_by_id_with_http_info(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_invoice_worksheet_line_by_id_with_http_info(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to be duplicated. (required)
         :return: InvoiceWorksheetLine
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type='InvoiceWorksheetLine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class InvoiceWorksheetLineApi(object):
 
         Returns the list of invoiceWorksheetLines that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class InvoiceWorksheetLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_line_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_line_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class InvoiceWorksheetLineApi(object):
 
         Returns the list of invoiceWorksheetLines that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type='list[InvoiceWorksheetLine]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class InvoiceWorksheetLineApi(object):
 
         Returns the invoiceWorksheetLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_by_id(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_by_id(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to be returned. (required)
         :return: InvoiceWorksheetLine
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_line_by_id_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_line_by_id_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class InvoiceWorksheetLineApi(object):
 
         Returns the invoiceWorksheetLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_by_id_with_http_info(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_by_id_with_http_info(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to be returned. (required)
         :return: InvoiceWorksheetLine
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type='InvoiceWorksheetLine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class InvoiceWorksheetLineApi(object):
 
         Get all existing invoiceWorksheetLine files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_files(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_files(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_line_files_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_line_files_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class InvoiceWorksheetLineApi(object):
 
         Get all existing invoiceWorksheetLine files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_files_with_http_info(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_files_with_http_info(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class InvoiceWorksheetLineApi(object):
 
         Get all existing invoiceWorksheetLine tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_tags(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_tags(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_line_tags_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_line_tags_with_http_info(invoice_worksheet_line_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class InvoiceWorksheetLineApi(object):
 
         Get all existing invoiceWorksheetLine tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_tags_with_http_info(invoice_worksheet_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_tags_with_http_info(invoice_worksheet_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_id: Id of the invoiceWorksheetLine to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['invoice_worksheet_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class InvoiceWorksheetLineApi(object):
 
         Updates an existing invoiceWorksheetLine using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_invoice_worksheet_line(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_invoice_worksheet_line(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheetLine body: InvoiceWorksheetLine to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_invoice_worksheet_line_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_invoice_worksheet_line_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class InvoiceWorksheetLineApi(object):
 
         Updates an existing invoiceWorksheetLine using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_invoice_worksheet_line_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_invoice_worksheet_line_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheetLine body: InvoiceWorksheetLine to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class InvoiceWorksheetLineApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class InvoiceWorksheetLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/invoice_worksheet_line_detail_api.py
+++ b/Infoplus/api/invoice_worksheet_line_detail_api.py
@@ -38,11 +38,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Adds an audit to an existing invoiceWorksheetLineDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_detail_audit(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_detail_audit(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to add an audit to (required)
         :param str invoice_worksheet_line_detail_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class InvoiceWorksheetLineDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_line_detail_audit_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_line_detail_audit_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Adds an audit to an existing invoiceWorksheetLineDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_detail_audit_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_detail_audit_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to add an audit to (required)
         :param str invoice_worksheet_line_detail_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['invoice_worksheet_line_detail_id', 'invoice_worksheet_line_detail_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Adds a file to an existing invoiceWorksheetLineDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_detail_file(invoice_worksheet_line_detail_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_detail_file(invoice_worksheet_line_detail_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class InvoiceWorksheetLineDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_line_detail_file_with_http_info(invoice_worksheet_line_detail_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_line_detail_file_with_http_info(invoice_worksheet_line_detail_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Adds a file to an existing invoiceWorksheetLineDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_detail_file_with_http_info(invoice_worksheet_line_detail_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_detail_file_with_http_info(invoice_worksheet_line_detail_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['invoice_worksheet_line_detail_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Adds a file to an existing invoiceWorksheetLineDetail by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_detail_file_by_url(body, invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_detail_file_by_url(body, invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class InvoiceWorksheetLineDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_line_detail_file_by_url_with_http_info(body, invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_line_detail_file_by_url_with_http_info(body, invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Adds a file to an existing invoiceWorksheetLineDetail by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_detail_file_by_url_with_http_info(body, invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_detail_file_by_url_with_http_info(body, invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['body', 'invoice_worksheet_line_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Adds a tag to an existing invoiceWorksheetLineDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_detail_tag(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_detail_tag(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to add a tag to (required)
         :param str invoice_worksheet_line_detail_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class InvoiceWorksheetLineDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_invoice_worksheet_line_detail_tag_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_invoice_worksheet_line_detail_tag_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Adds a tag to an existing invoiceWorksheetLineDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_invoice_worksheet_line_detail_tag_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_invoice_worksheet_line_detail_tag_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to add a tag to (required)
         :param str invoice_worksheet_line_detail_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['invoice_worksheet_line_detail_id', 'invoice_worksheet_line_detail_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Deletes an existing invoiceWorksheetLineDetail file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line_detail_file(invoice_worksheet_line_detail_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line_detail_file(invoice_worksheet_line_detail_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class InvoiceWorksheetLineDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_invoice_worksheet_line_detail_file_with_http_info(invoice_worksheet_line_detail_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_invoice_worksheet_line_detail_file_with_http_info(invoice_worksheet_line_detail_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Deletes an existing invoiceWorksheetLineDetail file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line_detail_file_with_http_info(invoice_worksheet_line_detail_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line_detail_file_with_http_info(invoice_worksheet_line_detail_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['invoice_worksheet_line_detail_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Deletes an existing invoiceWorksheetLineDetail tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line_detail_tag(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line_detail_tag(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to remove tag from (required)
         :param str invoice_worksheet_line_detail_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class InvoiceWorksheetLineDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_invoice_worksheet_line_detail_tag_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_invoice_worksheet_line_detail_tag_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Deletes an existing invoiceWorksheetLineDetail tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_invoice_worksheet_line_detail_tag_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_invoice_worksheet_line_detail_tag_with_http_info(invoice_worksheet_line_detail_id, invoice_worksheet_line_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to remove tag from (required)
         :param str invoice_worksheet_line_detail_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['invoice_worksheet_line_detail_id', 'invoice_worksheet_line_detail_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Returns a duplicated invoiceWorksheetLineDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_invoice_worksheet_line_detail_by_id(invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_invoice_worksheet_line_detail_by_id(invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to be duplicated. (required)
         :return: InvoiceWorksheetLineDetail
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_invoice_worksheet_line_detail_by_id_with_http_info(invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_invoice_worksheet_line_detail_by_id_with_http_info(invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Returns a duplicated invoiceWorksheetLineDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_invoice_worksheet_line_detail_by_id_with_http_info(invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_invoice_worksheet_line_detail_by_id_with_http_info(invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to be duplicated. (required)
         :return: InvoiceWorksheetLineDetail
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['invoice_worksheet_line_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type='InvoiceWorksheetLineDetail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Returns the list of invoiceWorksheetLineDetails that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_detail_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_detail_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class InvoiceWorksheetLineDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_line_detail_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_line_detail_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Returns the list of invoiceWorksheetLineDetails that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_detail_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_detail_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type='list[InvoiceWorksheetLineDetail]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Returns the invoiceWorksheetLineDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_detail_by_id(invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_detail_by_id(invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to be returned. (required)
         :return: InvoiceWorksheetLineDetail
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_line_detail_by_id_with_http_info(invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_line_detail_by_id_with_http_info(invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Returns the invoiceWorksheetLineDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_detail_by_id_with_http_info(invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_detail_by_id_with_http_info(invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to be returned. (required)
         :return: InvoiceWorksheetLineDetail
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['invoice_worksheet_line_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type='InvoiceWorksheetLineDetail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Get all existing invoiceWorksheetLineDetail files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_detail_files(invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_detail_files(invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_line_detail_files_with_http_info(invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_line_detail_files_with_http_info(invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Get all existing invoiceWorksheetLineDetail files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_detail_files_with_http_info(invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_detail_files_with_http_info(invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['invoice_worksheet_line_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Get all existing invoiceWorksheetLineDetail tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_detail_tags(invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_detail_tags(invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_invoice_worksheet_line_detail_tags_with_http_info(invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_invoice_worksheet_line_detail_tags_with_http_info(invoice_worksheet_line_detail_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Get all existing invoiceWorksheetLineDetail tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_invoice_worksheet_line_detail_tags_with_http_info(invoice_worksheet_line_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_invoice_worksheet_line_detail_tags_with_http_info(invoice_worksheet_line_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int invoice_worksheet_line_detail_id: Id of the invoiceWorksheetLineDetail to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['invoice_worksheet_line_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Updates an existing invoiceWorksheetLineDetail custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_invoice_worksheet_line_detail_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_invoice_worksheet_line_detail_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheetLineDetail body: InvoiceWorksheetLineDetail to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_invoice_worksheet_line_detail_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_invoice_worksheet_line_detail_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class InvoiceWorksheetLineDetailApi(object):
 
         Updates an existing invoiceWorksheetLineDetail custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_invoice_worksheet_line_detail_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_invoice_worksheet_line_detail_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param InvoiceWorksheetLineDetail body: InvoiceWorksheetLineDetail to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class InvoiceWorksheetLineDetailApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class InvoiceWorksheetLineDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_account_code_api.py
+++ b/Infoplus/api/item_account_code_api.py
@@ -38,18 +38,18 @@ class ItemAccountCodeApi(object):
 
         Inserts a new itemAccountCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemAccountCode body: ItemAccountCode to be inserted. (required)
         :return: ItemAccountCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_account_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_account_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemAccountCodeApi(object):
 
         Inserts a new itemAccountCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemAccountCode body: ItemAccountCode to be inserted. (required)
         :return: ItemAccountCode
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type='ItemAccountCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemAccountCodeApi(object):
 
         Adds an audit to an existing itemAccountCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code_audit(item_account_code_id, item_account_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code_audit(item_account_code_id, item_account_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to add an audit to (required)
         :param str item_account_code_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemAccountCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_account_code_audit_with_http_info(item_account_code_id, item_account_code_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_account_code_audit_with_http_info(item_account_code_id, item_account_code_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemAccountCodeApi(object):
 
         Adds an audit to an existing itemAccountCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code_audit_with_http_info(item_account_code_id, item_account_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code_audit_with_http_info(item_account_code_id, item_account_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to add an audit to (required)
         :param str item_account_code_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id', 'item_account_code_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemAccountCodeApi(object):
 
         Adds a file to an existing itemAccountCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code_file(item_account_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code_file(item_account_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemAccountCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_account_code_file_with_http_info(item_account_code_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_account_code_file_with_http_info(item_account_code_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemAccountCodeApi(object):
 
         Adds a file to an existing itemAccountCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code_file_with_http_info(item_account_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code_file_with_http_info(item_account_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemAccountCodeApi(object):
 
         Adds a file to an existing itemAccountCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code_file_by_url(body, item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code_file_by_url(body, item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_account_code_id: Id of the itemAccountCode to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemAccountCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_account_code_file_by_url_with_http_info(body, item_account_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_account_code_file_by_url_with_http_info(body, item_account_code_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemAccountCodeApi(object):
 
         Adds a file to an existing itemAccountCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code_file_by_url_with_http_info(body, item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code_file_by_url_with_http_info(body, item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_account_code_id: Id of the itemAccountCode to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['body', 'item_account_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemAccountCodeApi(object):
 
         Adds a tag to an existing itemAccountCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code_tag(item_account_code_id, item_account_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code_tag(item_account_code_id, item_account_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to add a tag to (required)
         :param str item_account_code_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemAccountCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_account_code_tag_with_http_info(item_account_code_id, item_account_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_account_code_tag_with_http_info(item_account_code_id, item_account_code_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemAccountCodeApi(object):
 
         Adds a tag to an existing itemAccountCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_account_code_tag_with_http_info(item_account_code_id, item_account_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_account_code_tag_with_http_info(item_account_code_id, item_account_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to add a tag to (required)
         :param str item_account_code_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id', 'item_account_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemAccountCodeApi(object):
 
         Deletes the itemAccountCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_account_code(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_account_code(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_account_code_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_account_code_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemAccountCodeApi(object):
 
         Deletes the itemAccountCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_account_code_with_http_info(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_account_code_with_http_info(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemAccountCodeApi(object):
 
         Deletes an existing itemAccountCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_account_code_file(item_account_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_account_code_file(item_account_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemAccountCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_account_code_file_with_http_info(item_account_code_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_account_code_file_with_http_info(item_account_code_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemAccountCodeApi(object):
 
         Deletes an existing itemAccountCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_account_code_file_with_http_info(item_account_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_account_code_file_with_http_info(item_account_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemAccountCodeApi(object):
 
         Deletes an existing itemAccountCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_account_code_tag(item_account_code_id, item_account_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_account_code_tag(item_account_code_id, item_account_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to remove tag from (required)
         :param str item_account_code_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemAccountCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_account_code_tag_with_http_info(item_account_code_id, item_account_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_account_code_tag_with_http_info(item_account_code_id, item_account_code_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemAccountCodeApi(object):
 
         Deletes an existing itemAccountCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_account_code_tag_with_http_info(item_account_code_id, item_account_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_account_code_tag_with_http_info(item_account_code_id, item_account_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to remove tag from (required)
         :param str item_account_code_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id', 'item_account_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemAccountCodeApi(object):
 
         Returns a duplicated itemAccountCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_account_code_by_id(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_account_code_by_id(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to be duplicated. (required)
         :return: ItemAccountCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_account_code_by_id_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_account_code_by_id_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemAccountCodeApi(object):
 
         Returns a duplicated itemAccountCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_account_code_by_id_with_http_info(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_account_code_by_id_with_http_info(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to be duplicated. (required)
         :return: ItemAccountCode
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type='ItemAccountCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemAccountCodeApi(object):
 
         Returns the list of itemAccountCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_account_code_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_account_code_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemAccountCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_account_code_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_account_code_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemAccountCodeApi(object):
 
         Returns the list of itemAccountCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_account_code_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_account_code_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type='list[ItemAccountCode]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemAccountCodeApi(object):
 
         Returns the itemAccountCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_account_code_by_id(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_account_code_by_id(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to be returned. (required)
         :return: ItemAccountCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_account_code_by_id_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_account_code_by_id_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemAccountCodeApi(object):
 
         Returns the itemAccountCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_account_code_by_id_with_http_info(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_account_code_by_id_with_http_info(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to be returned. (required)
         :return: ItemAccountCode
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type='ItemAccountCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemAccountCodeApi(object):
 
         Get all existing itemAccountCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_account_code_files(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_account_code_files(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_account_code_files_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_account_code_files_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemAccountCodeApi(object):
 
         Get all existing itemAccountCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_account_code_files_with_http_info(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_account_code_files_with_http_info(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemAccountCodeApi(object):
 
         Get all existing itemAccountCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_account_code_tags(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_account_code_tags(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_account_code_tags_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_account_code_tags_with_http_info(item_account_code_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemAccountCodeApi(object):
 
         Get all existing itemAccountCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_account_code_tags_with_http_info(item_account_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_account_code_tags_with_http_info(item_account_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_account_code_id: Id of the itemAccountCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['item_account_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemAccountCodeApi(object):
 
         Updates an existing itemAccountCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_account_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_account_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemAccountCode body: ItemAccountCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_account_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_account_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemAccountCodeApi(object):
 
         Updates an existing itemAccountCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_account_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_account_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemAccountCode body: ItemAccountCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemAccountCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemAccountCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_activity_api.py
+++ b/Infoplus/api/item_activity_api.py
@@ -38,11 +38,11 @@ class ItemActivityApi(object):
 
         Adds an audit to an existing itemActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_activity_audit(item_activity_id, item_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_activity_audit(item_activity_id, item_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to add an audit to (required)
         :param str item_activity_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ItemActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_activity_audit_with_http_info(item_activity_id, item_activity_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_activity_audit_with_http_info(item_activity_id, item_activity_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ItemActivityApi(object):
 
         Adds an audit to an existing itemActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_activity_audit_with_http_info(item_activity_id, item_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_activity_audit_with_http_info(item_activity_id, item_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to add an audit to (required)
         :param str item_activity_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['item_activity_id', 'item_activity_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ItemActivityApi(object):
 
         Adds a file to an existing itemActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_activity_file(item_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_activity_file(item_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ItemActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_activity_file_with_http_info(item_activity_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_activity_file_with_http_info(item_activity_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ItemActivityApi(object):
 
         Adds a file to an existing itemActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_activity_file_with_http_info(item_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_activity_file_with_http_info(item_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['item_activity_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ItemActivityApi(object):
 
         Adds a file to an existing itemActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_activity_file_by_url(body, item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_activity_file_by_url(body, item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_activity_id: Id of the itemActivity to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ItemActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_activity_file_by_url_with_http_info(body, item_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_activity_file_by_url_with_http_info(body, item_activity_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ItemActivityApi(object):
 
         Adds a file to an existing itemActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_activity_file_by_url_with_http_info(body, item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_activity_file_by_url_with_http_info(body, item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_activity_id: Id of the itemActivity to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['body', 'item_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ItemActivityApi(object):
 
         Adds a tag to an existing itemActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_activity_tag(item_activity_id, item_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_activity_tag(item_activity_id, item_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to add a tag to (required)
         :param str item_activity_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ItemActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_activity_tag_with_http_info(item_activity_id, item_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_activity_tag_with_http_info(item_activity_id, item_activity_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ItemActivityApi(object):
 
         Adds a tag to an existing itemActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_activity_tag_with_http_info(item_activity_id, item_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_activity_tag_with_http_info(item_activity_id, item_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to add a tag to (required)
         :param str item_activity_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['item_activity_id', 'item_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class ItemActivityApi(object):
 
         Deletes an existing itemActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_activity_file(item_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_activity_file(item_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class ItemActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_activity_file_with_http_info(item_activity_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_activity_file_with_http_info(item_activity_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class ItemActivityApi(object):
 
         Deletes an existing itemActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_activity_file_with_http_info(item_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_activity_file_with_http_info(item_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['item_activity_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class ItemActivityApi(object):
 
         Deletes an existing itemActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_activity_tag(item_activity_id, item_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_activity_tag(item_activity_id, item_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to remove tag from (required)
         :param str item_activity_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class ItemActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_activity_tag_with_http_info(item_activity_id, item_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_activity_tag_with_http_info(item_activity_id, item_activity_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class ItemActivityApi(object):
 
         Deletes an existing itemActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_activity_tag_with_http_info(item_activity_id, item_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_activity_tag_with_http_info(item_activity_id, item_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to remove tag from (required)
         :param str item_activity_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['item_activity_id', 'item_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class ItemActivityApi(object):
 
         Returns a duplicated itemActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_activity_by_id(item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_activity_by_id(item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to be duplicated. (required)
         :return: ItemActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_activity_by_id_with_http_info(item_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_activity_by_id_with_http_info(item_activity_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class ItemActivityApi(object):
 
         Returns a duplicated itemActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_activity_by_id_with_http_info(item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_activity_by_id_with_http_info(item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to be duplicated. (required)
         :return: ItemActivity
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['item_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type='ItemActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class ItemActivityApi(object):
 
         Returns the list of itemActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class ItemActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class ItemActivityApi(object):
 
         Returns the list of itemActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type='list[ItemActivity]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class ItemActivityApi(object):
 
         Returns the itemActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_by_id(item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_by_id(item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to be returned. (required)
         :return: ItemActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_activity_by_id_with_http_info(item_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_activity_by_id_with_http_info(item_activity_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class ItemActivityApi(object):
 
         Returns the itemActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_by_id_with_http_info(item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_by_id_with_http_info(item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to be returned. (required)
         :return: ItemActivity
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['item_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type='ItemActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ItemActivityApi(object):
 
         Get all existing itemActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_files(item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_files(item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_activity_files_with_http_info(item_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_activity_files_with_http_info(item_activity_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ItemActivityApi(object):
 
         Get all existing itemActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_files_with_http_info(item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_files_with_http_info(item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['item_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ItemActivityApi(object):
 
         Get all existing itemActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_tags(item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_tags(item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_activity_tags_with_http_info(item_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_activity_tags_with_http_info(item_activity_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ItemActivityApi(object):
 
         Get all existing itemActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_tags_with_http_info(item_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_tags_with_http_info(item_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_activity_id: Id of the itemActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ItemActivityApi(object):
         """
 
         all_params = ['item_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ItemActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_activity_type_api.py
+++ b/Infoplus/api/item_activity_type_api.py
@@ -38,18 +38,18 @@ class ItemActivityTypeApi(object):
 
         Returns the itemActivityType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_type_by_id(item_activity_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_type_by_id(item_activity_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str item_activity_type_id: Id of itemActivityType to be returned. (required)
         :return: ItemActivityType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_activity_type_by_id_with_http_info(item_activity_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_activity_type_by_id_with_http_info(item_activity_type_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemActivityTypeApi(object):
 
         Returns the itemActivityType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_type_by_id_with_http_info(item_activity_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_type_by_id_with_http_info(item_activity_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str item_activity_type_id: Id of itemActivityType to be returned. (required)
         :return: ItemActivityType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemActivityTypeApi(object):
         """
 
         all_params = ['item_activity_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class ItemActivityTypeApi(object):
             files=local_var_files,
             response_type='ItemActivityType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class ItemActivityTypeApi(object):
 
         Returns the list of itemActivityTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_type_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_type_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class ItemActivityTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_activity_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_activity_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class ItemActivityTypeApi(object):
 
         Returns the list of itemActivityTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_activity_type_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_activity_type_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class ItemActivityTypeApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class ItemActivityTypeApi(object):
             files=local_var_files,
             response_type='list[ItemActivityType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_api.py
+++ b/Infoplus/api/item_api.py
@@ -38,18 +38,18 @@ class ItemApi(object):
 
         Inserts a new item using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Item body: Item to be inserted. (required)
         :return: Item
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemApi(object):
 
         Inserts a new item using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Item body: Item to be inserted. (required)
         :return: Item
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type='Item',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemApi(object):
 
         Adds an audit to an existing item.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_audit(item_id, item_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_audit(item_id, item_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to add an audit to (required)
         :param str item_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_audit_with_http_info(item_id, item_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_audit_with_http_info(item_id, item_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemApi(object):
 
         Adds an audit to an existing item.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_audit_with_http_info(item_id, item_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_audit_with_http_info(item_id, item_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to add an audit to (required)
         :param str item_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id', 'item_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemApi(object):
 
         Adds a file to an existing item.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_file(item_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_file(item_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_file_with_http_info(item_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_file_with_http_info(item_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemApi(object):
 
         Adds a file to an existing item.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_file_with_http_info(item_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_file_with_http_info(item_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemApi(object):
 
         Adds a file to an existing item by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_file_by_url(body, item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_file_by_url(body, item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_id: Id of the item to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_file_by_url_with_http_info(body, item_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_file_by_url_with_http_info(body, item_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemApi(object):
 
         Adds a file to an existing item by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_file_by_url_with_http_info(body, item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_file_by_url_with_http_info(body, item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_id: Id of the item to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemApi(object):
         """
 
         all_params = ['body', 'item_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemApi(object):
 
         Adds a tag to an existing item.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_tag(item_id, item_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_tag(item_id, item_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to add a tag to (required)
         :param str item_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_tag_with_http_info(item_id, item_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_tag_with_http_info(item_id, item_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemApi(object):
 
         Adds a tag to an existing item.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_tag_with_http_info(item_id, item_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_tag_with_http_info(item_id, item_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to add a tag to (required)
         :param str item_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id', 'item_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemApi(object):
 
         Deletes the item identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_with_http_info(item_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_with_http_info(item_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemApi(object):
 
         Deletes the item identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_with_http_info(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_with_http_info(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemApi(object):
 
         Deletes an existing item file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_file(item_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_file(item_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_file_with_http_info(item_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_file_with_http_info(item_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemApi(object):
 
         Deletes an existing item file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_file_with_http_info(item_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_file_with_http_info(item_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemApi(object):
 
         Deletes an existing item tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_tag(item_id, item_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_tag(item_id, item_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to remove tag from (required)
         :param str item_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_tag_with_http_info(item_id, item_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_tag_with_http_info(item_id, item_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemApi(object):
 
         Deletes an existing item tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_tag_with_http_info(item_id, item_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_tag_with_http_info(item_id, item_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to remove tag from (required)
         :param str item_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id', 'item_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class ItemApi(object):
 
         Returns the item identified by the specified parameters.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_by_sku(lob_id, sku, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_by_sku(lob_id, sku, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int lob_id: lobId of the item to be returned. (required)
         :param str sku: sku of the item to be returned. (required)
         :return: Item
@@ -874,7 +874,7 @@ class ItemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_by_sku_with_http_info(lob_id, sku, **kwargs)  # noqa: E501
         else:
             (data) = self.get_by_sku_with_http_info(lob_id, sku, **kwargs)  # noqa: E501
@@ -885,11 +885,11 @@ class ItemApi(object):
 
         Returns the item identified by the specified parameters.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_by_sku_with_http_info(lob_id, sku, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_by_sku_with_http_info(lob_id, sku, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int lob_id: lobId of the item to be returned. (required)
         :param str sku: sku of the item to be returned. (required)
         :return: Item
@@ -898,7 +898,7 @@ class ItemApi(object):
         """
 
         all_params = ['lob_id', 'sku']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type='Item',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class ItemApi(object):
 
         Returns a duplicated item identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_by_id(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_by_id(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to be duplicated. (required)
         :return: Item
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_by_id_with_http_info(item_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_by_id_with_http_info(item_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class ItemApi(object):
 
         Returns a duplicated item identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_by_id_with_http_info(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_by_id_with_http_info(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to be duplicated. (required)
         :return: Item
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type='Item',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,11 +1060,11 @@ class ItemApi(object):
 
         Returns the list of items that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1074,7 +1074,7 @@ class ItemApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -1085,11 +1085,11 @@ class ItemApi(object):
 
         Returns the list of items that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1100,7 +1100,7 @@ class ItemApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1152,7 +1152,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type='list[Item]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1163,18 +1163,18 @@ class ItemApi(object):
 
         Returns the item identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_by_id(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_by_id(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to be returned. (required)
         :return: Item
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_by_id_with_http_info(item_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_by_id_with_http_info(item_id, **kwargs)  # noqa: E501
@@ -1185,11 +1185,11 @@ class ItemApi(object):
 
         Returns the item identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_by_id_with_http_info(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_by_id_with_http_info(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to be returned. (required)
         :return: Item
                  If the method is called asynchronously,
@@ -1197,7 +1197,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1247,7 +1247,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type='Item',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1258,18 +1258,18 @@ class ItemApi(object):
 
         Get all existing item files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_files(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_files(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_files_with_http_info(item_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_files_with_http_info(item_id, **kwargs)  # noqa: E501
@@ -1280,11 +1280,11 @@ class ItemApi(object):
 
         Get all existing item files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_files_with_http_info(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_files_with_http_info(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1292,7 +1292,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1342,7 +1342,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1353,18 +1353,18 @@ class ItemApi(object):
 
         Get all existing item tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_tags(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_tags(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_tags_with_http_info(item_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_tags_with_http_info(item_id, **kwargs)  # noqa: E501
@@ -1375,11 +1375,11 @@ class ItemApi(object):
 
         Get all existing item tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_tags_with_http_info(item_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_tags_with_http_info(item_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_id: Id of the item to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1387,7 +1387,7 @@ class ItemApi(object):
         """
 
         all_params = ['item_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1437,7 +1437,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1448,18 +1448,18 @@ class ItemApi(object):
 
         Updates an existing item using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Item body: Item to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_with_http_info(body, **kwargs)  # noqa: E501
@@ -1470,11 +1470,11 @@ class ItemApi(object):
 
         Updates an existing item using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Item body: Item to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1482,7 +1482,7 @@ class ItemApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1536,7 +1536,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1547,18 +1547,18 @@ class ItemApi(object):
 
         Updates an existing item custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Item body: Item to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1569,11 +1569,11 @@ class ItemApi(object):
 
         Updates an existing item custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Item body: Item to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1581,7 +1581,7 @@ class ItemApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1635,7 +1635,7 @@ class ItemApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_buyer_api.py
+++ b/Infoplus/api/item_buyer_api.py
@@ -38,18 +38,18 @@ class ItemBuyerApi(object):
 
         Inserts a new itemBuyer using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemBuyer body: ItemBuyer to be inserted. (required)
         :return: ItemBuyer
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_buyer_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_buyer_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemBuyerApi(object):
 
         Inserts a new itemBuyer using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemBuyer body: ItemBuyer to be inserted. (required)
         :return: ItemBuyer
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type='ItemBuyer',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemBuyerApi(object):
 
         Adds an audit to an existing itemBuyer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer_audit(item_buyer_id, item_buyer_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer_audit(item_buyer_id, item_buyer_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to add an audit to (required)
         :param str item_buyer_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemBuyerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_buyer_audit_with_http_info(item_buyer_id, item_buyer_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_buyer_audit_with_http_info(item_buyer_id, item_buyer_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemBuyerApi(object):
 
         Adds an audit to an existing itemBuyer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer_audit_with_http_info(item_buyer_id, item_buyer_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer_audit_with_http_info(item_buyer_id, item_buyer_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to add an audit to (required)
         :param str item_buyer_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id', 'item_buyer_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemBuyerApi(object):
 
         Adds a file to an existing itemBuyer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer_file(item_buyer_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer_file(item_buyer_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemBuyerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_buyer_file_with_http_info(item_buyer_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_buyer_file_with_http_info(item_buyer_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemBuyerApi(object):
 
         Adds a file to an existing itemBuyer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer_file_with_http_info(item_buyer_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer_file_with_http_info(item_buyer_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemBuyerApi(object):
 
         Adds a file to an existing itemBuyer by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer_file_by_url(body, item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer_file_by_url(body, item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_buyer_id: Id of the itemBuyer to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemBuyerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_buyer_file_by_url_with_http_info(body, item_buyer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_buyer_file_by_url_with_http_info(body, item_buyer_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemBuyerApi(object):
 
         Adds a file to an existing itemBuyer by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer_file_by_url_with_http_info(body, item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer_file_by_url_with_http_info(body, item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_buyer_id: Id of the itemBuyer to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['body', 'item_buyer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemBuyerApi(object):
 
         Adds a tag to an existing itemBuyer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer_tag(item_buyer_id, item_buyer_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer_tag(item_buyer_id, item_buyer_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to add a tag to (required)
         :param str item_buyer_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemBuyerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_buyer_tag_with_http_info(item_buyer_id, item_buyer_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_buyer_tag_with_http_info(item_buyer_id, item_buyer_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemBuyerApi(object):
 
         Adds a tag to an existing itemBuyer.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_buyer_tag_with_http_info(item_buyer_id, item_buyer_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_buyer_tag_with_http_info(item_buyer_id, item_buyer_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to add a tag to (required)
         :param str item_buyer_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id', 'item_buyer_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemBuyerApi(object):
 
         Deletes the itemBuyer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_buyer(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_buyer(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_buyer_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_buyer_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemBuyerApi(object):
 
         Deletes the itemBuyer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_buyer_with_http_info(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_buyer_with_http_info(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemBuyerApi(object):
 
         Deletes an existing itemBuyer file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_buyer_file(item_buyer_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_buyer_file(item_buyer_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemBuyerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_buyer_file_with_http_info(item_buyer_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_buyer_file_with_http_info(item_buyer_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemBuyerApi(object):
 
         Deletes an existing itemBuyer file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_buyer_file_with_http_info(item_buyer_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_buyer_file_with_http_info(item_buyer_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemBuyerApi(object):
 
         Deletes an existing itemBuyer tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_buyer_tag(item_buyer_id, item_buyer_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_buyer_tag(item_buyer_id, item_buyer_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to remove tag from (required)
         :param str item_buyer_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemBuyerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_buyer_tag_with_http_info(item_buyer_id, item_buyer_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_buyer_tag_with_http_info(item_buyer_id, item_buyer_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemBuyerApi(object):
 
         Deletes an existing itemBuyer tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_buyer_tag_with_http_info(item_buyer_id, item_buyer_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_buyer_tag_with_http_info(item_buyer_id, item_buyer_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to remove tag from (required)
         :param str item_buyer_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id', 'item_buyer_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemBuyerApi(object):
 
         Returns a duplicated itemBuyer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_buyer_by_id(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_buyer_by_id(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to be duplicated. (required)
         :return: ItemBuyer
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_buyer_by_id_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_buyer_by_id_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemBuyerApi(object):
 
         Returns a duplicated itemBuyer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_buyer_by_id_with_http_info(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_buyer_by_id_with_http_info(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to be duplicated. (required)
         :return: ItemBuyer
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type='ItemBuyer',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemBuyerApi(object):
 
         Returns the list of itemBuyers that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_buyer_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_buyer_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemBuyerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_buyer_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_buyer_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemBuyerApi(object):
 
         Returns the list of itemBuyers that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_buyer_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_buyer_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type='list[ItemBuyer]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemBuyerApi(object):
 
         Returns the itemBuyer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_buyer_by_id(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_buyer_by_id(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to be returned. (required)
         :return: ItemBuyer
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_buyer_by_id_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_buyer_by_id_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemBuyerApi(object):
 
         Returns the itemBuyer identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_buyer_by_id_with_http_info(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_buyer_by_id_with_http_info(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to be returned. (required)
         :return: ItemBuyer
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type='ItemBuyer',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemBuyerApi(object):
 
         Get all existing itemBuyer files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_buyer_files(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_buyer_files(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_buyer_files_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_buyer_files_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemBuyerApi(object):
 
         Get all existing itemBuyer files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_buyer_files_with_http_info(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_buyer_files_with_http_info(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemBuyerApi(object):
 
         Get all existing itemBuyer tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_buyer_tags(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_buyer_tags(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_buyer_tags_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_buyer_tags_with_http_info(item_buyer_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemBuyerApi(object):
 
         Get all existing itemBuyer tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_buyer_tags_with_http_info(item_buyer_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_buyer_tags_with_http_info(item_buyer_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_buyer_id: Id of the itemBuyer to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['item_buyer_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemBuyerApi(object):
 
         Updates an existing itemBuyer using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_buyer(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_buyer(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemBuyer body: ItemBuyer to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_buyer_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_buyer_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemBuyerApi(object):
 
         Updates an existing itemBuyer using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_buyer_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_buyer_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemBuyer body: ItemBuyer to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemBuyerApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemBuyerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_category_api.py
+++ b/Infoplus/api/item_category_api.py
@@ -38,18 +38,18 @@ class ItemCategoryApi(object):
 
         Inserts a new itemCategory using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemCategory body: ItemCategory to be inserted. (required)
         :return: ItemCategory
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_category_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_category_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemCategoryApi(object):
 
         Inserts a new itemCategory using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemCategory body: ItemCategory to be inserted. (required)
         :return: ItemCategory
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type='ItemCategory',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemCategoryApi(object):
 
         Adds an audit to an existing itemCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category_audit(item_category_id, item_category_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category_audit(item_category_id, item_category_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to add an audit to (required)
         :param str item_category_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_category_audit_with_http_info(item_category_id, item_category_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_category_audit_with_http_info(item_category_id, item_category_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemCategoryApi(object):
 
         Adds an audit to an existing itemCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category_audit_with_http_info(item_category_id, item_category_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category_audit_with_http_info(item_category_id, item_category_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to add an audit to (required)
         :param str item_category_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id', 'item_category_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemCategoryApi(object):
 
         Adds a file to an existing itemCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category_file(item_category_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category_file(item_category_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_category_file_with_http_info(item_category_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_category_file_with_http_info(item_category_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemCategoryApi(object):
 
         Adds a file to an existing itemCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category_file_with_http_info(item_category_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category_file_with_http_info(item_category_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemCategoryApi(object):
 
         Adds a file to an existing itemCategory by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category_file_by_url(body, item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category_file_by_url(body, item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_category_id: Id of the itemCategory to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_category_file_by_url_with_http_info(body, item_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_category_file_by_url_with_http_info(body, item_category_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemCategoryApi(object):
 
         Adds a file to an existing itemCategory by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category_file_by_url_with_http_info(body, item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category_file_by_url_with_http_info(body, item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_category_id: Id of the itemCategory to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['body', 'item_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemCategoryApi(object):
 
         Adds a tag to an existing itemCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category_tag(item_category_id, item_category_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category_tag(item_category_id, item_category_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to add a tag to (required)
         :param str item_category_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_category_tag_with_http_info(item_category_id, item_category_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_category_tag_with_http_info(item_category_id, item_category_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemCategoryApi(object):
 
         Adds a tag to an existing itemCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_category_tag_with_http_info(item_category_id, item_category_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_category_tag_with_http_info(item_category_id, item_category_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to add a tag to (required)
         :param str item_category_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id', 'item_category_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemCategoryApi(object):
 
         Deletes the itemCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_category(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_category(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_category_with_http_info(item_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_category_with_http_info(item_category_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemCategoryApi(object):
 
         Deletes the itemCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_category_with_http_info(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_category_with_http_info(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemCategoryApi(object):
 
         Deletes an existing itemCategory file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_category_file(item_category_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_category_file(item_category_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_category_file_with_http_info(item_category_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_category_file_with_http_info(item_category_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemCategoryApi(object):
 
         Deletes an existing itemCategory file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_category_file_with_http_info(item_category_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_category_file_with_http_info(item_category_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemCategoryApi(object):
 
         Deletes an existing itemCategory tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_category_tag(item_category_id, item_category_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_category_tag(item_category_id, item_category_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to remove tag from (required)
         :param str item_category_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_category_tag_with_http_info(item_category_id, item_category_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_category_tag_with_http_info(item_category_id, item_category_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemCategoryApi(object):
 
         Deletes an existing itemCategory tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_category_tag_with_http_info(item_category_id, item_category_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_category_tag_with_http_info(item_category_id, item_category_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to remove tag from (required)
         :param str item_category_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id', 'item_category_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemCategoryApi(object):
 
         Returns a duplicated itemCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_category_by_id(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_category_by_id(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to be duplicated. (required)
         :return: ItemCategory
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_category_by_id_with_http_info(item_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_category_by_id_with_http_info(item_category_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemCategoryApi(object):
 
         Returns a duplicated itemCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_category_by_id_with_http_info(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_category_by_id_with_http_info(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to be duplicated. (required)
         :return: ItemCategory
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type='ItemCategory',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemCategoryApi(object):
 
         Returns the list of itemCategorys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_category_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_category_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_category_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_category_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemCategoryApi(object):
 
         Returns the list of itemCategorys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_category_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_category_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type='list[ItemCategory]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemCategoryApi(object):
 
         Returns the itemCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_category_by_id(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_category_by_id(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to be returned. (required)
         :return: ItemCategory
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_category_by_id_with_http_info(item_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_category_by_id_with_http_info(item_category_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemCategoryApi(object):
 
         Returns the itemCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_category_by_id_with_http_info(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_category_by_id_with_http_info(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to be returned. (required)
         :return: ItemCategory
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type='ItemCategory',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemCategoryApi(object):
 
         Get all existing itemCategory files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_category_files(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_category_files(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_category_files_with_http_info(item_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_category_files_with_http_info(item_category_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemCategoryApi(object):
 
         Get all existing itemCategory files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_category_files_with_http_info(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_category_files_with_http_info(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemCategoryApi(object):
 
         Get all existing itemCategory tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_category_tags(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_category_tags(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_category_tags_with_http_info(item_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_category_tags_with_http_info(item_category_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemCategoryApi(object):
 
         Get all existing itemCategory tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_category_tags_with_http_info(item_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_category_tags_with_http_info(item_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_category_id: Id of the itemCategory to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['item_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemCategoryApi(object):
 
         Updates an existing itemCategory using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_category(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_category(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemCategory body: ItemCategory to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_category_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_category_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemCategoryApi(object):
 
         Updates an existing itemCategory using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_category_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_category_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemCategory body: ItemCategory to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemCategoryApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_lowstock_code_api.py
+++ b/Infoplus/api/item_lowstock_code_api.py
@@ -38,18 +38,18 @@ class ItemLowstockCodeApi(object):
 
         Inserts a new itemLowstockCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemLowstockCode body: ItemLowstockCode to be inserted. (required)
         :return: ItemLowstockCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_lowstock_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_lowstock_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemLowstockCodeApi(object):
 
         Inserts a new itemLowstockCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemLowstockCode body: ItemLowstockCode to be inserted. (required)
         :return: ItemLowstockCode
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type='ItemLowstockCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemLowstockCodeApi(object):
 
         Adds an audit to an existing itemLowstockCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code_audit(item_lowstock_code_id, item_lowstock_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code_audit(item_lowstock_code_id, item_lowstock_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to add an audit to (required)
         :param str item_lowstock_code_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemLowstockCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_lowstock_code_audit_with_http_info(item_lowstock_code_id, item_lowstock_code_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_lowstock_code_audit_with_http_info(item_lowstock_code_id, item_lowstock_code_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemLowstockCodeApi(object):
 
         Adds an audit to an existing itemLowstockCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code_audit_with_http_info(item_lowstock_code_id, item_lowstock_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code_audit_with_http_info(item_lowstock_code_id, item_lowstock_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to add an audit to (required)
         :param str item_lowstock_code_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id', 'item_lowstock_code_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemLowstockCodeApi(object):
 
         Adds a file to an existing itemLowstockCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code_file(item_lowstock_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code_file(item_lowstock_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemLowstockCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_lowstock_code_file_with_http_info(item_lowstock_code_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_lowstock_code_file_with_http_info(item_lowstock_code_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemLowstockCodeApi(object):
 
         Adds a file to an existing itemLowstockCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code_file_with_http_info(item_lowstock_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code_file_with_http_info(item_lowstock_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemLowstockCodeApi(object):
 
         Adds a file to an existing itemLowstockCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code_file_by_url(body, item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code_file_by_url(body, item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_lowstock_code_id: Id of the itemLowstockCode to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemLowstockCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_lowstock_code_file_by_url_with_http_info(body, item_lowstock_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_lowstock_code_file_by_url_with_http_info(body, item_lowstock_code_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemLowstockCodeApi(object):
 
         Adds a file to an existing itemLowstockCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code_file_by_url_with_http_info(body, item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code_file_by_url_with_http_info(body, item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_lowstock_code_id: Id of the itemLowstockCode to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['body', 'item_lowstock_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemLowstockCodeApi(object):
 
         Adds a tag to an existing itemLowstockCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code_tag(item_lowstock_code_id, item_lowstock_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code_tag(item_lowstock_code_id, item_lowstock_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to add a tag to (required)
         :param str item_lowstock_code_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemLowstockCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_lowstock_code_tag_with_http_info(item_lowstock_code_id, item_lowstock_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_lowstock_code_tag_with_http_info(item_lowstock_code_id, item_lowstock_code_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemLowstockCodeApi(object):
 
         Adds a tag to an existing itemLowstockCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_lowstock_code_tag_with_http_info(item_lowstock_code_id, item_lowstock_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_lowstock_code_tag_with_http_info(item_lowstock_code_id, item_lowstock_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to add a tag to (required)
         :param str item_lowstock_code_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id', 'item_lowstock_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemLowstockCodeApi(object):
 
         Deletes the itemLowstockCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_lowstock_code(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_lowstock_code(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_lowstock_code_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_lowstock_code_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemLowstockCodeApi(object):
 
         Deletes the itemLowstockCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_lowstock_code_with_http_info(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_lowstock_code_with_http_info(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemLowstockCodeApi(object):
 
         Deletes an existing itemLowstockCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_lowstock_code_file(item_lowstock_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_lowstock_code_file(item_lowstock_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemLowstockCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_lowstock_code_file_with_http_info(item_lowstock_code_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_lowstock_code_file_with_http_info(item_lowstock_code_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemLowstockCodeApi(object):
 
         Deletes an existing itemLowstockCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_lowstock_code_file_with_http_info(item_lowstock_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_lowstock_code_file_with_http_info(item_lowstock_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemLowstockCodeApi(object):
 
         Deletes an existing itemLowstockCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_lowstock_code_tag(item_lowstock_code_id, item_lowstock_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_lowstock_code_tag(item_lowstock_code_id, item_lowstock_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to remove tag from (required)
         :param str item_lowstock_code_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemLowstockCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_lowstock_code_tag_with_http_info(item_lowstock_code_id, item_lowstock_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_lowstock_code_tag_with_http_info(item_lowstock_code_id, item_lowstock_code_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemLowstockCodeApi(object):
 
         Deletes an existing itemLowstockCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_lowstock_code_tag_with_http_info(item_lowstock_code_id, item_lowstock_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_lowstock_code_tag_with_http_info(item_lowstock_code_id, item_lowstock_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to remove tag from (required)
         :param str item_lowstock_code_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id', 'item_lowstock_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemLowstockCodeApi(object):
 
         Returns a duplicated itemLowstockCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_lowstock_code_by_id(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_lowstock_code_by_id(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to be duplicated. (required)
         :return: ItemLowstockCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_lowstock_code_by_id_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_lowstock_code_by_id_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemLowstockCodeApi(object):
 
         Returns a duplicated itemLowstockCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_lowstock_code_by_id_with_http_info(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_lowstock_code_by_id_with_http_info(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to be duplicated. (required)
         :return: ItemLowstockCode
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type='ItemLowstockCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemLowstockCodeApi(object):
 
         Returns the list of itemLowstockCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_lowstock_code_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_lowstock_code_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemLowstockCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_lowstock_code_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_lowstock_code_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemLowstockCodeApi(object):
 
         Returns the list of itemLowstockCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_lowstock_code_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_lowstock_code_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type='list[ItemLowstockCode]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemLowstockCodeApi(object):
 
         Returns the itemLowstockCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_lowstock_code_by_id(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_lowstock_code_by_id(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to be returned. (required)
         :return: ItemLowstockCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_lowstock_code_by_id_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_lowstock_code_by_id_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemLowstockCodeApi(object):
 
         Returns the itemLowstockCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_lowstock_code_by_id_with_http_info(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_lowstock_code_by_id_with_http_info(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to be returned. (required)
         :return: ItemLowstockCode
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type='ItemLowstockCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemLowstockCodeApi(object):
 
         Get all existing itemLowstockCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_lowstock_code_files(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_lowstock_code_files(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_lowstock_code_files_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_lowstock_code_files_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemLowstockCodeApi(object):
 
         Get all existing itemLowstockCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_lowstock_code_files_with_http_info(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_lowstock_code_files_with_http_info(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemLowstockCodeApi(object):
 
         Get all existing itemLowstockCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_lowstock_code_tags(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_lowstock_code_tags(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_lowstock_code_tags_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_lowstock_code_tags_with_http_info(item_lowstock_code_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemLowstockCodeApi(object):
 
         Get all existing itemLowstockCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_lowstock_code_tags_with_http_info(item_lowstock_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_lowstock_code_tags_with_http_info(item_lowstock_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_lowstock_code_id: Id of the itemLowstockCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['item_lowstock_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemLowstockCodeApi(object):
 
         Updates an existing itemLowstockCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_lowstock_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_lowstock_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemLowstockCode body: ItemLowstockCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_lowstock_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_lowstock_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemLowstockCodeApi(object):
 
         Updates an existing itemLowstockCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_lowstock_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_lowstock_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemLowstockCode body: ItemLowstockCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemLowstockCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemLowstockCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_product_code_api.py
+++ b/Infoplus/api/item_product_code_api.py
@@ -38,18 +38,18 @@ class ItemProductCodeApi(object):
 
         Inserts a new itemProductCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemProductCode body: ItemProductCode to be inserted. (required)
         :return: ItemProductCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_product_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_product_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemProductCodeApi(object):
 
         Inserts a new itemProductCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemProductCode body: ItemProductCode to be inserted. (required)
         :return: ItemProductCode
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type='ItemProductCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemProductCodeApi(object):
 
         Adds an audit to an existing itemProductCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code_audit(item_product_code_id, item_product_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code_audit(item_product_code_id, item_product_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to add an audit to (required)
         :param str item_product_code_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemProductCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_product_code_audit_with_http_info(item_product_code_id, item_product_code_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_product_code_audit_with_http_info(item_product_code_id, item_product_code_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemProductCodeApi(object):
 
         Adds an audit to an existing itemProductCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code_audit_with_http_info(item_product_code_id, item_product_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code_audit_with_http_info(item_product_code_id, item_product_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to add an audit to (required)
         :param str item_product_code_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id', 'item_product_code_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemProductCodeApi(object):
 
         Adds a file to an existing itemProductCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code_file(item_product_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code_file(item_product_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemProductCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_product_code_file_with_http_info(item_product_code_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_product_code_file_with_http_info(item_product_code_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemProductCodeApi(object):
 
         Adds a file to an existing itemProductCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code_file_with_http_info(item_product_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code_file_with_http_info(item_product_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemProductCodeApi(object):
 
         Adds a file to an existing itemProductCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code_file_by_url(body, item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code_file_by_url(body, item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_product_code_id: Id of the itemProductCode to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemProductCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_product_code_file_by_url_with_http_info(body, item_product_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_product_code_file_by_url_with_http_info(body, item_product_code_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemProductCodeApi(object):
 
         Adds a file to an existing itemProductCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code_file_by_url_with_http_info(body, item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code_file_by_url_with_http_info(body, item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_product_code_id: Id of the itemProductCode to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['body', 'item_product_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemProductCodeApi(object):
 
         Adds a tag to an existing itemProductCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code_tag(item_product_code_id, item_product_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code_tag(item_product_code_id, item_product_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to add a tag to (required)
         :param str item_product_code_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemProductCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_product_code_tag_with_http_info(item_product_code_id, item_product_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_product_code_tag_with_http_info(item_product_code_id, item_product_code_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemProductCodeApi(object):
 
         Adds a tag to an existing itemProductCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_product_code_tag_with_http_info(item_product_code_id, item_product_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_product_code_tag_with_http_info(item_product_code_id, item_product_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to add a tag to (required)
         :param str item_product_code_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id', 'item_product_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemProductCodeApi(object):
 
         Deletes the itemProductCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_product_code(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_product_code(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_product_code_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_product_code_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemProductCodeApi(object):
 
         Deletes the itemProductCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_product_code_with_http_info(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_product_code_with_http_info(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemProductCodeApi(object):
 
         Deletes an existing itemProductCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_product_code_file(item_product_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_product_code_file(item_product_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemProductCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_product_code_file_with_http_info(item_product_code_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_product_code_file_with_http_info(item_product_code_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemProductCodeApi(object):
 
         Deletes an existing itemProductCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_product_code_file_with_http_info(item_product_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_product_code_file_with_http_info(item_product_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemProductCodeApi(object):
 
         Deletes an existing itemProductCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_product_code_tag(item_product_code_id, item_product_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_product_code_tag(item_product_code_id, item_product_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to remove tag from (required)
         :param str item_product_code_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemProductCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_product_code_tag_with_http_info(item_product_code_id, item_product_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_product_code_tag_with_http_info(item_product_code_id, item_product_code_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemProductCodeApi(object):
 
         Deletes an existing itemProductCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_product_code_tag_with_http_info(item_product_code_id, item_product_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_product_code_tag_with_http_info(item_product_code_id, item_product_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to remove tag from (required)
         :param str item_product_code_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id', 'item_product_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemProductCodeApi(object):
 
         Returns a duplicated itemProductCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_product_code_by_id(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_product_code_by_id(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to be duplicated. (required)
         :return: ItemProductCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_product_code_by_id_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_product_code_by_id_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemProductCodeApi(object):
 
         Returns a duplicated itemProductCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_product_code_by_id_with_http_info(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_product_code_by_id_with_http_info(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to be duplicated. (required)
         :return: ItemProductCode
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type='ItemProductCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemProductCodeApi(object):
 
         Returns the list of itemProductCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_product_code_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_product_code_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemProductCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_product_code_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_product_code_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemProductCodeApi(object):
 
         Returns the list of itemProductCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_product_code_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_product_code_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type='list[ItemProductCode]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemProductCodeApi(object):
 
         Returns the itemProductCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_product_code_by_id(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_product_code_by_id(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to be returned. (required)
         :return: ItemProductCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_product_code_by_id_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_product_code_by_id_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemProductCodeApi(object):
 
         Returns the itemProductCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_product_code_by_id_with_http_info(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_product_code_by_id_with_http_info(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to be returned. (required)
         :return: ItemProductCode
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type='ItemProductCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemProductCodeApi(object):
 
         Get all existing itemProductCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_product_code_files(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_product_code_files(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_product_code_files_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_product_code_files_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemProductCodeApi(object):
 
         Get all existing itemProductCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_product_code_files_with_http_info(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_product_code_files_with_http_info(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemProductCodeApi(object):
 
         Get all existing itemProductCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_product_code_tags(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_product_code_tags(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_product_code_tags_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_product_code_tags_with_http_info(item_product_code_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemProductCodeApi(object):
 
         Get all existing itemProductCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_product_code_tags_with_http_info(item_product_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_product_code_tags_with_http_info(item_product_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_product_code_id: Id of the itemProductCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['item_product_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemProductCodeApi(object):
 
         Updates an existing itemProductCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_product_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_product_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemProductCode body: ItemProductCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_product_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_product_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemProductCodeApi(object):
 
         Updates an existing itemProductCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_product_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_product_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemProductCode body: ItemProductCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemProductCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemProductCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_receipt_activity_api.py
+++ b/Infoplus/api/item_receipt_activity_api.py
@@ -38,18 +38,18 @@ class ItemReceiptActivityApi(object):
 
         Inserts a new itemReceiptActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemReceiptActivity body: ItemReceiptActivity to be inserted. (required)
         :return: ItemReceiptActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_receipt_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_receipt_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemReceiptActivityApi(object):
 
         Inserts a new itemReceiptActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemReceiptActivity body: ItemReceiptActivity to be inserted. (required)
         :return: ItemReceiptActivity
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type='ItemReceiptActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemReceiptActivityApi(object):
 
         Adds an audit to an existing itemReceiptActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity_audit(item_receipt_activity_id, item_receipt_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity_audit(item_receipt_activity_id, item_receipt_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to add an audit to (required)
         :param str item_receipt_activity_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemReceiptActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_receipt_activity_audit_with_http_info(item_receipt_activity_id, item_receipt_activity_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_receipt_activity_audit_with_http_info(item_receipt_activity_id, item_receipt_activity_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemReceiptActivityApi(object):
 
         Adds an audit to an existing itemReceiptActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity_audit_with_http_info(item_receipt_activity_id, item_receipt_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity_audit_with_http_info(item_receipt_activity_id, item_receipt_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to add an audit to (required)
         :param str item_receipt_activity_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id', 'item_receipt_activity_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemReceiptActivityApi(object):
 
         Adds a file to an existing itemReceiptActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity_file(item_receipt_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity_file(item_receipt_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemReceiptActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_receipt_activity_file_with_http_info(item_receipt_activity_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_receipt_activity_file_with_http_info(item_receipt_activity_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemReceiptActivityApi(object):
 
         Adds a file to an existing itemReceiptActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity_file_with_http_info(item_receipt_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity_file_with_http_info(item_receipt_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemReceiptActivityApi(object):
 
         Adds a file to an existing itemReceiptActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity_file_by_url(body, item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity_file_by_url(body, item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemReceiptActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_receipt_activity_file_by_url_with_http_info(body, item_receipt_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_receipt_activity_file_by_url_with_http_info(body, item_receipt_activity_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemReceiptActivityApi(object):
 
         Adds a file to an existing itemReceiptActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity_file_by_url_with_http_info(body, item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity_file_by_url_with_http_info(body, item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['body', 'item_receipt_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemReceiptActivityApi(object):
 
         Adds a tag to an existing itemReceiptActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity_tag(item_receipt_activity_id, item_receipt_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity_tag(item_receipt_activity_id, item_receipt_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to add a tag to (required)
         :param str item_receipt_activity_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemReceiptActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_receipt_activity_tag_with_http_info(item_receipt_activity_id, item_receipt_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_receipt_activity_tag_with_http_info(item_receipt_activity_id, item_receipt_activity_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemReceiptActivityApi(object):
 
         Adds a tag to an existing itemReceiptActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_activity_tag_with_http_info(item_receipt_activity_id, item_receipt_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_activity_tag_with_http_info(item_receipt_activity_id, item_receipt_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to add a tag to (required)
         :param str item_receipt_activity_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id', 'item_receipt_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemReceiptActivityApi(object):
 
         Deletes the itemReceiptActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_activity(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_activity(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_receipt_activity_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_receipt_activity_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemReceiptActivityApi(object):
 
         Deletes the itemReceiptActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_activity_with_http_info(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_activity_with_http_info(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemReceiptActivityApi(object):
 
         Deletes an existing itemReceiptActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_activity_file(item_receipt_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_activity_file(item_receipt_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemReceiptActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_receipt_activity_file_with_http_info(item_receipt_activity_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_receipt_activity_file_with_http_info(item_receipt_activity_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemReceiptActivityApi(object):
 
         Deletes an existing itemReceiptActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_activity_file_with_http_info(item_receipt_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_activity_file_with_http_info(item_receipt_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemReceiptActivityApi(object):
 
         Deletes an existing itemReceiptActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_activity_tag(item_receipt_activity_id, item_receipt_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_activity_tag(item_receipt_activity_id, item_receipt_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to remove tag from (required)
         :param str item_receipt_activity_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemReceiptActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_receipt_activity_tag_with_http_info(item_receipt_activity_id, item_receipt_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_receipt_activity_tag_with_http_info(item_receipt_activity_id, item_receipt_activity_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemReceiptActivityApi(object):
 
         Deletes an existing itemReceiptActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_activity_tag_with_http_info(item_receipt_activity_id, item_receipt_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_activity_tag_with_http_info(item_receipt_activity_id, item_receipt_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to remove tag from (required)
         :param str item_receipt_activity_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id', 'item_receipt_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemReceiptActivityApi(object):
 
         Returns a duplicated itemReceiptActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_receipt_activity_by_id(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_receipt_activity_by_id(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to be duplicated. (required)
         :return: ItemReceiptActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_receipt_activity_by_id_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_receipt_activity_by_id_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemReceiptActivityApi(object):
 
         Returns a duplicated itemReceiptActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_receipt_activity_by_id_with_http_info(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_receipt_activity_by_id_with_http_info(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to be duplicated. (required)
         :return: ItemReceiptActivity
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type='ItemReceiptActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemReceiptActivityApi(object):
 
         Returns the list of itemReceiptActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_activity_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_activity_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemReceiptActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_receipt_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_receipt_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemReceiptActivityApi(object):
 
         Returns the list of itemReceiptActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_activity_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_activity_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type='list[ItemReceiptActivity]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemReceiptActivityApi(object):
 
         Returns the itemReceiptActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_activity_by_id(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_activity_by_id(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to be returned. (required)
         :return: ItemReceiptActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_receipt_activity_by_id_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_receipt_activity_by_id_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemReceiptActivityApi(object):
 
         Returns the itemReceiptActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_activity_by_id_with_http_info(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_activity_by_id_with_http_info(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to be returned. (required)
         :return: ItemReceiptActivity
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type='ItemReceiptActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemReceiptActivityApi(object):
 
         Get all existing itemReceiptActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_activity_files(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_activity_files(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_receipt_activity_files_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_receipt_activity_files_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemReceiptActivityApi(object):
 
         Get all existing itemReceiptActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_activity_files_with_http_info(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_activity_files_with_http_info(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemReceiptActivityApi(object):
 
         Get all existing itemReceiptActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_activity_tags(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_activity_tags(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_receipt_activity_tags_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_receipt_activity_tags_with_http_info(item_receipt_activity_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemReceiptActivityApi(object):
 
         Get all existing itemReceiptActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_activity_tags_with_http_info(item_receipt_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_activity_tags_with_http_info(item_receipt_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_activity_id: Id of the itemReceiptActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['item_receipt_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemReceiptActivityApi(object):
 
         Updates an existing itemReceiptActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_receipt_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_receipt_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemReceiptActivity body: ItemReceiptActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_receipt_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_receipt_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemReceiptActivityApi(object):
 
         Updates an existing itemReceiptActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_receipt_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_receipt_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemReceiptActivity body: ItemReceiptActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemReceiptActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemReceiptActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_receipt_api.py
+++ b/Infoplus/api/item_receipt_api.py
@@ -38,11 +38,11 @@ class ItemReceiptApi(object):
 
         Adds an audit to an existing itemReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_audit(item_receipt_id, item_receipt_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_audit(item_receipt_id, item_receipt_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to add an audit to (required)
         :param str item_receipt_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ItemReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_receipt_audit_with_http_info(item_receipt_id, item_receipt_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_receipt_audit_with_http_info(item_receipt_id, item_receipt_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ItemReceiptApi(object):
 
         Adds an audit to an existing itemReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_audit_with_http_info(item_receipt_id, item_receipt_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_audit_with_http_info(item_receipt_id, item_receipt_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to add an audit to (required)
         :param str item_receipt_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['item_receipt_id', 'item_receipt_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ItemReceiptApi(object):
 
         Adds a file to an existing itemReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_file(item_receipt_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_file(item_receipt_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ItemReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_receipt_file_with_http_info(item_receipt_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_receipt_file_with_http_info(item_receipt_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ItemReceiptApi(object):
 
         Adds a file to an existing itemReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_file_with_http_info(item_receipt_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_file_with_http_info(item_receipt_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['item_receipt_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ItemReceiptApi(object):
 
         Adds a file to an existing itemReceipt by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_file_by_url(body, item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_file_by_url(body, item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_receipt_id: Id of the itemReceipt to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ItemReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_receipt_file_by_url_with_http_info(body, item_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_receipt_file_by_url_with_http_info(body, item_receipt_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ItemReceiptApi(object):
 
         Adds a file to an existing itemReceipt by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_file_by_url_with_http_info(body, item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_file_by_url_with_http_info(body, item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_receipt_id: Id of the itemReceipt to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['body', 'item_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ItemReceiptApi(object):
 
         Adds a tag to an existing itemReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_tag(item_receipt_id, item_receipt_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_tag(item_receipt_id, item_receipt_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to add a tag to (required)
         :param str item_receipt_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ItemReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_receipt_tag_with_http_info(item_receipt_id, item_receipt_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_receipt_tag_with_http_info(item_receipt_id, item_receipt_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ItemReceiptApi(object):
 
         Adds a tag to an existing itemReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_receipt_tag_with_http_info(item_receipt_id, item_receipt_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_receipt_tag_with_http_info(item_receipt_id, item_receipt_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to add a tag to (required)
         :param str item_receipt_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['item_receipt_id', 'item_receipt_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class ItemReceiptApi(object):
 
         Deletes an existing itemReceipt file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_file(item_receipt_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_file(item_receipt_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class ItemReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_receipt_file_with_http_info(item_receipt_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_receipt_file_with_http_info(item_receipt_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class ItemReceiptApi(object):
 
         Deletes an existing itemReceipt file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_file_with_http_info(item_receipt_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_file_with_http_info(item_receipt_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['item_receipt_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class ItemReceiptApi(object):
 
         Deletes an existing itemReceipt tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_tag(item_receipt_id, item_receipt_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_tag(item_receipt_id, item_receipt_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to remove tag from (required)
         :param str item_receipt_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class ItemReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_receipt_tag_with_http_info(item_receipt_id, item_receipt_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_receipt_tag_with_http_info(item_receipt_id, item_receipt_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class ItemReceiptApi(object):
 
         Deletes an existing itemReceipt tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_receipt_tag_with_http_info(item_receipt_id, item_receipt_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_receipt_tag_with_http_info(item_receipt_id, item_receipt_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to remove tag from (required)
         :param str item_receipt_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['item_receipt_id', 'item_receipt_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class ItemReceiptApi(object):
 
         Returns a duplicated itemReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_receipt_by_id(item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_receipt_by_id(item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to be duplicated. (required)
         :return: ItemReceipt
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_receipt_by_id_with_http_info(item_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_receipt_by_id_with_http_info(item_receipt_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class ItemReceiptApi(object):
 
         Returns a duplicated itemReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_receipt_by_id_with_http_info(item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_receipt_by_id_with_http_info(item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to be duplicated. (required)
         :return: ItemReceipt
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['item_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type='ItemReceipt',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class ItemReceiptApi(object):
 
         Returns the list of itemReceipts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class ItemReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_receipt_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_receipt_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class ItemReceiptApi(object):
 
         Returns the list of itemReceipts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type='list[ItemReceipt]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class ItemReceiptApi(object):
 
         Returns the itemReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_by_id(item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_by_id(item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to be returned. (required)
         :return: ItemReceipt
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_receipt_by_id_with_http_info(item_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_receipt_by_id_with_http_info(item_receipt_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class ItemReceiptApi(object):
 
         Returns the itemReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_by_id_with_http_info(item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_by_id_with_http_info(item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to be returned. (required)
         :return: ItemReceipt
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['item_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type='ItemReceipt',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ItemReceiptApi(object):
 
         Get all existing itemReceipt files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_files(item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_files(item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_receipt_files_with_http_info(item_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_receipt_files_with_http_info(item_receipt_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ItemReceiptApi(object):
 
         Get all existing itemReceipt files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_files_with_http_info(item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_files_with_http_info(item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['item_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ItemReceiptApi(object):
 
         Get all existing itemReceipt tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_tags(item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_tags(item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_receipt_tags_with_http_info(item_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_receipt_tags_with_http_info(item_receipt_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ItemReceiptApi(object):
 
         Get all existing itemReceipt tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_receipt_tags_with_http_info(item_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_receipt_tags_with_http_info(item_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_receipt_id: Id of the itemReceipt to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['item_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class ItemReceiptApi(object):
 
         Updates an existing itemReceipt using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_receipt(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_receipt(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemReceipt body: ItemReceipt to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_receipt_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_receipt_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class ItemReceiptApi(object):
 
         Updates an existing itemReceipt using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_receipt_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_receipt_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemReceipt body: ItemReceipt to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemReceiptApi(object):
 
         Updates an existing itemReceipt custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_receipt_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_receipt_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemReceipt body: ItemReceipt to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_receipt_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_receipt_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemReceiptApi(object):
 
         Updates an existing itemReceipt custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_receipt_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_receipt_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemReceipt body: ItemReceipt to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemReceiptApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class ItemReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_sector_api.py
+++ b/Infoplus/api/item_sector_api.py
@@ -38,18 +38,18 @@ class ItemSectorApi(object):
 
         Inserts a new itemSector using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSector body: ItemSector to be inserted. (required)
         :return: ItemSector
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sector_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sector_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemSectorApi(object):
 
         Inserts a new itemSector using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSector body: ItemSector to be inserted. (required)
         :return: ItemSector
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type='ItemSector',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemSectorApi(object):
 
         Adds an audit to an existing itemSector.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector_audit(item_sector_id, item_sector_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector_audit(item_sector_id, item_sector_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to add an audit to (required)
         :param str item_sector_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemSectorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sector_audit_with_http_info(item_sector_id, item_sector_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sector_audit_with_http_info(item_sector_id, item_sector_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemSectorApi(object):
 
         Adds an audit to an existing itemSector.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector_audit_with_http_info(item_sector_id, item_sector_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector_audit_with_http_info(item_sector_id, item_sector_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to add an audit to (required)
         :param str item_sector_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id', 'item_sector_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemSectorApi(object):
 
         Adds a file to an existing itemSector.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector_file(item_sector_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector_file(item_sector_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemSectorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sector_file_with_http_info(item_sector_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sector_file_with_http_info(item_sector_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemSectorApi(object):
 
         Adds a file to an existing itemSector.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector_file_with_http_info(item_sector_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector_file_with_http_info(item_sector_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemSectorApi(object):
 
         Adds a file to an existing itemSector by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector_file_by_url(body, item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector_file_by_url(body, item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_sector_id: Id of the itemSector to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemSectorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sector_file_by_url_with_http_info(body, item_sector_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sector_file_by_url_with_http_info(body, item_sector_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemSectorApi(object):
 
         Adds a file to an existing itemSector by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector_file_by_url_with_http_info(body, item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector_file_by_url_with_http_info(body, item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_sector_id: Id of the itemSector to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['body', 'item_sector_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemSectorApi(object):
 
         Adds a tag to an existing itemSector.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector_tag(item_sector_id, item_sector_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector_tag(item_sector_id, item_sector_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to add a tag to (required)
         :param str item_sector_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemSectorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sector_tag_with_http_info(item_sector_id, item_sector_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sector_tag_with_http_info(item_sector_id, item_sector_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemSectorApi(object):
 
         Adds a tag to an existing itemSector.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sector_tag_with_http_info(item_sector_id, item_sector_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sector_tag_with_http_info(item_sector_id, item_sector_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to add a tag to (required)
         :param str item_sector_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id', 'item_sector_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemSectorApi(object):
 
         Deletes the itemSector identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sector(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sector(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_sector_with_http_info(item_sector_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_sector_with_http_info(item_sector_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemSectorApi(object):
 
         Deletes the itemSector identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sector_with_http_info(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sector_with_http_info(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemSectorApi(object):
 
         Deletes an existing itemSector file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sector_file(item_sector_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sector_file(item_sector_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemSectorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_sector_file_with_http_info(item_sector_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_sector_file_with_http_info(item_sector_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemSectorApi(object):
 
         Deletes an existing itemSector file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sector_file_with_http_info(item_sector_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sector_file_with_http_info(item_sector_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemSectorApi(object):
 
         Deletes an existing itemSector tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sector_tag(item_sector_id, item_sector_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sector_tag(item_sector_id, item_sector_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to remove tag from (required)
         :param str item_sector_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemSectorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_sector_tag_with_http_info(item_sector_id, item_sector_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_sector_tag_with_http_info(item_sector_id, item_sector_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemSectorApi(object):
 
         Deletes an existing itemSector tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sector_tag_with_http_info(item_sector_id, item_sector_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sector_tag_with_http_info(item_sector_id, item_sector_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to remove tag from (required)
         :param str item_sector_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id', 'item_sector_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemSectorApi(object):
 
         Returns a duplicated itemSector identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_sector_by_id(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_sector_by_id(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to be duplicated. (required)
         :return: ItemSector
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_sector_by_id_with_http_info(item_sector_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_sector_by_id_with_http_info(item_sector_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemSectorApi(object):
 
         Returns a duplicated itemSector identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_sector_by_id_with_http_info(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_sector_by_id_with_http_info(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to be duplicated. (required)
         :return: ItemSector
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type='ItemSector',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemSectorApi(object):
 
         Returns the list of itemSectors that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sector_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sector_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemSectorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_sector_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_sector_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemSectorApi(object):
 
         Returns the list of itemSectors that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sector_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sector_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type='list[ItemSector]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemSectorApi(object):
 
         Returns the itemSector identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sector_by_id(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sector_by_id(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to be returned. (required)
         :return: ItemSector
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_sector_by_id_with_http_info(item_sector_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_sector_by_id_with_http_info(item_sector_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemSectorApi(object):
 
         Returns the itemSector identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sector_by_id_with_http_info(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sector_by_id_with_http_info(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to be returned. (required)
         :return: ItemSector
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type='ItemSector',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemSectorApi(object):
 
         Get all existing itemSector files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sector_files(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sector_files(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_sector_files_with_http_info(item_sector_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_sector_files_with_http_info(item_sector_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemSectorApi(object):
 
         Get all existing itemSector files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sector_files_with_http_info(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sector_files_with_http_info(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemSectorApi(object):
 
         Get all existing itemSector tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sector_tags(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sector_tags(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_sector_tags_with_http_info(item_sector_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_sector_tags_with_http_info(item_sector_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemSectorApi(object):
 
         Get all existing itemSector tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sector_tags_with_http_info(item_sector_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sector_tags_with_http_info(item_sector_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sector_id: Id of the itemSector to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['item_sector_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemSectorApi(object):
 
         Updates an existing itemSector using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_sector(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_sector(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSector body: ItemSector to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_sector_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_sector_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemSectorApi(object):
 
         Updates an existing itemSector using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_sector_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_sector_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSector body: ItemSector to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemSectorApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemSectorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_serial_api.py
+++ b/Infoplus/api/item_serial_api.py
@@ -38,18 +38,18 @@ class ItemSerialApi(object):
 
         Inserts a new itemSerial using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSerial body: ItemSerial to be inserted. (required)
         :return: ItemSerial
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemSerialApi(object):
 
         Inserts a new itemSerial using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSerial body: ItemSerial to be inserted. (required)
         :return: ItemSerial
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type='ItemSerial',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemSerialApi(object):
 
         Adds an audit to an existing itemSerial.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_audit(item_serial_id, item_serial_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_audit(item_serial_id, item_serial_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to add an audit to (required)
         :param str item_serial_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemSerialApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_audit_with_http_info(item_serial_id, item_serial_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_audit_with_http_info(item_serial_id, item_serial_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemSerialApi(object):
 
         Adds an audit to an existing itemSerial.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_audit_with_http_info(item_serial_id, item_serial_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_audit_with_http_info(item_serial_id, item_serial_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to add an audit to (required)
         :param str item_serial_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id', 'item_serial_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemSerialApi(object):
 
         Adds a file to an existing itemSerial.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_file(item_serial_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_file(item_serial_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemSerialApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_file_with_http_info(item_serial_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_file_with_http_info(item_serial_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemSerialApi(object):
 
         Adds a file to an existing itemSerial.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_file_with_http_info(item_serial_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_file_with_http_info(item_serial_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemSerialApi(object):
 
         Adds a file to an existing itemSerial by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_file_by_url(body, item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_file_by_url(body, item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_serial_id: Id of the itemSerial to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemSerialApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_file_by_url_with_http_info(body, item_serial_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_file_by_url_with_http_info(body, item_serial_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemSerialApi(object):
 
         Adds a file to an existing itemSerial by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_file_by_url_with_http_info(body, item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_file_by_url_with_http_info(body, item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_serial_id: Id of the itemSerial to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['body', 'item_serial_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemSerialApi(object):
 
         Adds a tag to an existing itemSerial.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_tag(item_serial_id, item_serial_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_tag(item_serial_id, item_serial_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to add a tag to (required)
         :param str item_serial_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemSerialApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_tag_with_http_info(item_serial_id, item_serial_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_tag_with_http_info(item_serial_id, item_serial_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemSerialApi(object):
 
         Adds a tag to an existing itemSerial.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_tag_with_http_info(item_serial_id, item_serial_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_tag_with_http_info(item_serial_id, item_serial_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to add a tag to (required)
         :param str item_serial_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id', 'item_serial_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemSerialApi(object):
 
         Deletes the itemSerial identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_serial_with_http_info(item_serial_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_serial_with_http_info(item_serial_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemSerialApi(object):
 
         Deletes the itemSerial identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_with_http_info(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_with_http_info(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemSerialApi(object):
 
         Deletes an existing itemSerial file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_file(item_serial_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_file(item_serial_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemSerialApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_serial_file_with_http_info(item_serial_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_serial_file_with_http_info(item_serial_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemSerialApi(object):
 
         Deletes an existing itemSerial file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_file_with_http_info(item_serial_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_file_with_http_info(item_serial_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemSerialApi(object):
 
         Deletes an existing itemSerial tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_tag(item_serial_id, item_serial_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_tag(item_serial_id, item_serial_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to remove tag from (required)
         :param str item_serial_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemSerialApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_serial_tag_with_http_info(item_serial_id, item_serial_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_serial_tag_with_http_info(item_serial_id, item_serial_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemSerialApi(object):
 
         Deletes an existing itemSerial tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_tag_with_http_info(item_serial_id, item_serial_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_tag_with_http_info(item_serial_id, item_serial_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to remove tag from (required)
         :param str item_serial_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id', 'item_serial_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemSerialApi(object):
 
         Returns a duplicated itemSerial identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_serial_by_id(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_serial_by_id(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to be duplicated. (required)
         :return: ItemSerial
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_serial_by_id_with_http_info(item_serial_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_serial_by_id_with_http_info(item_serial_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemSerialApi(object):
 
         Returns a duplicated itemSerial identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_serial_by_id_with_http_info(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_serial_by_id_with_http_info(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to be duplicated. (required)
         :return: ItemSerial
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type='ItemSerial',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemSerialApi(object):
 
         Returns the list of itemSerials that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemSerialApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_serial_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_serial_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemSerialApi(object):
 
         Returns the list of itemSerials that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type='list[ItemSerial]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemSerialApi(object):
 
         Returns the itemSerial identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_by_id(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_by_id(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to be returned. (required)
         :return: ItemSerial
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_serial_by_id_with_http_info(item_serial_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_serial_by_id_with_http_info(item_serial_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemSerialApi(object):
 
         Returns the itemSerial identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_by_id_with_http_info(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_by_id_with_http_info(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to be returned. (required)
         :return: ItemSerial
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type='ItemSerial',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemSerialApi(object):
 
         Get all existing itemSerial files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_files(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_files(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_serial_files_with_http_info(item_serial_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_serial_files_with_http_info(item_serial_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemSerialApi(object):
 
         Get all existing itemSerial files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_files_with_http_info(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_files_with_http_info(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemSerialApi(object):
 
         Get all existing itemSerial tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_tags(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_tags(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_serial_tags_with_http_info(item_serial_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_serial_tags_with_http_info(item_serial_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemSerialApi(object):
 
         Get all existing itemSerial tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_tags_with_http_info(item_serial_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_tags_with_http_info(item_serial_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_id: Id of the itemSerial to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['item_serial_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemSerialApi(object):
 
         Updates an existing itemSerial using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_serial(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_serial(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSerial body: ItemSerial to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_serial_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_serial_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemSerialApi(object):
 
         Updates an existing itemSerial using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_serial_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_serial_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSerial body: ItemSerial to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemSerialApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemSerialApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_serial_scheme_api.py
+++ b/Infoplus/api/item_serial_scheme_api.py
@@ -38,18 +38,18 @@ class ItemSerialSchemeApi(object):
 
         Inserts a new itemSerialScheme using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSerialScheme body: ItemSerialScheme to be inserted. (required)
         :return: ItemSerialScheme
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_scheme_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_scheme_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemSerialSchemeApi(object):
 
         Inserts a new itemSerialScheme using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSerialScheme body: ItemSerialScheme to be inserted. (required)
         :return: ItemSerialScheme
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type='ItemSerialScheme',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemSerialSchemeApi(object):
 
         Adds an audit to an existing itemSerialScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme_audit(item_serial_scheme_id, item_serial_scheme_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme_audit(item_serial_scheme_id, item_serial_scheme_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to add an audit to (required)
         :param str item_serial_scheme_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemSerialSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_scheme_audit_with_http_info(item_serial_scheme_id, item_serial_scheme_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_scheme_audit_with_http_info(item_serial_scheme_id, item_serial_scheme_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemSerialSchemeApi(object):
 
         Adds an audit to an existing itemSerialScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme_audit_with_http_info(item_serial_scheme_id, item_serial_scheme_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme_audit_with_http_info(item_serial_scheme_id, item_serial_scheme_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to add an audit to (required)
         :param str item_serial_scheme_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id', 'item_serial_scheme_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemSerialSchemeApi(object):
 
         Adds a file to an existing itemSerialScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme_file(item_serial_scheme_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme_file(item_serial_scheme_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemSerialSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_scheme_file_with_http_info(item_serial_scheme_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_scheme_file_with_http_info(item_serial_scheme_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemSerialSchemeApi(object):
 
         Adds a file to an existing itemSerialScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme_file_with_http_info(item_serial_scheme_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme_file_with_http_info(item_serial_scheme_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemSerialSchemeApi(object):
 
         Adds a file to an existing itemSerialScheme by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme_file_by_url(body, item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme_file_by_url(body, item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_serial_scheme_id: Id of the itemSerialScheme to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemSerialSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_scheme_file_by_url_with_http_info(body, item_serial_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_scheme_file_by_url_with_http_info(body, item_serial_scheme_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemSerialSchemeApi(object):
 
         Adds a file to an existing itemSerialScheme by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme_file_by_url_with_http_info(body, item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme_file_by_url_with_http_info(body, item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_serial_scheme_id: Id of the itemSerialScheme to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['body', 'item_serial_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemSerialSchemeApi(object):
 
         Adds a tag to an existing itemSerialScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme_tag(item_serial_scheme_id, item_serial_scheme_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme_tag(item_serial_scheme_id, item_serial_scheme_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to add a tag to (required)
         :param str item_serial_scheme_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemSerialSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_serial_scheme_tag_with_http_info(item_serial_scheme_id, item_serial_scheme_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_serial_scheme_tag_with_http_info(item_serial_scheme_id, item_serial_scheme_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemSerialSchemeApi(object):
 
         Adds a tag to an existing itemSerialScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_serial_scheme_tag_with_http_info(item_serial_scheme_id, item_serial_scheme_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_serial_scheme_tag_with_http_info(item_serial_scheme_id, item_serial_scheme_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to add a tag to (required)
         :param str item_serial_scheme_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id', 'item_serial_scheme_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemSerialSchemeApi(object):
 
         Deletes the itemSerialScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_scheme(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_scheme(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_serial_scheme_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_serial_scheme_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemSerialSchemeApi(object):
 
         Deletes the itemSerialScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_scheme_with_http_info(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_scheme_with_http_info(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemSerialSchemeApi(object):
 
         Deletes an existing itemSerialScheme file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_scheme_file(item_serial_scheme_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_scheme_file(item_serial_scheme_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemSerialSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_serial_scheme_file_with_http_info(item_serial_scheme_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_serial_scheme_file_with_http_info(item_serial_scheme_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemSerialSchemeApi(object):
 
         Deletes an existing itemSerialScheme file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_scheme_file_with_http_info(item_serial_scheme_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_scheme_file_with_http_info(item_serial_scheme_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemSerialSchemeApi(object):
 
         Deletes an existing itemSerialScheme tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_scheme_tag(item_serial_scheme_id, item_serial_scheme_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_scheme_tag(item_serial_scheme_id, item_serial_scheme_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to remove tag from (required)
         :param str item_serial_scheme_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemSerialSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_serial_scheme_tag_with_http_info(item_serial_scheme_id, item_serial_scheme_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_serial_scheme_tag_with_http_info(item_serial_scheme_id, item_serial_scheme_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemSerialSchemeApi(object):
 
         Deletes an existing itemSerialScheme tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_serial_scheme_tag_with_http_info(item_serial_scheme_id, item_serial_scheme_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_serial_scheme_tag_with_http_info(item_serial_scheme_id, item_serial_scheme_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to remove tag from (required)
         :param str item_serial_scheme_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id', 'item_serial_scheme_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemSerialSchemeApi(object):
 
         Returns a duplicated itemSerialScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_serial_scheme_by_id(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_serial_scheme_by_id(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to be duplicated. (required)
         :return: ItemSerialScheme
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_serial_scheme_by_id_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_serial_scheme_by_id_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemSerialSchemeApi(object):
 
         Returns a duplicated itemSerialScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_serial_scheme_by_id_with_http_info(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_serial_scheme_by_id_with_http_info(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to be duplicated. (required)
         :return: ItemSerialScheme
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type='ItemSerialScheme',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemSerialSchemeApi(object):
 
         Returns the list of itemSerialSchemes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_scheme_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_scheme_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemSerialSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_serial_scheme_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_serial_scheme_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemSerialSchemeApi(object):
 
         Returns the list of itemSerialSchemes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_scheme_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_scheme_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type='list[ItemSerialScheme]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemSerialSchemeApi(object):
 
         Returns the itemSerialScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_scheme_by_id(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_scheme_by_id(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to be returned. (required)
         :return: ItemSerialScheme
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_serial_scheme_by_id_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_serial_scheme_by_id_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemSerialSchemeApi(object):
 
         Returns the itemSerialScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_scheme_by_id_with_http_info(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_scheme_by_id_with_http_info(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to be returned. (required)
         :return: ItemSerialScheme
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type='ItemSerialScheme',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemSerialSchemeApi(object):
 
         Get all existing itemSerialScheme files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_scheme_files(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_scheme_files(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_serial_scheme_files_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_serial_scheme_files_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemSerialSchemeApi(object):
 
         Get all existing itemSerialScheme files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_scheme_files_with_http_info(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_scheme_files_with_http_info(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemSerialSchemeApi(object):
 
         Get all existing itemSerialScheme tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_scheme_tags(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_scheme_tags(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_serial_scheme_tags_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_serial_scheme_tags_with_http_info(item_serial_scheme_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemSerialSchemeApi(object):
 
         Get all existing itemSerialScheme tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_serial_scheme_tags_with_http_info(item_serial_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_serial_scheme_tags_with_http_info(item_serial_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_serial_scheme_id: Id of the itemSerialScheme to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['item_serial_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemSerialSchemeApi(object):
 
         Updates an existing itemSerialScheme using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_serial_scheme(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_serial_scheme(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSerialScheme body: ItemSerialScheme to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_serial_scheme_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_serial_scheme_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemSerialSchemeApi(object):
 
         Updates an existing itemSerialScheme using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_serial_scheme_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_serial_scheme_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSerialScheme body: ItemSerialScheme to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemSerialSchemeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemSerialSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_sub_category_api.py
+++ b/Infoplus/api/item_sub_category_api.py
@@ -38,18 +38,18 @@ class ItemSubCategoryApi(object):
 
         Inserts a new itemSubCategory using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSubCategory body: ItemSubCategory to be inserted. (required)
         :return: ItemSubCategory
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sub_category_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sub_category_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemSubCategoryApi(object):
 
         Inserts a new itemSubCategory using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSubCategory body: ItemSubCategory to be inserted. (required)
         :return: ItemSubCategory
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type='ItemSubCategory',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemSubCategoryApi(object):
 
         Adds an audit to an existing itemSubCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category_audit(item_sub_category_id, item_sub_category_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category_audit(item_sub_category_id, item_sub_category_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to add an audit to (required)
         :param str item_sub_category_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemSubCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sub_category_audit_with_http_info(item_sub_category_id, item_sub_category_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sub_category_audit_with_http_info(item_sub_category_id, item_sub_category_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemSubCategoryApi(object):
 
         Adds an audit to an existing itemSubCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category_audit_with_http_info(item_sub_category_id, item_sub_category_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category_audit_with_http_info(item_sub_category_id, item_sub_category_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to add an audit to (required)
         :param str item_sub_category_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id', 'item_sub_category_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemSubCategoryApi(object):
 
         Adds a file to an existing itemSubCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category_file(item_sub_category_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category_file(item_sub_category_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemSubCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sub_category_file_with_http_info(item_sub_category_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sub_category_file_with_http_info(item_sub_category_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemSubCategoryApi(object):
 
         Adds a file to an existing itemSubCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category_file_with_http_info(item_sub_category_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category_file_with_http_info(item_sub_category_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemSubCategoryApi(object):
 
         Adds a file to an existing itemSubCategory by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category_file_by_url(body, item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category_file_by_url(body, item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_sub_category_id: Id of the itemSubCategory to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemSubCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sub_category_file_by_url_with_http_info(body, item_sub_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sub_category_file_by_url_with_http_info(body, item_sub_category_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemSubCategoryApi(object):
 
         Adds a file to an existing itemSubCategory by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category_file_by_url_with_http_info(body, item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category_file_by_url_with_http_info(body, item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_sub_category_id: Id of the itemSubCategory to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['body', 'item_sub_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemSubCategoryApi(object):
 
         Adds a tag to an existing itemSubCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category_tag(item_sub_category_id, item_sub_category_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category_tag(item_sub_category_id, item_sub_category_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to add a tag to (required)
         :param str item_sub_category_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemSubCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_sub_category_tag_with_http_info(item_sub_category_id, item_sub_category_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_sub_category_tag_with_http_info(item_sub_category_id, item_sub_category_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemSubCategoryApi(object):
 
         Adds a tag to an existing itemSubCategory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_sub_category_tag_with_http_info(item_sub_category_id, item_sub_category_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_sub_category_tag_with_http_info(item_sub_category_id, item_sub_category_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to add a tag to (required)
         :param str item_sub_category_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id', 'item_sub_category_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemSubCategoryApi(object):
 
         Deletes the itemSubCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sub_category(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sub_category(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_sub_category_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_sub_category_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemSubCategoryApi(object):
 
         Deletes the itemSubCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sub_category_with_http_info(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sub_category_with_http_info(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemSubCategoryApi(object):
 
         Deletes an existing itemSubCategory file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sub_category_file(item_sub_category_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sub_category_file(item_sub_category_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemSubCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_sub_category_file_with_http_info(item_sub_category_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_sub_category_file_with_http_info(item_sub_category_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemSubCategoryApi(object):
 
         Deletes an existing itemSubCategory file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sub_category_file_with_http_info(item_sub_category_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sub_category_file_with_http_info(item_sub_category_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemSubCategoryApi(object):
 
         Deletes an existing itemSubCategory tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sub_category_tag(item_sub_category_id, item_sub_category_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sub_category_tag(item_sub_category_id, item_sub_category_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to remove tag from (required)
         :param str item_sub_category_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemSubCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_sub_category_tag_with_http_info(item_sub_category_id, item_sub_category_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_sub_category_tag_with_http_info(item_sub_category_id, item_sub_category_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemSubCategoryApi(object):
 
         Deletes an existing itemSubCategory tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_sub_category_tag_with_http_info(item_sub_category_id, item_sub_category_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_sub_category_tag_with_http_info(item_sub_category_id, item_sub_category_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to remove tag from (required)
         :param str item_sub_category_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id', 'item_sub_category_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemSubCategoryApi(object):
 
         Returns a duplicated itemSubCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_sub_category_by_id(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_sub_category_by_id(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to be duplicated. (required)
         :return: ItemSubCategory
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_sub_category_by_id_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_sub_category_by_id_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemSubCategoryApi(object):
 
         Returns a duplicated itemSubCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_sub_category_by_id_with_http_info(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_sub_category_by_id_with_http_info(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to be duplicated. (required)
         :return: ItemSubCategory
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type='ItemSubCategory',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemSubCategoryApi(object):
 
         Returns the list of itemSubCategorys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sub_category_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sub_category_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemSubCategoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_sub_category_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_sub_category_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemSubCategoryApi(object):
 
         Returns the list of itemSubCategorys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sub_category_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sub_category_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type='list[ItemSubCategory]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemSubCategoryApi(object):
 
         Returns the itemSubCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sub_category_by_id(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sub_category_by_id(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to be returned. (required)
         :return: ItemSubCategory
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_sub_category_by_id_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_sub_category_by_id_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemSubCategoryApi(object):
 
         Returns the itemSubCategory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sub_category_by_id_with_http_info(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sub_category_by_id_with_http_info(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to be returned. (required)
         :return: ItemSubCategory
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type='ItemSubCategory',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemSubCategoryApi(object):
 
         Get all existing itemSubCategory files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sub_category_files(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sub_category_files(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_sub_category_files_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_sub_category_files_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemSubCategoryApi(object):
 
         Get all existing itemSubCategory files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sub_category_files_with_http_info(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sub_category_files_with_http_info(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemSubCategoryApi(object):
 
         Get all existing itemSubCategory tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sub_category_tags(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sub_category_tags(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_sub_category_tags_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_sub_category_tags_with_http_info(item_sub_category_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemSubCategoryApi(object):
 
         Get all existing itemSubCategory tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_sub_category_tags_with_http_info(item_sub_category_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_sub_category_tags_with_http_info(item_sub_category_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_sub_category_id: Id of the itemSubCategory to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['item_sub_category_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemSubCategoryApi(object):
 
         Updates an existing itemSubCategory using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_sub_category(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_sub_category(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSubCategory body: ItemSubCategory to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_sub_category_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_sub_category_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemSubCategoryApi(object):
 
         Updates an existing itemSubCategory using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_sub_category_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_sub_category_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSubCategory body: ItemSubCategory to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemSubCategoryApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemSubCategoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/item_summary_code_api.py
+++ b/Infoplus/api/item_summary_code_api.py
@@ -38,18 +38,18 @@ class ItemSummaryCodeApi(object):
 
         Inserts a new itemSummaryCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSummaryCode body: ItemSummaryCode to be inserted. (required)
         :return: ItemSummaryCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_summary_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_summary_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ItemSummaryCodeApi(object):
 
         Inserts a new itemSummaryCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSummaryCode body: ItemSummaryCode to be inserted. (required)
         :return: ItemSummaryCode
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type='ItemSummaryCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ItemSummaryCodeApi(object):
 
         Adds an audit to an existing itemSummaryCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code_audit(item_summary_code_id, item_summary_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code_audit(item_summary_code_id, item_summary_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to add an audit to (required)
         :param str item_summary_code_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ItemSummaryCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_summary_code_audit_with_http_info(item_summary_code_id, item_summary_code_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_summary_code_audit_with_http_info(item_summary_code_id, item_summary_code_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ItemSummaryCodeApi(object):
 
         Adds an audit to an existing itemSummaryCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code_audit_with_http_info(item_summary_code_id, item_summary_code_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code_audit_with_http_info(item_summary_code_id, item_summary_code_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to add an audit to (required)
         :param str item_summary_code_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id', 'item_summary_code_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ItemSummaryCodeApi(object):
 
         Adds a file to an existing itemSummaryCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code_file(item_summary_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code_file(item_summary_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ItemSummaryCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_summary_code_file_with_http_info(item_summary_code_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_summary_code_file_with_http_info(item_summary_code_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ItemSummaryCodeApi(object):
 
         Adds a file to an existing itemSummaryCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code_file_with_http_info(item_summary_code_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code_file_with_http_info(item_summary_code_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ItemSummaryCodeApi(object):
 
         Adds a file to an existing itemSummaryCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code_file_by_url(body, item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code_file_by_url(body, item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_summary_code_id: Id of the itemSummaryCode to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ItemSummaryCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_summary_code_file_by_url_with_http_info(body, item_summary_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_summary_code_file_by_url_with_http_info(body, item_summary_code_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ItemSummaryCodeApi(object):
 
         Adds a file to an existing itemSummaryCode by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code_file_by_url_with_http_info(body, item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code_file_by_url_with_http_info(body, item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int item_summary_code_id: Id of the itemSummaryCode to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['body', 'item_summary_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ItemSummaryCodeApi(object):
 
         Adds a tag to an existing itemSummaryCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code_tag(item_summary_code_id, item_summary_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code_tag(item_summary_code_id, item_summary_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to add a tag to (required)
         :param str item_summary_code_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ItemSummaryCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_item_summary_code_tag_with_http_info(item_summary_code_id, item_summary_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_item_summary_code_tag_with_http_info(item_summary_code_id, item_summary_code_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ItemSummaryCodeApi(object):
 
         Adds a tag to an existing itemSummaryCode.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_item_summary_code_tag_with_http_info(item_summary_code_id, item_summary_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_item_summary_code_tag_with_http_info(item_summary_code_id, item_summary_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to add a tag to (required)
         :param str item_summary_code_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id', 'item_summary_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ItemSummaryCodeApi(object):
 
         Deletes the itemSummaryCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_summary_code(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_summary_code(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_summary_code_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_summary_code_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ItemSummaryCodeApi(object):
 
         Deletes the itemSummaryCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_summary_code_with_http_info(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_summary_code_with_http_info(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ItemSummaryCodeApi(object):
 
         Deletes an existing itemSummaryCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_summary_code_file(item_summary_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_summary_code_file(item_summary_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ItemSummaryCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_summary_code_file_with_http_info(item_summary_code_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_summary_code_file_with_http_info(item_summary_code_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ItemSummaryCodeApi(object):
 
         Deletes an existing itemSummaryCode file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_summary_code_file_with_http_info(item_summary_code_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_summary_code_file_with_http_info(item_summary_code_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ItemSummaryCodeApi(object):
 
         Deletes an existing itemSummaryCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_summary_code_tag(item_summary_code_id, item_summary_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_summary_code_tag(item_summary_code_id, item_summary_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to remove tag from (required)
         :param str item_summary_code_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ItemSummaryCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_item_summary_code_tag_with_http_info(item_summary_code_id, item_summary_code_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_item_summary_code_tag_with_http_info(item_summary_code_id, item_summary_code_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ItemSummaryCodeApi(object):
 
         Deletes an existing itemSummaryCode tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_item_summary_code_tag_with_http_info(item_summary_code_id, item_summary_code_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_item_summary_code_tag_with_http_info(item_summary_code_id, item_summary_code_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to remove tag from (required)
         :param str item_summary_code_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id', 'item_summary_code_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ItemSummaryCodeApi(object):
 
         Returns a duplicated itemSummaryCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_summary_code_by_id(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_summary_code_by_id(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to be duplicated. (required)
         :return: ItemSummaryCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_item_summary_code_by_id_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_item_summary_code_by_id_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ItemSummaryCodeApi(object):
 
         Returns a duplicated itemSummaryCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_item_summary_code_by_id_with_http_info(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_item_summary_code_by_id_with_http_info(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to be duplicated. (required)
         :return: ItemSummaryCode
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type='ItemSummaryCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ItemSummaryCodeApi(object):
 
         Returns the list of itemSummaryCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_summary_code_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_summary_code_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ItemSummaryCodeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_summary_code_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_item_summary_code_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ItemSummaryCodeApi(object):
 
         Returns the list of itemSummaryCodes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_summary_code_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_summary_code_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type='list[ItemSummaryCode]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ItemSummaryCodeApi(object):
 
         Returns the itemSummaryCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_summary_code_by_id(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_summary_code_by_id(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to be returned. (required)
         :return: ItemSummaryCode
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_summary_code_by_id_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_summary_code_by_id_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ItemSummaryCodeApi(object):
 
         Returns the itemSummaryCode identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_summary_code_by_id_with_http_info(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_summary_code_by_id_with_http_info(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to be returned. (required)
         :return: ItemSummaryCode
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type='ItemSummaryCode',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ItemSummaryCodeApi(object):
 
         Get all existing itemSummaryCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_summary_code_files(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_summary_code_files(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_summary_code_files_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_summary_code_files_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ItemSummaryCodeApi(object):
 
         Get all existing itemSummaryCode files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_summary_code_files_with_http_info(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_summary_code_files_with_http_info(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ItemSummaryCodeApi(object):
 
         Get all existing itemSummaryCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_summary_code_tags(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_summary_code_tags(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_item_summary_code_tags_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_item_summary_code_tags_with_http_info(item_summary_code_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ItemSummaryCodeApi(object):
 
         Get all existing itemSummaryCode tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_item_summary_code_tags_with_http_info(item_summary_code_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_item_summary_code_tags_with_http_info(item_summary_code_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int item_summary_code_id: Id of the itemSummaryCode to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['item_summary_code_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ItemSummaryCodeApi(object):
 
         Updates an existing itemSummaryCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_summary_code(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_summary_code(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSummaryCode body: ItemSummaryCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_item_summary_code_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_item_summary_code_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ItemSummaryCodeApi(object):
 
         Updates an existing itemSummaryCode using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_item_summary_code_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_item_summary_code_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ItemSummaryCode body: ItemSummaryCode to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ItemSummaryCodeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ItemSummaryCodeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/job_api.py
+++ b/Infoplus/api/job_api.py
@@ -38,18 +38,18 @@ class JobApi(object):
 
         Inserts a new job using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Job body: Job to be inserted. (required)
         :return: Job
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class JobApi(object):
 
         Inserts a new job using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Job body: Job to be inserted. (required)
         :return: Job
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class JobApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class JobApi(object):
             files=local_var_files,
             response_type='Job',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class JobApi(object):
 
         Adds an audit to an existing job.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_audit(job_id, job_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_audit(job_id, job_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to add an audit to (required)
         :param str job_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class JobApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_audit_with_http_info(job_id, job_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_audit_with_http_info(job_id, job_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class JobApi(object):
 
         Adds an audit to an existing job.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_audit_with_http_info(job_id, job_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_audit_with_http_info(job_id, job_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to add an audit to (required)
         :param str job_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id', 'job_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class JobApi(object):
 
         Adds a file to an existing job.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_file(job_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_file(job_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class JobApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_file_with_http_info(job_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_file_with_http_info(job_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class JobApi(object):
 
         Adds a file to an existing job.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_file_with_http_info(job_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_file_with_http_info(job_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class JobApi(object):
 
         Adds a file to an existing job by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_file_by_url(body, job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_file_by_url(body, job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_id: Id of the job to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class JobApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_file_by_url_with_http_info(body, job_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_file_by_url_with_http_info(body, job_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class JobApi(object):
 
         Adds a file to an existing job by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_file_by_url_with_http_info(body, job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_file_by_url_with_http_info(body, job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_id: Id of the job to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class JobApi(object):
         """
 
         all_params = ['body', 'job_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class JobApi(object):
 
         Adds a tag to an existing job.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_tag(job_id, job_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_tag(job_id, job_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to add a tag to (required)
         :param str job_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class JobApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_tag_with_http_info(job_id, job_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_tag_with_http_info(job_id, job_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class JobApi(object):
 
         Adds a tag to an existing job.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_tag_with_http_info(job_id, job_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_tag_with_http_info(job_id, job_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to add a tag to (required)
         :param str job_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id', 'job_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class JobApi(object):
 
         Deletes the job identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_with_http_info(job_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_with_http_info(job_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class JobApi(object):
 
         Deletes the job identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_with_http_info(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_with_http_info(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class JobApi(object):
 
         Deletes an existing job file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_file(job_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_file(job_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class JobApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_file_with_http_info(job_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_file_with_http_info(job_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class JobApi(object):
 
         Deletes an existing job file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_file_with_http_info(job_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_file_with_http_info(job_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class JobApi(object):
 
         Deletes an existing job tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_tag(job_id, job_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_tag(job_id, job_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to remove tag from (required)
         :param str job_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class JobApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_tag_with_http_info(job_id, job_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_tag_with_http_info(job_id, job_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class JobApi(object):
 
         Deletes an existing job tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_tag_with_http_info(job_id, job_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_tag_with_http_info(job_id, job_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to remove tag from (required)
         :param str job_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id', 'job_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class JobApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.execute_job(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.execute_job(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExecuteJobInputAPIModel body: Input data for ExecuteJob process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.execute_job_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.execute_job_with_http_info(body, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class JobApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.execute_job_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.execute_job_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExecuteJobInputAPIModel body: Input data for ExecuteJob process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class JobApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class JobApi(object):
             files=local_var_files,
             response_type='list[ProcessOutputAPIModel]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,18 +957,18 @@ class JobApi(object):
 
         Returns a duplicated job identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_by_id(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_by_id(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to be duplicated. (required)
         :return: Job
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_job_by_id_with_http_info(job_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_job_by_id_with_http_info(job_id, **kwargs)  # noqa: E501
@@ -979,11 +979,11 @@ class JobApi(object):
 
         Returns a duplicated job identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_by_id_with_http_info(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_by_id_with_http_info(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to be duplicated. (required)
         :return: Job
                  If the method is called asynchronously,
@@ -991,7 +991,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1041,7 +1041,7 @@ class JobApi(object):
             files=local_var_files,
             response_type='Job',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1052,11 +1052,11 @@ class JobApi(object):
 
         Returns the list of jobs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1066,7 +1066,7 @@ class JobApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_job_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -1077,11 +1077,11 @@ class JobApi(object):
 
         Returns the list of jobs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1092,7 +1092,7 @@ class JobApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class JobApi(object):
             files=local_var_files,
             response_type='list[Job]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class JobApi(object):
 
         Returns the job identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_by_id(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_by_id(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to be returned. (required)
         :return: Job
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_by_id_with_http_info(job_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_by_id_with_http_info(job_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class JobApi(object):
 
         Returns the job identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_by_id_with_http_info(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_by_id_with_http_info(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to be returned. (required)
         :return: Job
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class JobApi(object):
             files=local_var_files,
             response_type='Job',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class JobApi(object):
 
         Get all existing job files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_files(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_files(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_files_with_http_info(job_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_files_with_http_info(job_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class JobApi(object):
 
         Get all existing job files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_files_with_http_info(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_files_with_http_info(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class JobApi(object):
 
         Get all existing job tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_tags(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_tags(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_tags_with_http_info(job_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_tags_with_http_info(job_id, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class JobApi(object):
 
         Get all existing job tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_tags_with_http_info(job_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_tags_with_http_info(job_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_id: Id of the job to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class JobApi(object):
         """
 
         all_params = ['job_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1429,7 +1429,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1440,18 +1440,18 @@ class JobApi(object):
 
         Updates an existing job using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Job body: Job to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_job_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_job_with_http_info(body, **kwargs)  # noqa: E501
@@ -1462,11 +1462,11 @@ class JobApi(object):
 
         Updates an existing job using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Job body: Job to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1474,7 +1474,7 @@ class JobApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1528,7 +1528,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1539,18 +1539,18 @@ class JobApi(object):
 
         Updates an existing job custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Job body: Job to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_job_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_job_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1561,11 +1561,11 @@ class JobApi(object):
 
         Updates an existing job custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Job body: Job to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1573,7 +1573,7 @@ class JobApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1627,7 +1627,7 @@ class JobApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/job_recipe_api.py
+++ b/Infoplus/api/job_recipe_api.py
@@ -38,18 +38,18 @@ class JobRecipeApi(object):
 
         Inserts a new jobRecipe using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobRecipe body: JobRecipe to be inserted. (required)
         :return: JobRecipe
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_recipe_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_recipe_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class JobRecipeApi(object):
 
         Inserts a new jobRecipe using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobRecipe body: JobRecipe to be inserted. (required)
         :return: JobRecipe
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type='JobRecipe',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class JobRecipeApi(object):
 
         Adds an audit to an existing jobRecipe.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe_audit(job_recipe_id, job_recipe_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe_audit(job_recipe_id, job_recipe_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to add an audit to (required)
         :param str job_recipe_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class JobRecipeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_recipe_audit_with_http_info(job_recipe_id, job_recipe_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_recipe_audit_with_http_info(job_recipe_id, job_recipe_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class JobRecipeApi(object):
 
         Adds an audit to an existing jobRecipe.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe_audit_with_http_info(job_recipe_id, job_recipe_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe_audit_with_http_info(job_recipe_id, job_recipe_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to add an audit to (required)
         :param str job_recipe_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id', 'job_recipe_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class JobRecipeApi(object):
 
         Adds a file to an existing jobRecipe.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe_file(job_recipe_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe_file(job_recipe_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class JobRecipeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_recipe_file_with_http_info(job_recipe_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_recipe_file_with_http_info(job_recipe_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class JobRecipeApi(object):
 
         Adds a file to an existing jobRecipe.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe_file_with_http_info(job_recipe_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe_file_with_http_info(job_recipe_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class JobRecipeApi(object):
 
         Adds a file to an existing jobRecipe by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe_file_by_url(body, job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe_file_by_url(body, job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_recipe_id: Id of the jobRecipe to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class JobRecipeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_recipe_file_by_url_with_http_info(body, job_recipe_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_recipe_file_by_url_with_http_info(body, job_recipe_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class JobRecipeApi(object):
 
         Adds a file to an existing jobRecipe by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe_file_by_url_with_http_info(body, job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe_file_by_url_with_http_info(body, job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_recipe_id: Id of the jobRecipe to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['body', 'job_recipe_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class JobRecipeApi(object):
 
         Adds a tag to an existing jobRecipe.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe_tag(job_recipe_id, job_recipe_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe_tag(job_recipe_id, job_recipe_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to add a tag to (required)
         :param str job_recipe_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class JobRecipeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_recipe_tag_with_http_info(job_recipe_id, job_recipe_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_recipe_tag_with_http_info(job_recipe_id, job_recipe_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class JobRecipeApi(object):
 
         Adds a tag to an existing jobRecipe.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_recipe_tag_with_http_info(job_recipe_id, job_recipe_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_recipe_tag_with_http_info(job_recipe_id, job_recipe_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to add a tag to (required)
         :param str job_recipe_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id', 'job_recipe_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class JobRecipeApi(object):
 
         Deletes the jobRecipe identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_recipe(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_recipe(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_recipe_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_recipe_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class JobRecipeApi(object):
 
         Deletes the jobRecipe identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_recipe_with_http_info(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_recipe_with_http_info(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class JobRecipeApi(object):
 
         Deletes an existing jobRecipe file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_recipe_file(job_recipe_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_recipe_file(job_recipe_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class JobRecipeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_recipe_file_with_http_info(job_recipe_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_recipe_file_with_http_info(job_recipe_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class JobRecipeApi(object):
 
         Deletes an existing jobRecipe file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_recipe_file_with_http_info(job_recipe_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_recipe_file_with_http_info(job_recipe_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class JobRecipeApi(object):
 
         Deletes an existing jobRecipe tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_recipe_tag(job_recipe_id, job_recipe_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_recipe_tag(job_recipe_id, job_recipe_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to remove tag from (required)
         :param str job_recipe_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class JobRecipeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_recipe_tag_with_http_info(job_recipe_id, job_recipe_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_recipe_tag_with_http_info(job_recipe_id, job_recipe_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class JobRecipeApi(object):
 
         Deletes an existing jobRecipe tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_recipe_tag_with_http_info(job_recipe_id, job_recipe_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_recipe_tag_with_http_info(job_recipe_id, job_recipe_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to remove tag from (required)
         :param str job_recipe_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id', 'job_recipe_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class JobRecipeApi(object):
 
         Returns a duplicated jobRecipe identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_recipe_by_id(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_recipe_by_id(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to be duplicated. (required)
         :return: JobRecipe
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_job_recipe_by_id_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_job_recipe_by_id_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class JobRecipeApi(object):
 
         Returns a duplicated jobRecipe identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_recipe_by_id_with_http_info(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_recipe_by_id_with_http_info(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to be duplicated. (required)
         :return: JobRecipe
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type='JobRecipe',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class JobRecipeApi(object):
 
         Returns the list of jobRecipes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_recipe_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_recipe_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class JobRecipeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_recipe_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_job_recipe_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class JobRecipeApi(object):
 
         Returns the list of jobRecipes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_recipe_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_recipe_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type='list[JobRecipe]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class JobRecipeApi(object):
 
         Returns the jobRecipe identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_recipe_by_id(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_recipe_by_id(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to be returned. (required)
         :return: JobRecipe
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_recipe_by_id_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_recipe_by_id_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class JobRecipeApi(object):
 
         Returns the jobRecipe identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_recipe_by_id_with_http_info(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_recipe_by_id_with_http_info(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to be returned. (required)
         :return: JobRecipe
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type='JobRecipe',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class JobRecipeApi(object):
 
         Get all existing jobRecipe files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_recipe_files(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_recipe_files(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_recipe_files_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_recipe_files_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class JobRecipeApi(object):
 
         Get all existing jobRecipe files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_recipe_files_with_http_info(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_recipe_files_with_http_info(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class JobRecipeApi(object):
 
         Get all existing jobRecipe tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_recipe_tags(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_recipe_tags(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_recipe_tags_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_recipe_tags_with_http_info(job_recipe_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class JobRecipeApi(object):
 
         Get all existing jobRecipe tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_recipe_tags_with_http_info(job_recipe_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_recipe_tags_with_http_info(job_recipe_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_recipe_id: Id of the jobRecipe to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['job_recipe_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class JobRecipeApi(object):
 
         Updates an existing jobRecipe using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_recipe(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_recipe(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobRecipe body: JobRecipe to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_job_recipe_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_job_recipe_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class JobRecipeApi(object):
 
         Updates an existing jobRecipe using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_recipe_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_recipe_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobRecipe body: JobRecipe to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class JobRecipeApi(object):
 
         Updates an existing jobRecipe custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_recipe_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_recipe_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobRecipe body: JobRecipe to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_job_recipe_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_job_recipe_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class JobRecipeApi(object):
 
         Updates an existing jobRecipe custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_recipe_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_recipe_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobRecipe body: JobRecipe to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class JobRecipeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class JobRecipeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/job_time_activity_api.py
+++ b/Infoplus/api/job_time_activity_api.py
@@ -38,18 +38,18 @@ class JobTimeActivityApi(object):
 
         Inserts a new jobTimeActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTimeActivity body: JobTimeActivity to be inserted. (required)
         :return: JobTimeActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class JobTimeActivityApi(object):
 
         Inserts a new jobTimeActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTimeActivity body: JobTimeActivity to be inserted. (required)
         :return: JobTimeActivity
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type='JobTimeActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class JobTimeActivityApi(object):
 
         Adds an audit to an existing jobTimeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity_audit(job_time_activity_id, job_time_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity_audit(job_time_activity_id, job_time_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to add an audit to (required)
         :param str job_time_activity_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class JobTimeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_activity_audit_with_http_info(job_time_activity_id, job_time_activity_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_activity_audit_with_http_info(job_time_activity_id, job_time_activity_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class JobTimeActivityApi(object):
 
         Adds an audit to an existing jobTimeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity_audit_with_http_info(job_time_activity_id, job_time_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity_audit_with_http_info(job_time_activity_id, job_time_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to add an audit to (required)
         :param str job_time_activity_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id', 'job_time_activity_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class JobTimeActivityApi(object):
 
         Adds a file to an existing jobTimeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity_file(job_time_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity_file(job_time_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class JobTimeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_activity_file_with_http_info(job_time_activity_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_activity_file_with_http_info(job_time_activity_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class JobTimeActivityApi(object):
 
         Adds a file to an existing jobTimeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity_file_with_http_info(job_time_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity_file_with_http_info(job_time_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class JobTimeActivityApi(object):
 
         Adds a file to an existing jobTimeActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity_file_by_url(body, job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity_file_by_url(body, job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_time_activity_id: Id of the jobTimeActivity to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class JobTimeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_activity_file_by_url_with_http_info(body, job_time_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_activity_file_by_url_with_http_info(body, job_time_activity_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class JobTimeActivityApi(object):
 
         Adds a file to an existing jobTimeActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity_file_by_url_with_http_info(body, job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity_file_by_url_with_http_info(body, job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_time_activity_id: Id of the jobTimeActivity to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['body', 'job_time_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class JobTimeActivityApi(object):
 
         Adds a tag to an existing jobTimeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity_tag(job_time_activity_id, job_time_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity_tag(job_time_activity_id, job_time_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to add a tag to (required)
         :param str job_time_activity_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class JobTimeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_activity_tag_with_http_info(job_time_activity_id, job_time_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_activity_tag_with_http_info(job_time_activity_id, job_time_activity_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class JobTimeActivityApi(object):
 
         Adds a tag to an existing jobTimeActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_activity_tag_with_http_info(job_time_activity_id, job_time_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_activity_tag_with_http_info(job_time_activity_id, job_time_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to add a tag to (required)
         :param str job_time_activity_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id', 'job_time_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class JobTimeActivityApi(object):
 
         Deletes the jobTimeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_activity(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_activity(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_time_activity_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_time_activity_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class JobTimeActivityApi(object):
 
         Deletes the jobTimeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_activity_with_http_info(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_activity_with_http_info(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class JobTimeActivityApi(object):
 
         Deletes an existing jobTimeActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_activity_file(job_time_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_activity_file(job_time_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class JobTimeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_time_activity_file_with_http_info(job_time_activity_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_time_activity_file_with_http_info(job_time_activity_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class JobTimeActivityApi(object):
 
         Deletes an existing jobTimeActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_activity_file_with_http_info(job_time_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_activity_file_with_http_info(job_time_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class JobTimeActivityApi(object):
 
         Deletes an existing jobTimeActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_activity_tag(job_time_activity_id, job_time_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_activity_tag(job_time_activity_id, job_time_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to remove tag from (required)
         :param str job_time_activity_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class JobTimeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_time_activity_tag_with_http_info(job_time_activity_id, job_time_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_time_activity_tag_with_http_info(job_time_activity_id, job_time_activity_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class JobTimeActivityApi(object):
 
         Deletes an existing jobTimeActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_activity_tag_with_http_info(job_time_activity_id, job_time_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_activity_tag_with_http_info(job_time_activity_id, job_time_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to remove tag from (required)
         :param str job_time_activity_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id', 'job_time_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class JobTimeActivityApi(object):
 
         Returns a duplicated jobTimeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_time_activity_by_id(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_time_activity_by_id(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to be duplicated. (required)
         :return: JobTimeActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_job_time_activity_by_id_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_job_time_activity_by_id_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class JobTimeActivityApi(object):
 
         Returns a duplicated jobTimeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_time_activity_by_id_with_http_info(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_time_activity_by_id_with_http_info(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to be duplicated. (required)
         :return: JobTimeActivity
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type='JobTimeActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class JobTimeActivityApi(object):
 
         Returns the list of jobTimeActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_activity_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_activity_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class JobTimeActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_time_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_job_time_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class JobTimeActivityApi(object):
 
         Returns the list of jobTimeActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_activity_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_activity_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type='list[JobTimeActivity]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class JobTimeActivityApi(object):
 
         Returns the jobTimeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_activity_by_id(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_activity_by_id(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to be returned. (required)
         :return: JobTimeActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_time_activity_by_id_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_time_activity_by_id_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class JobTimeActivityApi(object):
 
         Returns the jobTimeActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_activity_by_id_with_http_info(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_activity_by_id_with_http_info(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to be returned. (required)
         :return: JobTimeActivity
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type='JobTimeActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class JobTimeActivityApi(object):
 
         Get all existing jobTimeActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_activity_files(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_activity_files(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_time_activity_files_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_time_activity_files_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class JobTimeActivityApi(object):
 
         Get all existing jobTimeActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_activity_files_with_http_info(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_activity_files_with_http_info(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class JobTimeActivityApi(object):
 
         Get all existing jobTimeActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_activity_tags(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_activity_tags(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_time_activity_tags_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_time_activity_tags_with_http_info(job_time_activity_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class JobTimeActivityApi(object):
 
         Get all existing jobTimeActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_activity_tags_with_http_info(job_time_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_activity_tags_with_http_info(job_time_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_activity_id: Id of the jobTimeActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['job_time_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class JobTimeActivityApi(object):
 
         Updates an existing jobTimeActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_time_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_time_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTimeActivity body: JobTimeActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_job_time_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_job_time_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class JobTimeActivityApi(object):
 
         Updates an existing jobTimeActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_time_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_time_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTimeActivity body: JobTimeActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class JobTimeActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class JobTimeActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/job_time_api.py
+++ b/Infoplus/api/job_time_api.py
@@ -38,18 +38,18 @@ class JobTimeApi(object):
 
         Inserts a new jobTime using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTime body: JobTime to be inserted. (required)
         :return: JobTime
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class JobTimeApi(object):
 
         Inserts a new jobTime using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTime body: JobTime to be inserted. (required)
         :return: JobTime
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type='JobTime',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class JobTimeApi(object):
 
         Adds an audit to an existing jobTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_audit(job_time_id, job_time_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_audit(job_time_id, job_time_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to add an audit to (required)
         :param str job_time_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class JobTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_audit_with_http_info(job_time_id, job_time_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_audit_with_http_info(job_time_id, job_time_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class JobTimeApi(object):
 
         Adds an audit to an existing jobTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_audit_with_http_info(job_time_id, job_time_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_audit_with_http_info(job_time_id, job_time_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to add an audit to (required)
         :param str job_time_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id', 'job_time_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class JobTimeApi(object):
 
         Adds a file to an existing jobTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_file(job_time_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_file(job_time_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class JobTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_file_with_http_info(job_time_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_file_with_http_info(job_time_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class JobTimeApi(object):
 
         Adds a file to an existing jobTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_file_with_http_info(job_time_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_file_with_http_info(job_time_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class JobTimeApi(object):
 
         Adds a file to an existing jobTime by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_file_by_url(body, job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_file_by_url(body, job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_time_id: Id of the jobTime to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class JobTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_file_by_url_with_http_info(body, job_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_file_by_url_with_http_info(body, job_time_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class JobTimeApi(object):
 
         Adds a file to an existing jobTime by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_file_by_url_with_http_info(body, job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_file_by_url_with_http_info(body, job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_time_id: Id of the jobTime to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['body', 'job_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class JobTimeApi(object):
 
         Adds a tag to an existing jobTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_tag(job_time_id, job_time_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_tag(job_time_id, job_time_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to add a tag to (required)
         :param str job_time_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class JobTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_time_tag_with_http_info(job_time_id, job_time_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_time_tag_with_http_info(job_time_id, job_time_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class JobTimeApi(object):
 
         Adds a tag to an existing jobTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_time_tag_with_http_info(job_time_id, job_time_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_time_tag_with_http_info(job_time_id, job_time_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to add a tag to (required)
         :param str job_time_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id', 'job_time_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class JobTimeApi(object):
 
         Deletes the jobTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_time_with_http_info(job_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_time_with_http_info(job_time_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class JobTimeApi(object):
 
         Deletes the jobTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_with_http_info(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_with_http_info(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class JobTimeApi(object):
 
         Deletes an existing jobTime file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_file(job_time_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_file(job_time_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class JobTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_time_file_with_http_info(job_time_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_time_file_with_http_info(job_time_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class JobTimeApi(object):
 
         Deletes an existing jobTime file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_file_with_http_info(job_time_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_file_with_http_info(job_time_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class JobTimeApi(object):
 
         Deletes an existing jobTime tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_tag(job_time_id, job_time_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_tag(job_time_id, job_time_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to remove tag from (required)
         :param str job_time_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class JobTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_time_tag_with_http_info(job_time_id, job_time_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_time_tag_with_http_info(job_time_id, job_time_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class JobTimeApi(object):
 
         Deletes an existing jobTime tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_time_tag_with_http_info(job_time_id, job_time_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_time_tag_with_http_info(job_time_id, job_time_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to remove tag from (required)
         :param str job_time_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id', 'job_time_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class JobTimeApi(object):
 
         Returns a duplicated jobTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_time_by_id(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_time_by_id(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to be duplicated. (required)
         :return: JobTime
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_job_time_by_id_with_http_info(job_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_job_time_by_id_with_http_info(job_time_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class JobTimeApi(object):
 
         Returns a duplicated jobTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_time_by_id_with_http_info(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_time_by_id_with_http_info(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to be duplicated. (required)
         :return: JobTime
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type='JobTime',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class JobTimeApi(object):
 
         Returns the list of jobTimes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class JobTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_time_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_job_time_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class JobTimeApi(object):
 
         Returns the list of jobTimes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type='list[JobTime]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class JobTimeApi(object):
 
         Returns the jobTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_by_id(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_by_id(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to be returned. (required)
         :return: JobTime
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_time_by_id_with_http_info(job_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_time_by_id_with_http_info(job_time_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class JobTimeApi(object):
 
         Returns the jobTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_by_id_with_http_info(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_by_id_with_http_info(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to be returned. (required)
         :return: JobTime
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type='JobTime',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class JobTimeApi(object):
 
         Get all existing jobTime files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_files(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_files(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_time_files_with_http_info(job_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_time_files_with_http_info(job_time_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class JobTimeApi(object):
 
         Get all existing jobTime files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_files_with_http_info(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_files_with_http_info(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class JobTimeApi(object):
 
         Get all existing jobTime tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_tags(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_tags(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_time_tags_with_http_info(job_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_time_tags_with_http_info(job_time_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class JobTimeApi(object):
 
         Get all existing jobTime tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_time_tags_with_http_info(job_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_time_tags_with_http_info(job_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_time_id: Id of the jobTime to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['job_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class JobTimeApi(object):
 
         Updates an existing jobTime using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_time(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_time(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTime body: JobTime to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_job_time_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_job_time_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class JobTimeApi(object):
 
         Updates an existing jobTime using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_time_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_time_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTime body: JobTime to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class JobTimeApi(object):
 
         Updates an existing jobTime custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_time_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_time_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTime body: JobTime to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_job_time_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_job_time_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class JobTimeApi(object):
 
         Updates an existing jobTime custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_time_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_time_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobTime body: JobTime to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class JobTimeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class JobTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/job_type_api.py
+++ b/Infoplus/api/job_type_api.py
@@ -38,18 +38,18 @@ class JobTypeApi(object):
 
         Inserts a new jobType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobType body: JobType to be inserted. (required)
         :return: JobType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class JobTypeApi(object):
 
         Inserts a new jobType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobType body: JobType to be inserted. (required)
         :return: JobType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type='JobType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class JobTypeApi(object):
 
         Adds an audit to an existing jobType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type_audit(job_type_id, job_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type_audit(job_type_id, job_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to add an audit to (required)
         :param str job_type_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class JobTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_type_audit_with_http_info(job_type_id, job_type_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_type_audit_with_http_info(job_type_id, job_type_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class JobTypeApi(object):
 
         Adds an audit to an existing jobType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type_audit_with_http_info(job_type_id, job_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type_audit_with_http_info(job_type_id, job_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to add an audit to (required)
         :param str job_type_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id', 'job_type_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class JobTypeApi(object):
 
         Adds a file to an existing jobType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type_file(job_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type_file(job_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class JobTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_type_file_with_http_info(job_type_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_type_file_with_http_info(job_type_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class JobTypeApi(object):
 
         Adds a file to an existing jobType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type_file_with_http_info(job_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type_file_with_http_info(job_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class JobTypeApi(object):
 
         Adds a file to an existing jobType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type_file_by_url(body, job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type_file_by_url(body, job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_type_id: Id of the jobType to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class JobTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_type_file_by_url_with_http_info(body, job_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_type_file_by_url_with_http_info(body, job_type_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class JobTypeApi(object):
 
         Adds a file to an existing jobType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type_file_by_url_with_http_info(body, job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type_file_by_url_with_http_info(body, job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int job_type_id: Id of the jobType to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['body', 'job_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class JobTypeApi(object):
 
         Adds a tag to an existing jobType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type_tag(job_type_id, job_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type_tag(job_type_id, job_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to add a tag to (required)
         :param str job_type_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class JobTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_job_type_tag_with_http_info(job_type_id, job_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_job_type_tag_with_http_info(job_type_id, job_type_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class JobTypeApi(object):
 
         Adds a tag to an existing jobType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_job_type_tag_with_http_info(job_type_id, job_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_job_type_tag_with_http_info(job_type_id, job_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to add a tag to (required)
         :param str job_type_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id', 'job_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class JobTypeApi(object):
 
         Deletes the jobType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_type(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_type(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_type_with_http_info(job_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_type_with_http_info(job_type_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class JobTypeApi(object):
 
         Deletes the jobType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_type_with_http_info(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_type_with_http_info(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class JobTypeApi(object):
 
         Deletes an existing jobType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_type_file(job_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_type_file(job_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class JobTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_type_file_with_http_info(job_type_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_type_file_with_http_info(job_type_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class JobTypeApi(object):
 
         Deletes an existing jobType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_type_file_with_http_info(job_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_type_file_with_http_info(job_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class JobTypeApi(object):
 
         Deletes an existing jobType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_type_tag(job_type_id, job_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_type_tag(job_type_id, job_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to remove tag from (required)
         :param str job_type_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class JobTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_job_type_tag_with_http_info(job_type_id, job_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_job_type_tag_with_http_info(job_type_id, job_type_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class JobTypeApi(object):
 
         Deletes an existing jobType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_job_type_tag_with_http_info(job_type_id, job_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_job_type_tag_with_http_info(job_type_id, job_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to remove tag from (required)
         :param str job_type_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id', 'job_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class JobTypeApi(object):
 
         Returns a duplicated jobType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_type_by_id(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_type_by_id(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to be duplicated. (required)
         :return: JobType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_job_type_by_id_with_http_info(job_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_job_type_by_id_with_http_info(job_type_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class JobTypeApi(object):
 
         Returns a duplicated jobType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_job_type_by_id_with_http_info(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_job_type_by_id_with_http_info(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to be duplicated. (required)
         :return: JobType
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type='JobType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class JobTypeApi(object):
 
         Returns the list of jobTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_type_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_type_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class JobTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_type_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_job_type_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class JobTypeApi(object):
 
         Returns the list of jobTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_type_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_type_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type='list[JobType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class JobTypeApi(object):
 
         Returns the jobType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_type_by_id(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_type_by_id(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to be returned. (required)
         :return: JobType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_type_by_id_with_http_info(job_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_type_by_id_with_http_info(job_type_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class JobTypeApi(object):
 
         Returns the jobType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_type_by_id_with_http_info(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_type_by_id_with_http_info(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to be returned. (required)
         :return: JobType
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type='JobType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class JobTypeApi(object):
 
         Get all existing jobType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_type_files(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_type_files(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_type_files_with_http_info(job_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_type_files_with_http_info(job_type_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class JobTypeApi(object):
 
         Get all existing jobType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_type_files_with_http_info(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_type_files_with_http_info(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class JobTypeApi(object):
 
         Get all existing jobType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_type_tags(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_type_tags(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_job_type_tags_with_http_info(job_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_job_type_tags_with_http_info(job_type_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class JobTypeApi(object):
 
         Get all existing jobType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_job_type_tags_with_http_info(job_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_job_type_tags_with_http_info(job_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int job_type_id: Id of the jobType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['job_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class JobTypeApi(object):
 
         Updates an existing jobType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobType body: JobType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_job_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_job_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class JobTypeApi(object):
 
         Updates an existing jobType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobType body: JobType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class JobTypeApi(object):
 
         Updates an existing jobType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_type_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_type_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobType body: JobType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_job_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_job_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class JobTypeApi(object):
 
         Updates an existing jobType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_job_type_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_job_type_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param JobType body: JobType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class JobTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class JobTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/kit_api.py
+++ b/Infoplus/api/kit_api.py
@@ -38,18 +38,18 @@ class KitApi(object):
 
         Inserts a new kit using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Kit body: Kit to be inserted. (required)
         :return: Kit
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_kit_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_kit_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class KitApi(object):
 
         Inserts a new kit using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Kit body: Kit to be inserted. (required)
         :return: Kit
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class KitApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class KitApi(object):
             files=local_var_files,
             response_type='Kit',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class KitApi(object):
 
         Adds an audit to an existing kit.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit_audit(kit_id, kit_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit_audit(kit_id, kit_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to add an audit to (required)
         :param str kit_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class KitApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_kit_audit_with_http_info(kit_id, kit_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_kit_audit_with_http_info(kit_id, kit_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class KitApi(object):
 
         Adds an audit to an existing kit.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit_audit_with_http_info(kit_id, kit_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit_audit_with_http_info(kit_id, kit_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to add an audit to (required)
         :param str kit_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id', 'kit_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class KitApi(object):
 
         Adds a file to an existing kit.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit_file(kit_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit_file(kit_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class KitApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_kit_file_with_http_info(kit_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_kit_file_with_http_info(kit_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class KitApi(object):
 
         Adds a file to an existing kit.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit_file_with_http_info(kit_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit_file_with_http_info(kit_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class KitApi(object):
 
         Adds a file to an existing kit by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit_file_by_url(body, kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit_file_by_url(body, kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int kit_id: Id of the kit to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class KitApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_kit_file_by_url_with_http_info(body, kit_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_kit_file_by_url_with_http_info(body, kit_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class KitApi(object):
 
         Adds a file to an existing kit by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit_file_by_url_with_http_info(body, kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit_file_by_url_with_http_info(body, kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int kit_id: Id of the kit to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class KitApi(object):
         """
 
         all_params = ['body', 'kit_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class KitApi(object):
 
         Adds a tag to an existing kit.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit_tag(kit_id, kit_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit_tag(kit_id, kit_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to add a tag to (required)
         :param str kit_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class KitApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_kit_tag_with_http_info(kit_id, kit_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_kit_tag_with_http_info(kit_id, kit_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class KitApi(object):
 
         Adds a tag to an existing kit.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_kit_tag_with_http_info(kit_id, kit_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_kit_tag_with_http_info(kit_id, kit_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to add a tag to (required)
         :param str kit_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id', 'kit_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class KitApi(object):
 
         Deletes the kit identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_kit(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_kit(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_kit_with_http_info(kit_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_kit_with_http_info(kit_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class KitApi(object):
 
         Deletes the kit identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_kit_with_http_info(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_kit_with_http_info(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class KitApi(object):
 
         Deletes an existing kit file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_kit_file(kit_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_kit_file(kit_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class KitApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_kit_file_with_http_info(kit_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_kit_file_with_http_info(kit_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class KitApi(object):
 
         Deletes an existing kit file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_kit_file_with_http_info(kit_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_kit_file_with_http_info(kit_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class KitApi(object):
 
         Deletes an existing kit tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_kit_tag(kit_id, kit_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_kit_tag(kit_id, kit_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to remove tag from (required)
         :param str kit_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class KitApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_kit_tag_with_http_info(kit_id, kit_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_kit_tag_with_http_info(kit_id, kit_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class KitApi(object):
 
         Deletes an existing kit tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_kit_tag_with_http_info(kit_id, kit_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_kit_tag_with_http_info(kit_id, kit_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to remove tag from (required)
         :param str kit_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id', 'kit_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class KitApi(object):
 
         Returns a duplicated kit identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_kit_by_id(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_kit_by_id(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to be duplicated. (required)
         :return: Kit
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_kit_by_id_with_http_info(kit_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_kit_by_id_with_http_info(kit_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class KitApi(object):
 
         Returns a duplicated kit identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_kit_by_id_with_http_info(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_kit_by_id_with_http_info(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to be duplicated. (required)
         :return: Kit
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class KitApi(object):
             files=local_var_files,
             response_type='Kit',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class KitApi(object):
 
         Returns the list of kits that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_kit_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_kit_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class KitApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_kit_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_kit_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class KitApi(object):
 
         Returns the list of kits that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_kit_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_kit_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class KitApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class KitApi(object):
             files=local_var_files,
             response_type='list[Kit]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class KitApi(object):
 
         Returns the kit identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_kit_by_id(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_kit_by_id(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to be returned. (required)
         :return: Kit
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_kit_by_id_with_http_info(kit_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_kit_by_id_with_http_info(kit_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class KitApi(object):
 
         Returns the kit identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_kit_by_id_with_http_info(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_kit_by_id_with_http_info(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to be returned. (required)
         :return: Kit
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class KitApi(object):
             files=local_var_files,
             response_type='Kit',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class KitApi(object):
 
         Get all existing kit files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_kit_files(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_kit_files(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_kit_files_with_http_info(kit_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_kit_files_with_http_info(kit_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class KitApi(object):
 
         Get all existing kit files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_kit_files_with_http_info(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_kit_files_with_http_info(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class KitApi(object):
 
         Get all existing kit tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_kit_tags(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_kit_tags(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_kit_tags_with_http_info(kit_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_kit_tags_with_http_info(kit_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class KitApi(object):
 
         Get all existing kit tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_kit_tags_with_http_info(kit_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_kit_tags_with_http_info(kit_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int kit_id: Id of the kit to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class KitApi(object):
         """
 
         all_params = ['kit_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class KitApi(object):
 
         Updates an existing kit using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_kit(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_kit(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Kit body: Kit to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_kit_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_kit_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class KitApi(object):
 
         Updates an existing kit using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_kit_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_kit_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Kit body: Kit to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class KitApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class KitApi(object):
 
         Updates an existing kit custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_kit_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_kit_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Kit body: Kit to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_kit_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_kit_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class KitApi(object):
 
         Updates an existing kit custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_kit_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_kit_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Kit body: Kit to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class KitApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class KitApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/legacy_lowstock_contact_api.py
+++ b/Infoplus/api/legacy_lowstock_contact_api.py
@@ -38,18 +38,18 @@ class LegacyLowstockContactApi(object):
 
         Inserts a new legacyLowstockContact using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LegacyLowstockContact body: LegacyLowstockContact to be inserted. (required)
         :return: LegacyLowstockContact
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_legacy_lowstock_contact_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_legacy_lowstock_contact_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class LegacyLowstockContactApi(object):
 
         Inserts a new legacyLowstockContact using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LegacyLowstockContact body: LegacyLowstockContact to be inserted. (required)
         :return: LegacyLowstockContact
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type='LegacyLowstockContact',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class LegacyLowstockContactApi(object):
 
         Adds an audit to an existing legacyLowstockContact.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact_audit(legacy_lowstock_contact_id, legacy_lowstock_contact_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact_audit(legacy_lowstock_contact_id, legacy_lowstock_contact_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to add an audit to (required)
         :param str legacy_lowstock_contact_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class LegacyLowstockContactApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_legacy_lowstock_contact_audit_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_legacy_lowstock_contact_audit_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class LegacyLowstockContactApi(object):
 
         Adds an audit to an existing legacyLowstockContact.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact_audit_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact_audit_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to add an audit to (required)
         :param str legacy_lowstock_contact_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id', 'legacy_lowstock_contact_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class LegacyLowstockContactApi(object):
 
         Adds a file to an existing legacyLowstockContact.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact_file(legacy_lowstock_contact_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact_file(legacy_lowstock_contact_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class LegacyLowstockContactApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_legacy_lowstock_contact_file_with_http_info(legacy_lowstock_contact_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_legacy_lowstock_contact_file_with_http_info(legacy_lowstock_contact_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class LegacyLowstockContactApi(object):
 
         Adds a file to an existing legacyLowstockContact.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact_file_with_http_info(legacy_lowstock_contact_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact_file_with_http_info(legacy_lowstock_contact_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class LegacyLowstockContactApi(object):
 
         Adds a file to an existing legacyLowstockContact by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact_file_by_url(body, legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact_file_by_url(body, legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class LegacyLowstockContactApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_legacy_lowstock_contact_file_by_url_with_http_info(body, legacy_lowstock_contact_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_legacy_lowstock_contact_file_by_url_with_http_info(body, legacy_lowstock_contact_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class LegacyLowstockContactApi(object):
 
         Adds a file to an existing legacyLowstockContact by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact_file_by_url_with_http_info(body, legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact_file_by_url_with_http_info(body, legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['body', 'legacy_lowstock_contact_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class LegacyLowstockContactApi(object):
 
         Adds a tag to an existing legacyLowstockContact.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact_tag(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact_tag(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to add a tag to (required)
         :param str legacy_lowstock_contact_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class LegacyLowstockContactApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_legacy_lowstock_contact_tag_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_legacy_lowstock_contact_tag_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class LegacyLowstockContactApi(object):
 
         Adds a tag to an existing legacyLowstockContact.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_legacy_lowstock_contact_tag_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_legacy_lowstock_contact_tag_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to add a tag to (required)
         :param str legacy_lowstock_contact_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id', 'legacy_lowstock_contact_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class LegacyLowstockContactApi(object):
 
         Deletes the legacyLowstockContact identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_legacy_lowstock_contact(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_legacy_lowstock_contact(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_legacy_lowstock_contact_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_legacy_lowstock_contact_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class LegacyLowstockContactApi(object):
 
         Deletes the legacyLowstockContact identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_legacy_lowstock_contact_with_http_info(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_legacy_lowstock_contact_with_http_info(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class LegacyLowstockContactApi(object):
 
         Deletes an existing legacyLowstockContact file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_legacy_lowstock_contact_file(legacy_lowstock_contact_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_legacy_lowstock_contact_file(legacy_lowstock_contact_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class LegacyLowstockContactApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_legacy_lowstock_contact_file_with_http_info(legacy_lowstock_contact_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_legacy_lowstock_contact_file_with_http_info(legacy_lowstock_contact_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class LegacyLowstockContactApi(object):
 
         Deletes an existing legacyLowstockContact file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_legacy_lowstock_contact_file_with_http_info(legacy_lowstock_contact_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_legacy_lowstock_contact_file_with_http_info(legacy_lowstock_contact_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class LegacyLowstockContactApi(object):
 
         Deletes an existing legacyLowstockContact tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_legacy_lowstock_contact_tag(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_legacy_lowstock_contact_tag(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to remove tag from (required)
         :param str legacy_lowstock_contact_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class LegacyLowstockContactApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_legacy_lowstock_contact_tag_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_legacy_lowstock_contact_tag_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class LegacyLowstockContactApi(object):
 
         Deletes an existing legacyLowstockContact tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_legacy_lowstock_contact_tag_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_legacy_lowstock_contact_tag_with_http_info(legacy_lowstock_contact_id, legacy_lowstock_contact_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to remove tag from (required)
         :param str legacy_lowstock_contact_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id', 'legacy_lowstock_contact_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class LegacyLowstockContactApi(object):
 
         Returns a duplicated legacyLowstockContact identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_legacy_lowstock_contact_by_id(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_legacy_lowstock_contact_by_id(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to be duplicated. (required)
         :return: LegacyLowstockContact
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_legacy_lowstock_contact_by_id_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_legacy_lowstock_contact_by_id_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class LegacyLowstockContactApi(object):
 
         Returns a duplicated legacyLowstockContact identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_legacy_lowstock_contact_by_id_with_http_info(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_legacy_lowstock_contact_by_id_with_http_info(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to be duplicated. (required)
         :return: LegacyLowstockContact
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type='LegacyLowstockContact',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class LegacyLowstockContactApi(object):
 
         Returns the list of legacyLowstockContacts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_legacy_lowstock_contact_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_legacy_lowstock_contact_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class LegacyLowstockContactApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_legacy_lowstock_contact_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_legacy_lowstock_contact_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class LegacyLowstockContactApi(object):
 
         Returns the list of legacyLowstockContacts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_legacy_lowstock_contact_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_legacy_lowstock_contact_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type='list[LegacyLowstockContact]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class LegacyLowstockContactApi(object):
 
         Returns the legacyLowstockContact identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_legacy_lowstock_contact_by_id(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_legacy_lowstock_contact_by_id(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to be returned. (required)
         :return: LegacyLowstockContact
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_legacy_lowstock_contact_by_id_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_legacy_lowstock_contact_by_id_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class LegacyLowstockContactApi(object):
 
         Returns the legacyLowstockContact identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_legacy_lowstock_contact_by_id_with_http_info(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_legacy_lowstock_contact_by_id_with_http_info(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to be returned. (required)
         :return: LegacyLowstockContact
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type='LegacyLowstockContact',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class LegacyLowstockContactApi(object):
 
         Get all existing legacyLowstockContact files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_legacy_lowstock_contact_files(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_legacy_lowstock_contact_files(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_legacy_lowstock_contact_files_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_legacy_lowstock_contact_files_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class LegacyLowstockContactApi(object):
 
         Get all existing legacyLowstockContact files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_legacy_lowstock_contact_files_with_http_info(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_legacy_lowstock_contact_files_with_http_info(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class LegacyLowstockContactApi(object):
 
         Get all existing legacyLowstockContact tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_legacy_lowstock_contact_tags(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_legacy_lowstock_contact_tags(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_legacy_lowstock_contact_tags_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_legacy_lowstock_contact_tags_with_http_info(legacy_lowstock_contact_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class LegacyLowstockContactApi(object):
 
         Get all existing legacyLowstockContact tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_legacy_lowstock_contact_tags_with_http_info(legacy_lowstock_contact_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_legacy_lowstock_contact_tags_with_http_info(legacy_lowstock_contact_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int legacy_lowstock_contact_id: Id of the legacyLowstockContact to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['legacy_lowstock_contact_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class LegacyLowstockContactApi(object):
 
         Updates an existing legacyLowstockContact using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_legacy_lowstock_contact(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_legacy_lowstock_contact(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LegacyLowstockContact body: LegacyLowstockContact to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_legacy_lowstock_contact_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_legacy_lowstock_contact_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class LegacyLowstockContactApi(object):
 
         Updates an existing legacyLowstockContact using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_legacy_lowstock_contact_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_legacy_lowstock_contact_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LegacyLowstockContact body: LegacyLowstockContact to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class LegacyLowstockContactApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class LegacyLowstockContactApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/line_of_business_api.py
+++ b/Infoplus/api/line_of_business_api.py
@@ -38,18 +38,18 @@ class LineOfBusinessApi(object):
 
         Inserts a new lineOfBusiness using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LineOfBusiness body: LineOfBusiness to be inserted. (required)
         :return: LineOfBusiness
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_line_of_business_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_line_of_business_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class LineOfBusinessApi(object):
 
         Inserts a new lineOfBusiness using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LineOfBusiness body: LineOfBusiness to be inserted. (required)
         :return: LineOfBusiness
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type='LineOfBusiness',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class LineOfBusinessApi(object):
 
         Adds an audit to an existing lineOfBusiness.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business_audit(line_of_business_id, line_of_business_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business_audit(line_of_business_id, line_of_business_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to add an audit to (required)
         :param str line_of_business_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class LineOfBusinessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_line_of_business_audit_with_http_info(line_of_business_id, line_of_business_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_line_of_business_audit_with_http_info(line_of_business_id, line_of_business_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class LineOfBusinessApi(object):
 
         Adds an audit to an existing lineOfBusiness.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business_audit_with_http_info(line_of_business_id, line_of_business_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business_audit_with_http_info(line_of_business_id, line_of_business_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to add an audit to (required)
         :param str line_of_business_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['line_of_business_id', 'line_of_business_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class LineOfBusinessApi(object):
 
         Adds a file to an existing lineOfBusiness.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business_file(line_of_business_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business_file(line_of_business_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class LineOfBusinessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_line_of_business_file_with_http_info(line_of_business_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_line_of_business_file_with_http_info(line_of_business_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class LineOfBusinessApi(object):
 
         Adds a file to an existing lineOfBusiness.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business_file_with_http_info(line_of_business_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business_file_with_http_info(line_of_business_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['line_of_business_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class LineOfBusinessApi(object):
 
         Adds a file to an existing lineOfBusiness by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business_file_by_url(body, line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business_file_by_url(body, line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int line_of_business_id: Id of the lineOfBusiness to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class LineOfBusinessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_line_of_business_file_by_url_with_http_info(body, line_of_business_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_line_of_business_file_by_url_with_http_info(body, line_of_business_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class LineOfBusinessApi(object):
 
         Adds a file to an existing lineOfBusiness by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business_file_by_url_with_http_info(body, line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business_file_by_url_with_http_info(body, line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int line_of_business_id: Id of the lineOfBusiness to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['body', 'line_of_business_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class LineOfBusinessApi(object):
 
         Adds a tag to an existing lineOfBusiness.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business_tag(line_of_business_id, line_of_business_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business_tag(line_of_business_id, line_of_business_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to add a tag to (required)
         :param str line_of_business_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class LineOfBusinessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_line_of_business_tag_with_http_info(line_of_business_id, line_of_business_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_line_of_business_tag_with_http_info(line_of_business_id, line_of_business_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class LineOfBusinessApi(object):
 
         Adds a tag to an existing lineOfBusiness.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_line_of_business_tag_with_http_info(line_of_business_id, line_of_business_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_line_of_business_tag_with_http_info(line_of_business_id, line_of_business_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to add a tag to (required)
         :param str line_of_business_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['line_of_business_id', 'line_of_business_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,11 +561,11 @@ class LineOfBusinessApi(object):
 
         Deletes an existing lineOfBusiness file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_line_of_business_file(line_of_business_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_line_of_business_file(line_of_business_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -573,7 +573,7 @@ class LineOfBusinessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_line_of_business_file_with_http_info(line_of_business_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_line_of_business_file_with_http_info(line_of_business_id, file_id, **kwargs)  # noqa: E501
@@ -584,11 +584,11 @@ class LineOfBusinessApi(object):
 
         Deletes an existing lineOfBusiness file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_line_of_business_file_with_http_info(line_of_business_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_line_of_business_file_with_http_info(line_of_business_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -597,7 +597,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['line_of_business_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -653,7 +653,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -664,11 +664,11 @@ class LineOfBusinessApi(object):
 
         Deletes an existing lineOfBusiness tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_line_of_business_tag(line_of_business_id, line_of_business_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_line_of_business_tag(line_of_business_id, line_of_business_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to remove tag from (required)
         :param str line_of_business_tag: The tag to delete (required)
         :return: None
@@ -676,7 +676,7 @@ class LineOfBusinessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_line_of_business_tag_with_http_info(line_of_business_id, line_of_business_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_line_of_business_tag_with_http_info(line_of_business_id, line_of_business_tag, **kwargs)  # noqa: E501
@@ -687,11 +687,11 @@ class LineOfBusinessApi(object):
 
         Deletes an existing lineOfBusiness tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_line_of_business_tag_with_http_info(line_of_business_id, line_of_business_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_line_of_business_tag_with_http_info(line_of_business_id, line_of_business_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to remove tag from (required)
         :param str line_of_business_tag: The tag to delete (required)
         :return: None
@@ -700,7 +700,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['line_of_business_id', 'line_of_business_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -756,7 +756,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -767,18 +767,18 @@ class LineOfBusinessApi(object):
 
         Returns a duplicated lineOfBusiness identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_line_of_business_by_id(line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_line_of_business_by_id(line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to be duplicated. (required)
         :return: LineOfBusiness
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_line_of_business_by_id_with_http_info(line_of_business_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_line_of_business_by_id_with_http_info(line_of_business_id, **kwargs)  # noqa: E501
@@ -789,11 +789,11 @@ class LineOfBusinessApi(object):
 
         Returns a duplicated lineOfBusiness identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_line_of_business_by_id_with_http_info(line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_line_of_business_by_id_with_http_info(line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to be duplicated. (required)
         :return: LineOfBusiness
                  If the method is called asynchronously,
@@ -801,7 +801,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['line_of_business_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type='LineOfBusiness',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class LineOfBusinessApi(object):
 
         Returns the list of lineOfBusinesses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_line_of_business_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_line_of_business_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class LineOfBusinessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_line_of_business_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_line_of_business_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class LineOfBusinessApi(object):
 
         Returns the list of lineOfBusinesses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_line_of_business_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_line_of_business_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type='list[LineOfBusiness]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class LineOfBusinessApi(object):
 
         Returns the lineOfBusiness identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_line_of_business_by_id(line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_line_of_business_by_id(line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to be returned. (required)
         :return: LineOfBusiness
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_line_of_business_by_id_with_http_info(line_of_business_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_line_of_business_by_id_with_http_info(line_of_business_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class LineOfBusinessApi(object):
 
         Returns the lineOfBusiness identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_line_of_business_by_id_with_http_info(line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_line_of_business_by_id_with_http_info(line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to be returned. (required)
         :return: LineOfBusiness
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['line_of_business_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type='LineOfBusiness',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class LineOfBusinessApi(object):
 
         Get all existing lineOfBusiness files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_line_of_business_files(line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_line_of_business_files(line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_line_of_business_files_with_http_info(line_of_business_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_line_of_business_files_with_http_info(line_of_business_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class LineOfBusinessApi(object):
 
         Get all existing lineOfBusiness files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_line_of_business_files_with_http_info(line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_line_of_business_files_with_http_info(line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['line_of_business_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class LineOfBusinessApi(object):
 
         Get all existing lineOfBusiness tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_line_of_business_tags(line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_line_of_business_tags(line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_line_of_business_tags_with_http_info(line_of_business_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_line_of_business_tags_with_http_info(line_of_business_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class LineOfBusinessApi(object):
 
         Get all existing lineOfBusiness tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_line_of_business_tags_with_http_info(line_of_business_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_line_of_business_tags_with_http_info(line_of_business_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int line_of_business_id: Id of the lineOfBusiness to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['line_of_business_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class LineOfBusinessApi(object):
 
         Updates an existing lineOfBusiness using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_line_of_business(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_line_of_business(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LineOfBusiness body: LineOfBusiness to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_line_of_business_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_line_of_business_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class LineOfBusinessApi(object):
 
         Updates an existing lineOfBusiness using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_line_of_business_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_line_of_business_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LineOfBusiness body: LineOfBusiness to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1349,18 +1349,18 @@ class LineOfBusinessApi(object):
 
         Updates an existing lineOfBusiness custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_line_of_business_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_line_of_business_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LineOfBusiness body: LineOfBusiness to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_line_of_business_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_line_of_business_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1371,11 +1371,11 @@ class LineOfBusinessApi(object):
 
         Updates an existing lineOfBusiness custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_line_of_business_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_line_of_business_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LineOfBusiness body: LineOfBusiness to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1383,7 +1383,7 @@ class LineOfBusinessApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1437,7 +1437,7 @@ class LineOfBusinessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/load_api.py
+++ b/Infoplus/api/load_api.py
@@ -38,11 +38,11 @@ class LoadApi(object):
 
         Adds an audit to an existing load.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_audit(load_id, load_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_audit(load_id, load_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to add an audit to (required)
         :param str load_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class LoadApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_load_audit_with_http_info(load_id, load_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_load_audit_with_http_info(load_id, load_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class LoadApi(object):
 
         Adds an audit to an existing load.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_audit_with_http_info(load_id, load_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_audit_with_http_info(load_id, load_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to add an audit to (required)
         :param str load_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class LoadApi(object):
         """
 
         all_params = ['load_id', 'load_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class LoadApi(object):
 
         Adds a file to an existing load.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_file(load_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_file(load_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class LoadApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_load_file_with_http_info(load_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_load_file_with_http_info(load_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class LoadApi(object):
 
         Adds a file to an existing load.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_file_with_http_info(load_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_file_with_http_info(load_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class LoadApi(object):
         """
 
         all_params = ['load_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class LoadApi(object):
 
         Adds a file to an existing load by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_file_by_url(body, load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_file_by_url(body, load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int load_id: Id of the load to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class LoadApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_load_file_by_url_with_http_info(body, load_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_load_file_by_url_with_http_info(body, load_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class LoadApi(object):
 
         Adds a file to an existing load by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_file_by_url_with_http_info(body, load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_file_by_url_with_http_info(body, load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int load_id: Id of the load to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class LoadApi(object):
         """
 
         all_params = ['body', 'load_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class LoadApi(object):
 
         Adds a tag to an existing load.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_tag(load_id, load_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_tag(load_id, load_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to add a tag to (required)
         :param str load_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class LoadApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_load_tag_with_http_info(load_id, load_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_load_tag_with_http_info(load_id, load_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class LoadApi(object):
 
         Adds a tag to an existing load.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_tag_with_http_info(load_id, load_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_tag_with_http_info(load_id, load_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to add a tag to (required)
         :param str load_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class LoadApi(object):
         """
 
         all_params = ['load_id', 'load_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class LoadApi(object):
 
         Deletes an existing load file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_load_file(load_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_load_file(load_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class LoadApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_load_file_with_http_info(load_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_load_file_with_http_info(load_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class LoadApi(object):
 
         Deletes an existing load file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_load_file_with_http_info(load_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_load_file_with_http_info(load_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class LoadApi(object):
         """
 
         all_params = ['load_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class LoadApi(object):
 
         Deletes an existing load tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_load_tag(load_id, load_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_load_tag(load_id, load_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to remove tag from (required)
         :param str load_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class LoadApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_load_tag_with_http_info(load_id, load_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_load_tag_with_http_info(load_id, load_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class LoadApi(object):
 
         Deletes an existing load tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_load_tag_with_http_info(load_id, load_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_load_tag_with_http_info(load_id, load_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to remove tag from (required)
         :param str load_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class LoadApi(object):
         """
 
         all_params = ['load_id', 'load_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class LoadApi(object):
 
         Returns a duplicated load identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_load_by_id(load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_load_by_id(load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to be duplicated. (required)
         :return: Load
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_load_by_id_with_http_info(load_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_load_by_id_with_http_info(load_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class LoadApi(object):
 
         Returns a duplicated load identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_load_by_id_with_http_info(load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_load_by_id_with_http_info(load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to be duplicated. (required)
         :return: Load
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class LoadApi(object):
         """
 
         all_params = ['load_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type='Load',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class LoadApi(object):
 
         Returns the list of loads that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class LoadApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_load_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_load_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class LoadApi(object):
 
         Returns the list of loads that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class LoadApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type='list[Load]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class LoadApi(object):
 
         Returns the load identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_by_id(load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_by_id(load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to be returned. (required)
         :return: Load
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_load_by_id_with_http_info(load_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_load_by_id_with_http_info(load_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class LoadApi(object):
 
         Returns the load identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_by_id_with_http_info(load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_by_id_with_http_info(load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to be returned. (required)
         :return: Load
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class LoadApi(object):
         """
 
         all_params = ['load_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type='Load',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class LoadApi(object):
 
         Get all existing load files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_files(load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_files(load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_load_files_with_http_info(load_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_load_files_with_http_info(load_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class LoadApi(object):
 
         Get all existing load files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_files_with_http_info(load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_files_with_http_info(load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class LoadApi(object):
         """
 
         all_params = ['load_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class LoadApi(object):
 
         Get all existing load tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_tags(load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_tags(load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_load_tags_with_http_info(load_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_load_tags_with_http_info(load_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class LoadApi(object):
 
         Get all existing load tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_tags_with_http_info(load_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_tags_with_http_info(load_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_id: Id of the load to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class LoadApi(object):
         """
 
         all_params = ['load_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class LoadApi(object):
 
         Updates an existing load custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_load_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_load_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Load body: Load to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_load_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_load_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class LoadApi(object):
 
         Updates an existing load custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_load_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_load_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Load body: Load to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class LoadApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class LoadApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/load_content_api.py
+++ b/Infoplus/api/load_content_api.py
@@ -38,11 +38,11 @@ class LoadContentApi(object):
 
         Adds an audit to an existing loadContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_content_audit(load_content_id, load_content_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_content_audit(load_content_id, load_content_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to add an audit to (required)
         :param str load_content_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class LoadContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_load_content_audit_with_http_info(load_content_id, load_content_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_load_content_audit_with_http_info(load_content_id, load_content_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class LoadContentApi(object):
 
         Adds an audit to an existing loadContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_content_audit_with_http_info(load_content_id, load_content_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_content_audit_with_http_info(load_content_id, load_content_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to add an audit to (required)
         :param str load_content_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['load_content_id', 'load_content_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class LoadContentApi(object):
 
         Adds a file to an existing loadContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_content_file(load_content_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_content_file(load_content_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class LoadContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_load_content_file_with_http_info(load_content_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_load_content_file_with_http_info(load_content_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class LoadContentApi(object):
 
         Adds a file to an existing loadContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_content_file_with_http_info(load_content_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_content_file_with_http_info(load_content_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['load_content_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class LoadContentApi(object):
 
         Adds a file to an existing loadContent by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_content_file_by_url(body, load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_content_file_by_url(body, load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int load_content_id: Id of the loadContent to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class LoadContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_load_content_file_by_url_with_http_info(body, load_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_load_content_file_by_url_with_http_info(body, load_content_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class LoadContentApi(object):
 
         Adds a file to an existing loadContent by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_content_file_by_url_with_http_info(body, load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_content_file_by_url_with_http_info(body, load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int load_content_id: Id of the loadContent to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['body', 'load_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class LoadContentApi(object):
 
         Adds a tag to an existing loadContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_content_tag(load_content_id, load_content_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_content_tag(load_content_id, load_content_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to add a tag to (required)
         :param str load_content_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class LoadContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_load_content_tag_with_http_info(load_content_id, load_content_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_load_content_tag_with_http_info(load_content_id, load_content_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class LoadContentApi(object):
 
         Adds a tag to an existing loadContent.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_load_content_tag_with_http_info(load_content_id, load_content_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_load_content_tag_with_http_info(load_content_id, load_content_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to add a tag to (required)
         :param str load_content_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['load_content_id', 'load_content_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class LoadContentApi(object):
 
         Deletes an existing loadContent file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_load_content_file(load_content_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_load_content_file(load_content_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class LoadContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_load_content_file_with_http_info(load_content_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_load_content_file_with_http_info(load_content_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class LoadContentApi(object):
 
         Deletes an existing loadContent file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_load_content_file_with_http_info(load_content_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_load_content_file_with_http_info(load_content_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['load_content_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class LoadContentApi(object):
 
         Deletes an existing loadContent tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_load_content_tag(load_content_id, load_content_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_load_content_tag(load_content_id, load_content_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to remove tag from (required)
         :param str load_content_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class LoadContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_load_content_tag_with_http_info(load_content_id, load_content_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_load_content_tag_with_http_info(load_content_id, load_content_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class LoadContentApi(object):
 
         Deletes an existing loadContent tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_load_content_tag_with_http_info(load_content_id, load_content_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_load_content_tag_with_http_info(load_content_id, load_content_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to remove tag from (required)
         :param str load_content_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['load_content_id', 'load_content_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class LoadContentApi(object):
 
         Returns a duplicated loadContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_load_content_by_id(load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_load_content_by_id(load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to be duplicated. (required)
         :return: LoadContent
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_load_content_by_id_with_http_info(load_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_load_content_by_id_with_http_info(load_content_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class LoadContentApi(object):
 
         Returns a duplicated loadContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_load_content_by_id_with_http_info(load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_load_content_by_id_with_http_info(load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to be duplicated. (required)
         :return: LoadContent
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['load_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type='LoadContent',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class LoadContentApi(object):
 
         Returns the list of loadContents that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_content_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_content_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class LoadContentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_load_content_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_load_content_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class LoadContentApi(object):
 
         Returns the list of loadContents that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_content_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_content_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type='list[LoadContent]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class LoadContentApi(object):
 
         Returns the loadContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_content_by_id(load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_content_by_id(load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to be returned. (required)
         :return: LoadContent
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_load_content_by_id_with_http_info(load_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_load_content_by_id_with_http_info(load_content_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class LoadContentApi(object):
 
         Returns the loadContent identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_content_by_id_with_http_info(load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_content_by_id_with_http_info(load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to be returned. (required)
         :return: LoadContent
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['load_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type='LoadContent',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class LoadContentApi(object):
 
         Get all existing loadContent files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_content_files(load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_content_files(load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_load_content_files_with_http_info(load_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_load_content_files_with_http_info(load_content_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class LoadContentApi(object):
 
         Get all existing loadContent files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_content_files_with_http_info(load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_content_files_with_http_info(load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['load_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class LoadContentApi(object):
 
         Get all existing loadContent tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_content_tags(load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_content_tags(load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_load_content_tags_with_http_info(load_content_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_load_content_tags_with_http_info(load_content_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class LoadContentApi(object):
 
         Get all existing loadContent tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_load_content_tags_with_http_info(load_content_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_load_content_tags_with_http_info(load_content_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int load_content_id: Id of the loadContent to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['load_content_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class LoadContentApi(object):
 
         Updates an existing loadContent custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_load_content_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_load_content_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LoadContent body: LoadContent to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_load_content_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_load_content_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class LoadContentApi(object):
 
         Updates an existing loadContent custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_load_content_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_load_content_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LoadContent body: LoadContent to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class LoadContentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class LoadContentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/location_address_scheme_api.py
+++ b/Infoplus/api/location_address_scheme_api.py
@@ -38,18 +38,18 @@ class LocationAddressSchemeApi(object):
 
         Inserts a new locationAddressScheme using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationAddressScheme body: LocationAddressScheme to be inserted. (required)
         :return: LocationAddressScheme
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_address_scheme_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_address_scheme_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class LocationAddressSchemeApi(object):
 
         Inserts a new locationAddressScheme using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationAddressScheme body: LocationAddressScheme to be inserted. (required)
         :return: LocationAddressScheme
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type='LocationAddressScheme',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class LocationAddressSchemeApi(object):
 
         Adds an audit to an existing locationAddressScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme_audit(location_address_scheme_id, location_address_scheme_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme_audit(location_address_scheme_id, location_address_scheme_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to add an audit to (required)
         :param str location_address_scheme_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class LocationAddressSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_address_scheme_audit_with_http_info(location_address_scheme_id, location_address_scheme_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_address_scheme_audit_with_http_info(location_address_scheme_id, location_address_scheme_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class LocationAddressSchemeApi(object):
 
         Adds an audit to an existing locationAddressScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme_audit_with_http_info(location_address_scheme_id, location_address_scheme_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme_audit_with_http_info(location_address_scheme_id, location_address_scheme_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to add an audit to (required)
         :param str location_address_scheme_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id', 'location_address_scheme_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class LocationAddressSchemeApi(object):
 
         Adds a file to an existing locationAddressScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme_file(location_address_scheme_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme_file(location_address_scheme_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class LocationAddressSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_address_scheme_file_with_http_info(location_address_scheme_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_address_scheme_file_with_http_info(location_address_scheme_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class LocationAddressSchemeApi(object):
 
         Adds a file to an existing locationAddressScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme_file_with_http_info(location_address_scheme_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme_file_with_http_info(location_address_scheme_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class LocationAddressSchemeApi(object):
 
         Adds a file to an existing locationAddressScheme by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme_file_by_url(body, location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme_file_by_url(body, location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int location_address_scheme_id: Id of the locationAddressScheme to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class LocationAddressSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_address_scheme_file_by_url_with_http_info(body, location_address_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_address_scheme_file_by_url_with_http_info(body, location_address_scheme_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class LocationAddressSchemeApi(object):
 
         Adds a file to an existing locationAddressScheme by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme_file_by_url_with_http_info(body, location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme_file_by_url_with_http_info(body, location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int location_address_scheme_id: Id of the locationAddressScheme to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['body', 'location_address_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class LocationAddressSchemeApi(object):
 
         Adds a tag to an existing locationAddressScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme_tag(location_address_scheme_id, location_address_scheme_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme_tag(location_address_scheme_id, location_address_scheme_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to add a tag to (required)
         :param str location_address_scheme_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class LocationAddressSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_address_scheme_tag_with_http_info(location_address_scheme_id, location_address_scheme_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_address_scheme_tag_with_http_info(location_address_scheme_id, location_address_scheme_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class LocationAddressSchemeApi(object):
 
         Adds a tag to an existing locationAddressScheme.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_address_scheme_tag_with_http_info(location_address_scheme_id, location_address_scheme_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_address_scheme_tag_with_http_info(location_address_scheme_id, location_address_scheme_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to add a tag to (required)
         :param str location_address_scheme_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id', 'location_address_scheme_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class LocationAddressSchemeApi(object):
 
         Deletes the locationAddressScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_address_scheme(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_address_scheme(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_address_scheme_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_address_scheme_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class LocationAddressSchemeApi(object):
 
         Deletes the locationAddressScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_address_scheme_with_http_info(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_address_scheme_with_http_info(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class LocationAddressSchemeApi(object):
 
         Deletes an existing locationAddressScheme file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_address_scheme_file(location_address_scheme_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_address_scheme_file(location_address_scheme_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class LocationAddressSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_address_scheme_file_with_http_info(location_address_scheme_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_address_scheme_file_with_http_info(location_address_scheme_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class LocationAddressSchemeApi(object):
 
         Deletes an existing locationAddressScheme file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_address_scheme_file_with_http_info(location_address_scheme_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_address_scheme_file_with_http_info(location_address_scheme_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class LocationAddressSchemeApi(object):
 
         Deletes an existing locationAddressScheme tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_address_scheme_tag(location_address_scheme_id, location_address_scheme_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_address_scheme_tag(location_address_scheme_id, location_address_scheme_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to remove tag from (required)
         :param str location_address_scheme_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class LocationAddressSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_address_scheme_tag_with_http_info(location_address_scheme_id, location_address_scheme_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_address_scheme_tag_with_http_info(location_address_scheme_id, location_address_scheme_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class LocationAddressSchemeApi(object):
 
         Deletes an existing locationAddressScheme tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_address_scheme_tag_with_http_info(location_address_scheme_id, location_address_scheme_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_address_scheme_tag_with_http_info(location_address_scheme_id, location_address_scheme_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to remove tag from (required)
         :param str location_address_scheme_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id', 'location_address_scheme_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class LocationAddressSchemeApi(object):
 
         Returns a duplicated locationAddressScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_location_address_scheme_by_id(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_location_address_scheme_by_id(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to be duplicated. (required)
         :return: LocationAddressScheme
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_location_address_scheme_by_id_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_location_address_scheme_by_id_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class LocationAddressSchemeApi(object):
 
         Returns a duplicated locationAddressScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_location_address_scheme_by_id_with_http_info(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_location_address_scheme_by_id_with_http_info(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to be duplicated. (required)
         :return: LocationAddressScheme
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type='LocationAddressScheme',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class LocationAddressSchemeApi(object):
 
         Returns the list of locationAddressSchemes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_address_scheme_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_address_scheme_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class LocationAddressSchemeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_address_scheme_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_location_address_scheme_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class LocationAddressSchemeApi(object):
 
         Returns the list of locationAddressSchemes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_address_scheme_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_address_scheme_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type='list[LocationAddressScheme]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class LocationAddressSchemeApi(object):
 
         Returns the locationAddressScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_address_scheme_by_id(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_address_scheme_by_id(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to be returned. (required)
         :return: LocationAddressScheme
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_address_scheme_by_id_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_address_scheme_by_id_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class LocationAddressSchemeApi(object):
 
         Returns the locationAddressScheme identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_address_scheme_by_id_with_http_info(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_address_scheme_by_id_with_http_info(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to be returned. (required)
         :return: LocationAddressScheme
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type='LocationAddressScheme',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class LocationAddressSchemeApi(object):
 
         Get all existing locationAddressScheme files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_address_scheme_files(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_address_scheme_files(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_address_scheme_files_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_address_scheme_files_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class LocationAddressSchemeApi(object):
 
         Get all existing locationAddressScheme files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_address_scheme_files_with_http_info(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_address_scheme_files_with_http_info(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class LocationAddressSchemeApi(object):
 
         Get all existing locationAddressScheme tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_address_scheme_tags(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_address_scheme_tags(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_address_scheme_tags_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_address_scheme_tags_with_http_info(location_address_scheme_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class LocationAddressSchemeApi(object):
 
         Get all existing locationAddressScheme tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_address_scheme_tags_with_http_info(location_address_scheme_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_address_scheme_tags_with_http_info(location_address_scheme_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_address_scheme_id: Id of the locationAddressScheme to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['location_address_scheme_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class LocationAddressSchemeApi(object):
 
         Updates an existing locationAddressScheme using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_address_scheme(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_address_scheme(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationAddressScheme body: LocationAddressScheme to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_location_address_scheme_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_location_address_scheme_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class LocationAddressSchemeApi(object):
 
         Updates an existing locationAddressScheme using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_address_scheme_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_address_scheme_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationAddressScheme body: LocationAddressScheme to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class LocationAddressSchemeApi(object):
 
         Updates an existing locationAddressScheme custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_address_scheme_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_address_scheme_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationAddressScheme body: LocationAddressScheme to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_location_address_scheme_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_location_address_scheme_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class LocationAddressSchemeApi(object):
 
         Updates an existing locationAddressScheme custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_address_scheme_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_address_scheme_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationAddressScheme body: LocationAddressScheme to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class LocationAddressSchemeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class LocationAddressSchemeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/location_api.py
+++ b/Infoplus/api/location_api.py
@@ -38,18 +38,18 @@ class LocationApi(object):
 
         Inserts a new location using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Location body: Location to be inserted. (required)
         :return: Location
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class LocationApi(object):
 
         Inserts a new location using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Location body: Location to be inserted. (required)
         :return: Location
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class LocationApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type='Location',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class LocationApi(object):
 
         Adds an audit to an existing location.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_audit(location_id, location_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_audit(location_id, location_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to add an audit to (required)
         :param str location_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class LocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_audit_with_http_info(location_id, location_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_audit_with_http_info(location_id, location_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class LocationApi(object):
 
         Adds an audit to an existing location.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_audit_with_http_info(location_id, location_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_audit_with_http_info(location_id, location_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to add an audit to (required)
         :param str location_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id', 'location_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class LocationApi(object):
 
         Adds a file to an existing location.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_file(location_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_file(location_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class LocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_file_with_http_info(location_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_file_with_http_info(location_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class LocationApi(object):
 
         Adds a file to an existing location.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_file_with_http_info(location_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_file_with_http_info(location_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class LocationApi(object):
 
         Adds a file to an existing location by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_file_by_url(body, location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_file_by_url(body, location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int location_id: Id of the location to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class LocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_file_by_url_with_http_info(body, location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_file_by_url_with_http_info(body, location_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class LocationApi(object):
 
         Adds a file to an existing location by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_file_by_url_with_http_info(body, location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_file_by_url_with_http_info(body, location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int location_id: Id of the location to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class LocationApi(object):
         """
 
         all_params = ['body', 'location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class LocationApi(object):
 
         Adds a tag to an existing location.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_tag(location_id, location_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_tag(location_id, location_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to add a tag to (required)
         :param str location_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class LocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_tag_with_http_info(location_id, location_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_tag_with_http_info(location_id, location_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class LocationApi(object):
 
         Adds a tag to an existing location.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_tag_with_http_info(location_id, location_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_tag_with_http_info(location_id, location_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to add a tag to (required)
         :param str location_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id', 'location_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class LocationApi(object):
 
         Deletes the location identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_with_http_info(location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_with_http_info(location_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class LocationApi(object):
 
         Deletes the location identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_with_http_info(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_with_http_info(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class LocationApi(object):
 
         Deletes an existing location file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_file(location_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_file(location_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class LocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_file_with_http_info(location_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_file_with_http_info(location_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class LocationApi(object):
 
         Deletes an existing location file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_file_with_http_info(location_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_file_with_http_info(location_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class LocationApi(object):
 
         Deletes an existing location tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_tag(location_id, location_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_tag(location_id, location_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to remove tag from (required)
         :param str location_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class LocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_tag_with_http_info(location_id, location_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_tag_with_http_info(location_id, location_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class LocationApi(object):
 
         Deletes an existing location tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_tag_with_http_info(location_id, location_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_tag_with_http_info(location_id, location_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to remove tag from (required)
         :param str location_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id', 'location_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class LocationApi(object):
 
         Returns a duplicated location identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_location_by_id(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_location_by_id(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to be duplicated. (required)
         :return: Location
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_location_by_id_with_http_info(location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_location_by_id_with_http_info(location_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class LocationApi(object):
 
         Returns a duplicated location identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_location_by_id_with_http_info(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_location_by_id_with_http_info(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to be duplicated. (required)
         :return: Location
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type='Location',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class LocationApi(object):
 
         Returns the list of locations that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class LocationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_location_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class LocationApi(object):
 
         Returns the list of locations that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class LocationApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type='list[Location]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class LocationApi(object):
 
         Returns the location identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_by_id(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_by_id(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to be returned. (required)
         :return: Location
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_by_id_with_http_info(location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_by_id_with_http_info(location_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class LocationApi(object):
 
         Returns the location identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_by_id_with_http_info(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_by_id_with_http_info(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to be returned. (required)
         :return: Location
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type='Location',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class LocationApi(object):
 
         Get all existing location files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_files(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_files(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_files_with_http_info(location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_files_with_http_info(location_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class LocationApi(object):
 
         Get all existing location files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_files_with_http_info(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_files_with_http_info(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class LocationApi(object):
 
         Get all existing location tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_tags(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_tags(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_tags_with_http_info(location_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_tags_with_http_info(location_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class LocationApi(object):
 
         Get all existing location tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_tags_with_http_info(location_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_tags_with_http_info(location_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_id: Id of the location to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class LocationApi(object):
         """
 
         all_params = ['location_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class LocationApi(object):
 
         Updates an existing location using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Location body: Location to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_location_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_location_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class LocationApi(object):
 
         Updates an existing location using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Location body: Location to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class LocationApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class LocationApi(object):
 
         Updates an existing location custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Location body: Location to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_location_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_location_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class LocationApi(object):
 
         Updates an existing location custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Location body: Location to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class LocationApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class LocationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/location_billing_type_api.py
+++ b/Infoplus/api/location_billing_type_api.py
@@ -38,18 +38,18 @@ class LocationBillingTypeApi(object):
 
         Inserts a new locationBillingType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationBillingType body: LocationBillingType to be inserted. (required)
         :return: LocationBillingType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_billing_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_billing_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class LocationBillingTypeApi(object):
 
         Inserts a new locationBillingType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationBillingType body: LocationBillingType to be inserted. (required)
         :return: LocationBillingType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type='LocationBillingType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class LocationBillingTypeApi(object):
 
         Adds an audit to an existing locationBillingType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type_audit(location_billing_type_id, location_billing_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type_audit(location_billing_type_id, location_billing_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to add an audit to (required)
         :param str location_billing_type_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class LocationBillingTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_billing_type_audit_with_http_info(location_billing_type_id, location_billing_type_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_billing_type_audit_with_http_info(location_billing_type_id, location_billing_type_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class LocationBillingTypeApi(object):
 
         Adds an audit to an existing locationBillingType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type_audit_with_http_info(location_billing_type_id, location_billing_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type_audit_with_http_info(location_billing_type_id, location_billing_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to add an audit to (required)
         :param str location_billing_type_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id', 'location_billing_type_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class LocationBillingTypeApi(object):
 
         Adds a file to an existing locationBillingType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type_file(location_billing_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type_file(location_billing_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class LocationBillingTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_billing_type_file_with_http_info(location_billing_type_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_billing_type_file_with_http_info(location_billing_type_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class LocationBillingTypeApi(object):
 
         Adds a file to an existing locationBillingType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type_file_with_http_info(location_billing_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type_file_with_http_info(location_billing_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class LocationBillingTypeApi(object):
 
         Adds a file to an existing locationBillingType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type_file_by_url(body, location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type_file_by_url(body, location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int location_billing_type_id: Id of the locationBillingType to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class LocationBillingTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_billing_type_file_by_url_with_http_info(body, location_billing_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_billing_type_file_by_url_with_http_info(body, location_billing_type_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class LocationBillingTypeApi(object):
 
         Adds a file to an existing locationBillingType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type_file_by_url_with_http_info(body, location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type_file_by_url_with_http_info(body, location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int location_billing_type_id: Id of the locationBillingType to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['body', 'location_billing_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class LocationBillingTypeApi(object):
 
         Adds a tag to an existing locationBillingType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type_tag(location_billing_type_id, location_billing_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type_tag(location_billing_type_id, location_billing_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to add a tag to (required)
         :param str location_billing_type_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class LocationBillingTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_billing_type_tag_with_http_info(location_billing_type_id, location_billing_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_billing_type_tag_with_http_info(location_billing_type_id, location_billing_type_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class LocationBillingTypeApi(object):
 
         Adds a tag to an existing locationBillingType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_billing_type_tag_with_http_info(location_billing_type_id, location_billing_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_billing_type_tag_with_http_info(location_billing_type_id, location_billing_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to add a tag to (required)
         :param str location_billing_type_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id', 'location_billing_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class LocationBillingTypeApi(object):
 
         Deletes the locationBillingType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_billing_type(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_billing_type(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_billing_type_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_billing_type_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class LocationBillingTypeApi(object):
 
         Deletes the locationBillingType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_billing_type_with_http_info(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_billing_type_with_http_info(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class LocationBillingTypeApi(object):
 
         Deletes an existing locationBillingType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_billing_type_file(location_billing_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_billing_type_file(location_billing_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class LocationBillingTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_billing_type_file_with_http_info(location_billing_type_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_billing_type_file_with_http_info(location_billing_type_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class LocationBillingTypeApi(object):
 
         Deletes an existing locationBillingType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_billing_type_file_with_http_info(location_billing_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_billing_type_file_with_http_info(location_billing_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class LocationBillingTypeApi(object):
 
         Deletes an existing locationBillingType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_billing_type_tag(location_billing_type_id, location_billing_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_billing_type_tag(location_billing_type_id, location_billing_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to remove tag from (required)
         :param str location_billing_type_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class LocationBillingTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_billing_type_tag_with_http_info(location_billing_type_id, location_billing_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_billing_type_tag_with_http_info(location_billing_type_id, location_billing_type_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class LocationBillingTypeApi(object):
 
         Deletes an existing locationBillingType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_billing_type_tag_with_http_info(location_billing_type_id, location_billing_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_billing_type_tag_with_http_info(location_billing_type_id, location_billing_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to remove tag from (required)
         :param str location_billing_type_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id', 'location_billing_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class LocationBillingTypeApi(object):
 
         Returns a duplicated locationBillingType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_location_billing_type_by_id(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_location_billing_type_by_id(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to be duplicated. (required)
         :return: LocationBillingType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_location_billing_type_by_id_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_location_billing_type_by_id_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class LocationBillingTypeApi(object):
 
         Returns a duplicated locationBillingType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_location_billing_type_by_id_with_http_info(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_location_billing_type_by_id_with_http_info(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to be duplicated. (required)
         :return: LocationBillingType
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type='LocationBillingType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class LocationBillingTypeApi(object):
 
         Returns the list of locationBillingTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_billing_type_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_billing_type_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class LocationBillingTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_billing_type_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_location_billing_type_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class LocationBillingTypeApi(object):
 
         Returns the list of locationBillingTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_billing_type_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_billing_type_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type='list[LocationBillingType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class LocationBillingTypeApi(object):
 
         Returns the locationBillingType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_billing_type_by_id(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_billing_type_by_id(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to be returned. (required)
         :return: LocationBillingType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_billing_type_by_id_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_billing_type_by_id_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class LocationBillingTypeApi(object):
 
         Returns the locationBillingType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_billing_type_by_id_with_http_info(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_billing_type_by_id_with_http_info(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to be returned. (required)
         :return: LocationBillingType
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type='LocationBillingType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class LocationBillingTypeApi(object):
 
         Get all existing locationBillingType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_billing_type_files(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_billing_type_files(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_billing_type_files_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_billing_type_files_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class LocationBillingTypeApi(object):
 
         Get all existing locationBillingType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_billing_type_files_with_http_info(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_billing_type_files_with_http_info(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class LocationBillingTypeApi(object):
 
         Get all existing locationBillingType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_billing_type_tags(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_billing_type_tags(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_billing_type_tags_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_billing_type_tags_with_http_info(location_billing_type_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class LocationBillingTypeApi(object):
 
         Get all existing locationBillingType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_billing_type_tags_with_http_info(location_billing_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_billing_type_tags_with_http_info(location_billing_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_billing_type_id: Id of the locationBillingType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['location_billing_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class LocationBillingTypeApi(object):
 
         Updates an existing locationBillingType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_billing_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_billing_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationBillingType body: LocationBillingType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_location_billing_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_location_billing_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class LocationBillingTypeApi(object):
 
         Updates an existing locationBillingType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_billing_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_billing_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationBillingType body: LocationBillingType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class LocationBillingTypeApi(object):
 
         Updates an existing locationBillingType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_billing_type_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_billing_type_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationBillingType body: LocationBillingType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_location_billing_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_location_billing_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class LocationBillingTypeApi(object):
 
         Updates an existing locationBillingType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_billing_type_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_billing_type_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationBillingType body: LocationBillingType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class LocationBillingTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class LocationBillingTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/location_footprint_api.py
+++ b/Infoplus/api/location_footprint_api.py
@@ -38,18 +38,18 @@ class LocationFootprintApi(object):
 
         Inserts a new locationFootprint using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationFootprint body: LocationFootprint to be inserted. (required)
         :return: LocationFootprint
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_footprint_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_footprint_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class LocationFootprintApi(object):
 
         Inserts a new locationFootprint using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationFootprint body: LocationFootprint to be inserted. (required)
         :return: LocationFootprint
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type='LocationFootprint',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class LocationFootprintApi(object):
 
         Adds an audit to an existing locationFootprint.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint_audit(location_footprint_id, location_footprint_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint_audit(location_footprint_id, location_footprint_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to add an audit to (required)
         :param str location_footprint_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class LocationFootprintApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_footprint_audit_with_http_info(location_footprint_id, location_footprint_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_footprint_audit_with_http_info(location_footprint_id, location_footprint_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class LocationFootprintApi(object):
 
         Adds an audit to an existing locationFootprint.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint_audit_with_http_info(location_footprint_id, location_footprint_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint_audit_with_http_info(location_footprint_id, location_footprint_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to add an audit to (required)
         :param str location_footprint_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id', 'location_footprint_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class LocationFootprintApi(object):
 
         Adds a file to an existing locationFootprint.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint_file(location_footprint_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint_file(location_footprint_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class LocationFootprintApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_footprint_file_with_http_info(location_footprint_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_footprint_file_with_http_info(location_footprint_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class LocationFootprintApi(object):
 
         Adds a file to an existing locationFootprint.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint_file_with_http_info(location_footprint_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint_file_with_http_info(location_footprint_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class LocationFootprintApi(object):
 
         Adds a file to an existing locationFootprint by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint_file_by_url(body, location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint_file_by_url(body, location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int location_footprint_id: Id of the locationFootprint to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class LocationFootprintApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_footprint_file_by_url_with_http_info(body, location_footprint_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_footprint_file_by_url_with_http_info(body, location_footprint_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class LocationFootprintApi(object):
 
         Adds a file to an existing locationFootprint by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint_file_by_url_with_http_info(body, location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint_file_by_url_with_http_info(body, location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int location_footprint_id: Id of the locationFootprint to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['body', 'location_footprint_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class LocationFootprintApi(object):
 
         Adds a tag to an existing locationFootprint.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint_tag(location_footprint_id, location_footprint_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint_tag(location_footprint_id, location_footprint_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to add a tag to (required)
         :param str location_footprint_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class LocationFootprintApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_location_footprint_tag_with_http_info(location_footprint_id, location_footprint_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_location_footprint_tag_with_http_info(location_footprint_id, location_footprint_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class LocationFootprintApi(object):
 
         Adds a tag to an existing locationFootprint.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_location_footprint_tag_with_http_info(location_footprint_id, location_footprint_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_location_footprint_tag_with_http_info(location_footprint_id, location_footprint_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to add a tag to (required)
         :param str location_footprint_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id', 'location_footprint_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class LocationFootprintApi(object):
 
         Deletes the locationFootprint identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_footprint(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_footprint(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_footprint_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_footprint_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class LocationFootprintApi(object):
 
         Deletes the locationFootprint identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_footprint_with_http_info(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_footprint_with_http_info(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class LocationFootprintApi(object):
 
         Deletes an existing locationFootprint file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_footprint_file(location_footprint_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_footprint_file(location_footprint_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class LocationFootprintApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_footprint_file_with_http_info(location_footprint_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_footprint_file_with_http_info(location_footprint_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class LocationFootprintApi(object):
 
         Deletes an existing locationFootprint file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_footprint_file_with_http_info(location_footprint_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_footprint_file_with_http_info(location_footprint_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class LocationFootprintApi(object):
 
         Deletes an existing locationFootprint tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_footprint_tag(location_footprint_id, location_footprint_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_footprint_tag(location_footprint_id, location_footprint_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to remove tag from (required)
         :param str location_footprint_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class LocationFootprintApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_location_footprint_tag_with_http_info(location_footprint_id, location_footprint_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_location_footprint_tag_with_http_info(location_footprint_id, location_footprint_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class LocationFootprintApi(object):
 
         Deletes an existing locationFootprint tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_location_footprint_tag_with_http_info(location_footprint_id, location_footprint_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_location_footprint_tag_with_http_info(location_footprint_id, location_footprint_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to remove tag from (required)
         :param str location_footprint_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id', 'location_footprint_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class LocationFootprintApi(object):
 
         Returns a duplicated locationFootprint identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_location_footprint_by_id(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_location_footprint_by_id(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to be duplicated. (required)
         :return: LocationFootprint
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_location_footprint_by_id_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_location_footprint_by_id_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class LocationFootprintApi(object):
 
         Returns a duplicated locationFootprint identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_location_footprint_by_id_with_http_info(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_location_footprint_by_id_with_http_info(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to be duplicated. (required)
         :return: LocationFootprint
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type='LocationFootprint',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class LocationFootprintApi(object):
 
         Returns the list of locationFootprints that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_footprint_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_footprint_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class LocationFootprintApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_footprint_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_location_footprint_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class LocationFootprintApi(object):
 
         Returns the list of locationFootprints that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_footprint_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_footprint_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type='list[LocationFootprint]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class LocationFootprintApi(object):
 
         Returns the locationFootprint identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_footprint_by_id(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_footprint_by_id(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to be returned. (required)
         :return: LocationFootprint
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_footprint_by_id_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_footprint_by_id_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class LocationFootprintApi(object):
 
         Returns the locationFootprint identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_footprint_by_id_with_http_info(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_footprint_by_id_with_http_info(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to be returned. (required)
         :return: LocationFootprint
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type='LocationFootprint',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class LocationFootprintApi(object):
 
         Get all existing locationFootprint files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_footprint_files(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_footprint_files(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_footprint_files_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_footprint_files_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class LocationFootprintApi(object):
 
         Get all existing locationFootprint files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_footprint_files_with_http_info(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_footprint_files_with_http_info(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class LocationFootprintApi(object):
 
         Get all existing locationFootprint tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_footprint_tags(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_footprint_tags(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_location_footprint_tags_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_location_footprint_tags_with_http_info(location_footprint_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class LocationFootprintApi(object):
 
         Get all existing locationFootprint tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_location_footprint_tags_with_http_info(location_footprint_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_location_footprint_tags_with_http_info(location_footprint_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int location_footprint_id: Id of the locationFootprint to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['location_footprint_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class LocationFootprintApi(object):
 
         Updates an existing locationFootprint using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_footprint(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_footprint(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationFootprint body: LocationFootprint to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_location_footprint_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_location_footprint_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class LocationFootprintApi(object):
 
         Updates an existing locationFootprint using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_footprint_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_footprint_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationFootprint body: LocationFootprint to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class LocationFootprintApi(object):
 
         Updates an existing locationFootprint custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_footprint_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_footprint_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationFootprint body: LocationFootprint to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_location_footprint_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_location_footprint_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class LocationFootprintApi(object):
 
         Updates an existing locationFootprint custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_location_footprint_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_location_footprint_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LocationFootprint body: LocationFootprint to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class LocationFootprintApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class LocationFootprintApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/logged_time_api.py
+++ b/Infoplus/api/logged_time_api.py
@@ -38,11 +38,11 @@ class LoggedTimeApi(object):
 
         Adds an audit to an existing loggedTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_logged_time_audit(logged_time_id, logged_time_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_logged_time_audit(logged_time_id, logged_time_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to add an audit to (required)
         :param str logged_time_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class LoggedTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_logged_time_audit_with_http_info(logged_time_id, logged_time_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_logged_time_audit_with_http_info(logged_time_id, logged_time_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class LoggedTimeApi(object):
 
         Adds an audit to an existing loggedTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_logged_time_audit_with_http_info(logged_time_id, logged_time_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_logged_time_audit_with_http_info(logged_time_id, logged_time_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to add an audit to (required)
         :param str logged_time_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['logged_time_id', 'logged_time_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class LoggedTimeApi(object):
 
         Adds a file to an existing loggedTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_logged_time_file(logged_time_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_logged_time_file(logged_time_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class LoggedTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_logged_time_file_with_http_info(logged_time_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_logged_time_file_with_http_info(logged_time_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class LoggedTimeApi(object):
 
         Adds a file to an existing loggedTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_logged_time_file_with_http_info(logged_time_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_logged_time_file_with_http_info(logged_time_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['logged_time_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class LoggedTimeApi(object):
 
         Adds a file to an existing loggedTime by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_logged_time_file_by_url(body, logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_logged_time_file_by_url(body, logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int logged_time_id: Id of the loggedTime to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class LoggedTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_logged_time_file_by_url_with_http_info(body, logged_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_logged_time_file_by_url_with_http_info(body, logged_time_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class LoggedTimeApi(object):
 
         Adds a file to an existing loggedTime by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_logged_time_file_by_url_with_http_info(body, logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_logged_time_file_by_url_with_http_info(body, logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int logged_time_id: Id of the loggedTime to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['body', 'logged_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class LoggedTimeApi(object):
 
         Adds a tag to an existing loggedTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_logged_time_tag(logged_time_id, logged_time_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_logged_time_tag(logged_time_id, logged_time_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to add a tag to (required)
         :param str logged_time_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class LoggedTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_logged_time_tag_with_http_info(logged_time_id, logged_time_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_logged_time_tag_with_http_info(logged_time_id, logged_time_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class LoggedTimeApi(object):
 
         Adds a tag to an existing loggedTime.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_logged_time_tag_with_http_info(logged_time_id, logged_time_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_logged_time_tag_with_http_info(logged_time_id, logged_time_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to add a tag to (required)
         :param str logged_time_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['logged_time_id', 'logged_time_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class LoggedTimeApi(object):
 
         Deletes an existing loggedTime file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_logged_time_file(logged_time_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_logged_time_file(logged_time_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class LoggedTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_logged_time_file_with_http_info(logged_time_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_logged_time_file_with_http_info(logged_time_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class LoggedTimeApi(object):
 
         Deletes an existing loggedTime file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_logged_time_file_with_http_info(logged_time_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_logged_time_file_with_http_info(logged_time_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['logged_time_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class LoggedTimeApi(object):
 
         Deletes an existing loggedTime tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_logged_time_tag(logged_time_id, logged_time_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_logged_time_tag(logged_time_id, logged_time_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to remove tag from (required)
         :param str logged_time_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class LoggedTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_logged_time_tag_with_http_info(logged_time_id, logged_time_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_logged_time_tag_with_http_info(logged_time_id, logged_time_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class LoggedTimeApi(object):
 
         Deletes an existing loggedTime tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_logged_time_tag_with_http_info(logged_time_id, logged_time_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_logged_time_tag_with_http_info(logged_time_id, logged_time_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to remove tag from (required)
         :param str logged_time_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['logged_time_id', 'logged_time_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class LoggedTimeApi(object):
 
         Returns a duplicated loggedTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_logged_time_by_id(logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_logged_time_by_id(logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to be duplicated. (required)
         :return: LoggedTime
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_logged_time_by_id_with_http_info(logged_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_logged_time_by_id_with_http_info(logged_time_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class LoggedTimeApi(object):
 
         Returns a duplicated loggedTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_logged_time_by_id_with_http_info(logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_logged_time_by_id_with_http_info(logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to be duplicated. (required)
         :return: LoggedTime
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['logged_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type='LoggedTime',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class LoggedTimeApi(object):
 
         Returns the list of loggedTimes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class LoggedTimeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_logged_time_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_logged_time_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class LoggedTimeApi(object):
 
         Returns the list of loggedTimes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type='list[LoggedTime]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class LoggedTimeApi(object):
 
         Returns the loggedTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_by_id(logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_by_id(logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to be returned. (required)
         :return: LoggedTime
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_logged_time_by_id_with_http_info(logged_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_logged_time_by_id_with_http_info(logged_time_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class LoggedTimeApi(object):
 
         Returns the loggedTime identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_by_id_with_http_info(logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_by_id_with_http_info(logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to be returned. (required)
         :return: LoggedTime
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['logged_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type='LoggedTime',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class LoggedTimeApi(object):
 
         Get all existing loggedTime files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_files(logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_files(logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_logged_time_files_with_http_info(logged_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_logged_time_files_with_http_info(logged_time_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class LoggedTimeApi(object):
 
         Get all existing loggedTime files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_files_with_http_info(logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_files_with_http_info(logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['logged_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class LoggedTimeApi(object):
 
         Get all existing loggedTime tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_tags(logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_tags(logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_logged_time_tags_with_http_info(logged_time_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_logged_time_tags_with_http_info(logged_time_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class LoggedTimeApi(object):
 
         Get all existing loggedTime tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_tags_with_http_info(logged_time_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_tags_with_http_info(logged_time_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int logged_time_id: Id of the loggedTime to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['logged_time_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class LoggedTimeApi(object):
 
         Updates an existing loggedTime custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_logged_time_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_logged_time_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LoggedTime body: LoggedTime to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_logged_time_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_logged_time_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class LoggedTimeApi(object):
 
         Updates an existing loggedTime custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_logged_time_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_logged_time_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param LoggedTime body: LoggedTime to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class LoggedTimeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class LoggedTimeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/logged_time_type_api.py
+++ b/Infoplus/api/logged_time_type_api.py
@@ -38,18 +38,18 @@ class LoggedTimeTypeApi(object):
 
         Returns the loggedTimeType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_type_by_id(logged_time_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_type_by_id(logged_time_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str logged_time_type_id: Id of loggedTimeType to be returned. (required)
         :return: LoggedTimeType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_logged_time_type_by_id_with_http_info(logged_time_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_logged_time_type_by_id_with_http_info(logged_time_type_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class LoggedTimeTypeApi(object):
 
         Returns the loggedTimeType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_type_by_id_with_http_info(logged_time_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_type_by_id_with_http_info(logged_time_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str logged_time_type_id: Id of loggedTimeType to be returned. (required)
         :return: LoggedTimeType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class LoggedTimeTypeApi(object):
         """
 
         all_params = ['logged_time_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class LoggedTimeTypeApi(object):
             files=local_var_files,
             response_type='LoggedTimeType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class LoggedTimeTypeApi(object):
 
         Returns the list of loggedTimeTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_type_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_type_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class LoggedTimeTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_logged_time_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_logged_time_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class LoggedTimeTypeApi(object):
 
         Returns the list of loggedTimeTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logged_time_type_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_logged_time_type_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class LoggedTimeTypeApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class LoggedTimeTypeApi(object):
             files=local_var_files,
             response_type='list[LoggedTimeType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/low_stock_api.py
+++ b/Infoplus/api/low_stock_api.py
@@ -38,11 +38,11 @@ class LowStockApi(object):
 
         Adds an audit to an existing lowStock.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_low_stock_audit(low_stock_id, low_stock_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_low_stock_audit(low_stock_id, low_stock_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to add an audit to (required)
         :param str low_stock_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class LowStockApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_low_stock_audit_with_http_info(low_stock_id, low_stock_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_low_stock_audit_with_http_info(low_stock_id, low_stock_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class LowStockApi(object):
 
         Adds an audit to an existing lowStock.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_low_stock_audit_with_http_info(low_stock_id, low_stock_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_low_stock_audit_with_http_info(low_stock_id, low_stock_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to add an audit to (required)
         :param str low_stock_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class LowStockApi(object):
         """
 
         all_params = ['low_stock_id', 'low_stock_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class LowStockApi(object):
 
         Adds a file to an existing lowStock.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_low_stock_file(low_stock_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_low_stock_file(low_stock_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class LowStockApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_low_stock_file_with_http_info(low_stock_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_low_stock_file_with_http_info(low_stock_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class LowStockApi(object):
 
         Adds a file to an existing lowStock.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_low_stock_file_with_http_info(low_stock_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_low_stock_file_with_http_info(low_stock_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class LowStockApi(object):
         """
 
         all_params = ['low_stock_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class LowStockApi(object):
 
         Adds a file to an existing lowStock by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_low_stock_file_by_url(body, low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_low_stock_file_by_url(body, low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int low_stock_id: Id of the lowStock to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class LowStockApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_low_stock_file_by_url_with_http_info(body, low_stock_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_low_stock_file_by_url_with_http_info(body, low_stock_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class LowStockApi(object):
 
         Adds a file to an existing lowStock by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_low_stock_file_by_url_with_http_info(body, low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_low_stock_file_by_url_with_http_info(body, low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int low_stock_id: Id of the lowStock to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class LowStockApi(object):
         """
 
         all_params = ['body', 'low_stock_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class LowStockApi(object):
 
         Adds a tag to an existing lowStock.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_low_stock_tag(low_stock_id, low_stock_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_low_stock_tag(low_stock_id, low_stock_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to add a tag to (required)
         :param str low_stock_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class LowStockApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_low_stock_tag_with_http_info(low_stock_id, low_stock_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_low_stock_tag_with_http_info(low_stock_id, low_stock_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class LowStockApi(object):
 
         Adds a tag to an existing lowStock.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_low_stock_tag_with_http_info(low_stock_id, low_stock_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_low_stock_tag_with_http_info(low_stock_id, low_stock_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to add a tag to (required)
         :param str low_stock_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class LowStockApi(object):
         """
 
         all_params = ['low_stock_id', 'low_stock_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class LowStockApi(object):
 
         Deletes an existing lowStock file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_low_stock_file(low_stock_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_low_stock_file(low_stock_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class LowStockApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_low_stock_file_with_http_info(low_stock_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_low_stock_file_with_http_info(low_stock_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class LowStockApi(object):
 
         Deletes an existing lowStock file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_low_stock_file_with_http_info(low_stock_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_low_stock_file_with_http_info(low_stock_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class LowStockApi(object):
         """
 
         all_params = ['low_stock_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class LowStockApi(object):
 
         Deletes an existing lowStock tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_low_stock_tag(low_stock_id, low_stock_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_low_stock_tag(low_stock_id, low_stock_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to remove tag from (required)
         :param str low_stock_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class LowStockApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_low_stock_tag_with_http_info(low_stock_id, low_stock_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_low_stock_tag_with_http_info(low_stock_id, low_stock_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class LowStockApi(object):
 
         Deletes an existing lowStock tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_low_stock_tag_with_http_info(low_stock_id, low_stock_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_low_stock_tag_with_http_info(low_stock_id, low_stock_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to remove tag from (required)
         :param str low_stock_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class LowStockApi(object):
         """
 
         all_params = ['low_stock_id', 'low_stock_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class LowStockApi(object):
 
         Returns a duplicated lowStock identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_low_stock_by_id(low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_low_stock_by_id(low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to be duplicated. (required)
         :return: LowStock
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_low_stock_by_id_with_http_info(low_stock_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_low_stock_by_id_with_http_info(low_stock_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class LowStockApi(object):
 
         Returns a duplicated lowStock identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_low_stock_by_id_with_http_info(low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_low_stock_by_id_with_http_info(low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to be duplicated. (required)
         :return: LowStock
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class LowStockApi(object):
         """
 
         all_params = ['low_stock_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type='LowStock',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class LowStockApi(object):
 
         Returns the list of lowStocks that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_low_stock_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_low_stock_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class LowStockApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_low_stock_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_low_stock_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class LowStockApi(object):
 
         Returns the list of lowStocks that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_low_stock_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_low_stock_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class LowStockApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type='list[LowStock]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class LowStockApi(object):
 
         Returns the lowStock identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_low_stock_by_id(low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_low_stock_by_id(low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to be returned. (required)
         :return: LowStock
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_low_stock_by_id_with_http_info(low_stock_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_low_stock_by_id_with_http_info(low_stock_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class LowStockApi(object):
 
         Returns the lowStock identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_low_stock_by_id_with_http_info(low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_low_stock_by_id_with_http_info(low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to be returned. (required)
         :return: LowStock
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class LowStockApi(object):
         """
 
         all_params = ['low_stock_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type='LowStock',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class LowStockApi(object):
 
         Get all existing lowStock files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_low_stock_files(low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_low_stock_files(low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_low_stock_files_with_http_info(low_stock_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_low_stock_files_with_http_info(low_stock_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class LowStockApi(object):
 
         Get all existing lowStock files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_low_stock_files_with_http_info(low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_low_stock_files_with_http_info(low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class LowStockApi(object):
         """
 
         all_params = ['low_stock_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class LowStockApi(object):
 
         Get all existing lowStock tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_low_stock_tags(low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_low_stock_tags(low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_low_stock_tags_with_http_info(low_stock_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_low_stock_tags_with_http_info(low_stock_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class LowStockApi(object):
 
         Get all existing lowStock tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_low_stock_tags_with_http_info(low_stock_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_low_stock_tags_with_http_info(low_stock_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int low_stock_id: Id of the lowStock to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class LowStockApi(object):
         """
 
         all_params = ['low_stock_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class LowStockApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/manage_scheduled_plans_api.py
+++ b/Infoplus/api/manage_scheduled_plans_api.py
@@ -38,18 +38,18 @@ class ManageScheduledPlansApi(object):
 
         Inserts a new manageScheduledPlans using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ManageScheduledPlans body: ManageScheduledPlans to be inserted. (required)
         :return: ManageScheduledPlans
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_manage_scheduled_plans_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_manage_scheduled_plans_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ManageScheduledPlansApi(object):
 
         Inserts a new manageScheduledPlans using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ManageScheduledPlans body: ManageScheduledPlans to be inserted. (required)
         :return: ManageScheduledPlans
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type='ManageScheduledPlans',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ManageScheduledPlansApi(object):
 
         Adds an audit to an existing manageScheduledPlans.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans_audit(manage_scheduled_plans_id, manage_scheduled_plans_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans_audit(manage_scheduled_plans_id, manage_scheduled_plans_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to add an audit to (required)
         :param str manage_scheduled_plans_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ManageScheduledPlansApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_manage_scheduled_plans_audit_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_manage_scheduled_plans_audit_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ManageScheduledPlansApi(object):
 
         Adds an audit to an existing manageScheduledPlans.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans_audit_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans_audit_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to add an audit to (required)
         :param str manage_scheduled_plans_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id', 'manage_scheduled_plans_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ManageScheduledPlansApi(object):
 
         Adds a file to an existing manageScheduledPlans.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans_file(manage_scheduled_plans_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans_file(manage_scheduled_plans_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ManageScheduledPlansApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_manage_scheduled_plans_file_with_http_info(manage_scheduled_plans_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_manage_scheduled_plans_file_with_http_info(manage_scheduled_plans_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ManageScheduledPlansApi(object):
 
         Adds a file to an existing manageScheduledPlans.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans_file_with_http_info(manage_scheduled_plans_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans_file_with_http_info(manage_scheduled_plans_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ManageScheduledPlansApi(object):
 
         Adds a file to an existing manageScheduledPlans by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans_file_by_url(body, manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans_file_by_url(body, manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ManageScheduledPlansApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_manage_scheduled_plans_file_by_url_with_http_info(body, manage_scheduled_plans_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_manage_scheduled_plans_file_by_url_with_http_info(body, manage_scheduled_plans_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ManageScheduledPlansApi(object):
 
         Adds a file to an existing manageScheduledPlans by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans_file_by_url_with_http_info(body, manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans_file_by_url_with_http_info(body, manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['body', 'manage_scheduled_plans_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ManageScheduledPlansApi(object):
 
         Adds a tag to an existing manageScheduledPlans.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans_tag(manage_scheduled_plans_id, manage_scheduled_plans_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans_tag(manage_scheduled_plans_id, manage_scheduled_plans_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to add a tag to (required)
         :param str manage_scheduled_plans_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ManageScheduledPlansApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_manage_scheduled_plans_tag_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_manage_scheduled_plans_tag_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ManageScheduledPlansApi(object):
 
         Adds a tag to an existing manageScheduledPlans.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_manage_scheduled_plans_tag_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_manage_scheduled_plans_tag_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to add a tag to (required)
         :param str manage_scheduled_plans_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id', 'manage_scheduled_plans_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ManageScheduledPlansApi(object):
 
         Deletes the manageScheduledPlans identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_manage_scheduled_plans(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_manage_scheduled_plans(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_manage_scheduled_plans_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_manage_scheduled_plans_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ManageScheduledPlansApi(object):
 
         Deletes the manageScheduledPlans identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_manage_scheduled_plans_with_http_info(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_manage_scheduled_plans_with_http_info(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ManageScheduledPlansApi(object):
 
         Deletes an existing manageScheduledPlans file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_manage_scheduled_plans_file(manage_scheduled_plans_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_manage_scheduled_plans_file(manage_scheduled_plans_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ManageScheduledPlansApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_manage_scheduled_plans_file_with_http_info(manage_scheduled_plans_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_manage_scheduled_plans_file_with_http_info(manage_scheduled_plans_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ManageScheduledPlansApi(object):
 
         Deletes an existing manageScheduledPlans file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_manage_scheduled_plans_file_with_http_info(manage_scheduled_plans_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_manage_scheduled_plans_file_with_http_info(manage_scheduled_plans_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ManageScheduledPlansApi(object):
 
         Deletes an existing manageScheduledPlans tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_manage_scheduled_plans_tag(manage_scheduled_plans_id, manage_scheduled_plans_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_manage_scheduled_plans_tag(manage_scheduled_plans_id, manage_scheduled_plans_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to remove tag from (required)
         :param str manage_scheduled_plans_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ManageScheduledPlansApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_manage_scheduled_plans_tag_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_manage_scheduled_plans_tag_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ManageScheduledPlansApi(object):
 
         Deletes an existing manageScheduledPlans tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_manage_scheduled_plans_tag_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_manage_scheduled_plans_tag_with_http_info(manage_scheduled_plans_id, manage_scheduled_plans_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to remove tag from (required)
         :param str manage_scheduled_plans_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id', 'manage_scheduled_plans_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ManageScheduledPlansApi(object):
 
         Returns a duplicated manageScheduledPlans identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_manage_scheduled_plans_by_id(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_manage_scheduled_plans_by_id(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to be duplicated. (required)
         :return: ManageScheduledPlans
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_manage_scheduled_plans_by_id_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_manage_scheduled_plans_by_id_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ManageScheduledPlansApi(object):
 
         Returns a duplicated manageScheduledPlans identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_manage_scheduled_plans_by_id_with_http_info(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_manage_scheduled_plans_by_id_with_http_info(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to be duplicated. (required)
         :return: ManageScheduledPlans
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type='ManageScheduledPlans',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ManageScheduledPlansApi(object):
 
         Returns the list of manageScheduledPlanses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manage_scheduled_plans_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manage_scheduled_plans_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ManageScheduledPlansApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_manage_scheduled_plans_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_manage_scheduled_plans_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ManageScheduledPlansApi(object):
 
         Returns the list of manageScheduledPlanses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manage_scheduled_plans_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manage_scheduled_plans_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type='list[ManageScheduledPlans]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ManageScheduledPlansApi(object):
 
         Returns the manageScheduledPlans identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manage_scheduled_plans_by_id(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manage_scheduled_plans_by_id(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to be returned. (required)
         :return: ManageScheduledPlans
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_manage_scheduled_plans_by_id_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_manage_scheduled_plans_by_id_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ManageScheduledPlansApi(object):
 
         Returns the manageScheduledPlans identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manage_scheduled_plans_by_id_with_http_info(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manage_scheduled_plans_by_id_with_http_info(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to be returned. (required)
         :return: ManageScheduledPlans
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type='ManageScheduledPlans',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ManageScheduledPlansApi(object):
 
         Get all existing manageScheduledPlans files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manage_scheduled_plans_files(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manage_scheduled_plans_files(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_manage_scheduled_plans_files_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_manage_scheduled_plans_files_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ManageScheduledPlansApi(object):
 
         Get all existing manageScheduledPlans files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manage_scheduled_plans_files_with_http_info(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manage_scheduled_plans_files_with_http_info(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ManageScheduledPlansApi(object):
 
         Get all existing manageScheduledPlans tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manage_scheduled_plans_tags(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manage_scheduled_plans_tags(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_manage_scheduled_plans_tags_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_manage_scheduled_plans_tags_with_http_info(manage_scheduled_plans_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ManageScheduledPlansApi(object):
 
         Get all existing manageScheduledPlans tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manage_scheduled_plans_tags_with_http_info(manage_scheduled_plans_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manage_scheduled_plans_tags_with_http_info(manage_scheduled_plans_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int manage_scheduled_plans_id: Id of the manageScheduledPlans to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['manage_scheduled_plans_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ManageScheduledPlansApi(object):
 
         Updates an existing manageScheduledPlans using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_manage_scheduled_plans(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_manage_scheduled_plans(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ManageScheduledPlans body: ManageScheduledPlans to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_manage_scheduled_plans_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_manage_scheduled_plans_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ManageScheduledPlansApi(object):
 
         Updates an existing manageScheduledPlans using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_manage_scheduled_plans_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_manage_scheduled_plans_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ManageScheduledPlans body: ManageScheduledPlans to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ManageScheduledPlansApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ManageScheduledPlansApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/manifest_partner_api.py
+++ b/Infoplus/api/manifest_partner_api.py
@@ -38,11 +38,11 @@ class ManifestPartnerApi(object):
 
         Returns the list of manifestPartners that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manifest_partner_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manifest_partner_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -51,7 +51,7 @@ class ManifestPartnerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_manifest_partner_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_manifest_partner_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -62,11 +62,11 @@ class ManifestPartnerApi(object):
 
         Returns the list of manifestPartners that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manifest_partner_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manifest_partner_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -76,7 +76,7 @@ class ManifestPartnerApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ManifestPartnerApi(object):
             files=local_var_files,
             response_type='list[ManifestPartner]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,18 +137,18 @@ class ManifestPartnerApi(object):
 
         Returns the manifestPartner identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manifest_solution_provider_by_id(manifest_partner_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manifest_solution_provider_by_id(manifest_partner_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str manifest_partner_id: Id of manifestPartner to be returned. (required)
         :return: ManifestPartner
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_manifest_solution_provider_by_id_with_http_info(manifest_partner_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_manifest_solution_provider_by_id_with_http_info(manifest_partner_id, **kwargs)  # noqa: E501
@@ -159,11 +159,11 @@ class ManifestPartnerApi(object):
 
         Returns the manifestPartner identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_manifest_solution_provider_by_id_with_http_info(manifest_partner_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_manifest_solution_provider_by_id_with_http_info(manifest_partner_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str manifest_partner_id: Id of manifestPartner to be returned. (required)
         :return: ManifestPartner
                  If the method is called asynchronously,
@@ -171,7 +171,7 @@ class ManifestPartnerApi(object):
         """
 
         all_params = ['manifest_partner_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class ManifestPartnerApi(object):
             files=local_var_files,
             response_type='ManifestPartner',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/non_business_day_api.py
+++ b/Infoplus/api/non_business_day_api.py
@@ -38,18 +38,18 @@ class NonBusinessDayApi(object):
 
         Inserts a new nonBusinessDay using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param NonBusinessDay body: NonBusinessDay to be inserted. (required)
         :return: NonBusinessDay
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_non_business_day_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_non_business_day_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class NonBusinessDayApi(object):
 
         Inserts a new nonBusinessDay using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param NonBusinessDay body: NonBusinessDay to be inserted. (required)
         :return: NonBusinessDay
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type='NonBusinessDay',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class NonBusinessDayApi(object):
 
         Adds an audit to an existing nonBusinessDay.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day_audit(non_business_day_id, non_business_day_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day_audit(non_business_day_id, non_business_day_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to add an audit to (required)
         :param str non_business_day_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class NonBusinessDayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_non_business_day_audit_with_http_info(non_business_day_id, non_business_day_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_non_business_day_audit_with_http_info(non_business_day_id, non_business_day_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class NonBusinessDayApi(object):
 
         Adds an audit to an existing nonBusinessDay.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day_audit_with_http_info(non_business_day_id, non_business_day_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day_audit_with_http_info(non_business_day_id, non_business_day_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to add an audit to (required)
         :param str non_business_day_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id', 'non_business_day_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class NonBusinessDayApi(object):
 
         Adds a file to an existing nonBusinessDay.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day_file(non_business_day_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day_file(non_business_day_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class NonBusinessDayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_non_business_day_file_with_http_info(non_business_day_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_non_business_day_file_with_http_info(non_business_day_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class NonBusinessDayApi(object):
 
         Adds a file to an existing nonBusinessDay.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day_file_with_http_info(non_business_day_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day_file_with_http_info(non_business_day_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class NonBusinessDayApi(object):
 
         Adds a file to an existing nonBusinessDay by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day_file_by_url(body, non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day_file_by_url(body, non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int non_business_day_id: Id of the nonBusinessDay to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class NonBusinessDayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_non_business_day_file_by_url_with_http_info(body, non_business_day_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_non_business_day_file_by_url_with_http_info(body, non_business_day_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class NonBusinessDayApi(object):
 
         Adds a file to an existing nonBusinessDay by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day_file_by_url_with_http_info(body, non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day_file_by_url_with_http_info(body, non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int non_business_day_id: Id of the nonBusinessDay to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['body', 'non_business_day_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class NonBusinessDayApi(object):
 
         Adds a tag to an existing nonBusinessDay.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day_tag(non_business_day_id, non_business_day_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day_tag(non_business_day_id, non_business_day_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to add a tag to (required)
         :param str non_business_day_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class NonBusinessDayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_non_business_day_tag_with_http_info(non_business_day_id, non_business_day_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_non_business_day_tag_with_http_info(non_business_day_id, non_business_day_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class NonBusinessDayApi(object):
 
         Adds a tag to an existing nonBusinessDay.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_non_business_day_tag_with_http_info(non_business_day_id, non_business_day_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_non_business_day_tag_with_http_info(non_business_day_id, non_business_day_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to add a tag to (required)
         :param str non_business_day_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id', 'non_business_day_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class NonBusinessDayApi(object):
 
         Deletes the nonBusinessDay identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_non_business_day(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_non_business_day(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_non_business_day_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_non_business_day_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class NonBusinessDayApi(object):
 
         Deletes the nonBusinessDay identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_non_business_day_with_http_info(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_non_business_day_with_http_info(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class NonBusinessDayApi(object):
 
         Deletes an existing nonBusinessDay file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_non_business_day_file(non_business_day_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_non_business_day_file(non_business_day_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class NonBusinessDayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_non_business_day_file_with_http_info(non_business_day_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_non_business_day_file_with_http_info(non_business_day_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class NonBusinessDayApi(object):
 
         Deletes an existing nonBusinessDay file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_non_business_day_file_with_http_info(non_business_day_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_non_business_day_file_with_http_info(non_business_day_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class NonBusinessDayApi(object):
 
         Deletes an existing nonBusinessDay tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_non_business_day_tag(non_business_day_id, non_business_day_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_non_business_day_tag(non_business_day_id, non_business_day_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to remove tag from (required)
         :param str non_business_day_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class NonBusinessDayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_non_business_day_tag_with_http_info(non_business_day_id, non_business_day_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_non_business_day_tag_with_http_info(non_business_day_id, non_business_day_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class NonBusinessDayApi(object):
 
         Deletes an existing nonBusinessDay tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_non_business_day_tag_with_http_info(non_business_day_id, non_business_day_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_non_business_day_tag_with_http_info(non_business_day_id, non_business_day_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to remove tag from (required)
         :param str non_business_day_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id', 'non_business_day_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class NonBusinessDayApi(object):
 
         Returns a duplicated nonBusinessDay identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_non_business_day_by_id(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_non_business_day_by_id(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to be duplicated. (required)
         :return: NonBusinessDay
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_non_business_day_by_id_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_non_business_day_by_id_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class NonBusinessDayApi(object):
 
         Returns a duplicated nonBusinessDay identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_non_business_day_by_id_with_http_info(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_non_business_day_by_id_with_http_info(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to be duplicated. (required)
         :return: NonBusinessDay
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type='NonBusinessDay',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class NonBusinessDayApi(object):
 
         Returns the list of nonBusinessDays that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_non_business_day_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_non_business_day_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class NonBusinessDayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_non_business_day_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_non_business_day_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class NonBusinessDayApi(object):
 
         Returns the list of nonBusinessDays that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_non_business_day_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_non_business_day_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type='list[NonBusinessDay]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class NonBusinessDayApi(object):
 
         Returns the nonBusinessDay identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_non_business_day_by_id(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_non_business_day_by_id(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to be returned. (required)
         :return: NonBusinessDay
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_non_business_day_by_id_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_non_business_day_by_id_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class NonBusinessDayApi(object):
 
         Returns the nonBusinessDay identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_non_business_day_by_id_with_http_info(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_non_business_day_by_id_with_http_info(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to be returned. (required)
         :return: NonBusinessDay
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type='NonBusinessDay',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class NonBusinessDayApi(object):
 
         Get all existing nonBusinessDay files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_non_business_day_files(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_non_business_day_files(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_non_business_day_files_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_non_business_day_files_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class NonBusinessDayApi(object):
 
         Get all existing nonBusinessDay files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_non_business_day_files_with_http_info(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_non_business_day_files_with_http_info(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class NonBusinessDayApi(object):
 
         Get all existing nonBusinessDay tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_non_business_day_tags(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_non_business_day_tags(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_non_business_day_tags_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_non_business_day_tags_with_http_info(non_business_day_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class NonBusinessDayApi(object):
 
         Get all existing nonBusinessDay tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_non_business_day_tags_with_http_info(non_business_day_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_non_business_day_tags_with_http_info(non_business_day_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int non_business_day_id: Id of the nonBusinessDay to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['non_business_day_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class NonBusinessDayApi(object):
 
         Updates an existing nonBusinessDay using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_non_business_day(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_non_business_day(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param NonBusinessDay body: NonBusinessDay to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_non_business_day_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_non_business_day_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class NonBusinessDayApi(object):
 
         Updates an existing nonBusinessDay using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_non_business_day_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_non_business_day_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param NonBusinessDay body: NonBusinessDay to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class NonBusinessDayApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class NonBusinessDayApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/oms_order_api.py
+++ b/Infoplus/api/oms_order_api.py
@@ -38,18 +38,18 @@ class OmsOrderApi(object):
 
         Inserts a new omsOrder using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OmsOrder body: OmsOrder to be inserted. (required)
         :return: OmsOrder
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_oms_order_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_oms_order_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class OmsOrderApi(object):
 
         Inserts a new omsOrder using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OmsOrder body: OmsOrder to be inserted. (required)
         :return: OmsOrder
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type='OmsOrder',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class OmsOrderApi(object):
 
         Adds an audit to an existing omsOrder.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order_audit(oms_order_id, oms_order_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order_audit(oms_order_id, oms_order_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to add an audit to (required)
         :param str oms_order_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class OmsOrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_oms_order_audit_with_http_info(oms_order_id, oms_order_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_oms_order_audit_with_http_info(oms_order_id, oms_order_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class OmsOrderApi(object):
 
         Adds an audit to an existing omsOrder.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order_audit_with_http_info(oms_order_id, oms_order_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order_audit_with_http_info(oms_order_id, oms_order_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to add an audit to (required)
         :param str oms_order_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['oms_order_id', 'oms_order_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class OmsOrderApi(object):
 
         Adds a file to an existing omsOrder.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order_file(oms_order_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order_file(oms_order_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class OmsOrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_oms_order_file_with_http_info(oms_order_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_oms_order_file_with_http_info(oms_order_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class OmsOrderApi(object):
 
         Adds a file to an existing omsOrder.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order_file_with_http_info(oms_order_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order_file_with_http_info(oms_order_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['oms_order_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class OmsOrderApi(object):
 
         Adds a file to an existing omsOrder by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order_file_by_url(body, oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order_file_by_url(body, oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int oms_order_id: Id of the omsOrder to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class OmsOrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_oms_order_file_by_url_with_http_info(body, oms_order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_oms_order_file_by_url_with_http_info(body, oms_order_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class OmsOrderApi(object):
 
         Adds a file to an existing omsOrder by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order_file_by_url_with_http_info(body, oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order_file_by_url_with_http_info(body, oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int oms_order_id: Id of the omsOrder to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['body', 'oms_order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class OmsOrderApi(object):
 
         Adds a tag to an existing omsOrder.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order_tag(oms_order_id, oms_order_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order_tag(oms_order_id, oms_order_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to add a tag to (required)
         :param str oms_order_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class OmsOrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_oms_order_tag_with_http_info(oms_order_id, oms_order_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_oms_order_tag_with_http_info(oms_order_id, oms_order_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class OmsOrderApi(object):
 
         Adds a tag to an existing omsOrder.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_oms_order_tag_with_http_info(oms_order_id, oms_order_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_oms_order_tag_with_http_info(oms_order_id, oms_order_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to add a tag to (required)
         :param str oms_order_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['oms_order_id', 'oms_order_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,11 +561,11 @@ class OmsOrderApi(object):
 
         Deletes an existing omsOrder file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_oms_order_file(oms_order_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_oms_order_file(oms_order_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -573,7 +573,7 @@ class OmsOrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_oms_order_file_with_http_info(oms_order_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_oms_order_file_with_http_info(oms_order_id, file_id, **kwargs)  # noqa: E501
@@ -584,11 +584,11 @@ class OmsOrderApi(object):
 
         Deletes an existing omsOrder file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_oms_order_file_with_http_info(oms_order_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_oms_order_file_with_http_info(oms_order_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -597,7 +597,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['oms_order_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -653,7 +653,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -664,11 +664,11 @@ class OmsOrderApi(object):
 
         Deletes an existing omsOrder tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_oms_order_tag(oms_order_id, oms_order_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_oms_order_tag(oms_order_id, oms_order_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to remove tag from (required)
         :param str oms_order_tag: The tag to delete (required)
         :return: None
@@ -676,7 +676,7 @@ class OmsOrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_oms_order_tag_with_http_info(oms_order_id, oms_order_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_oms_order_tag_with_http_info(oms_order_id, oms_order_tag, **kwargs)  # noqa: E501
@@ -687,11 +687,11 @@ class OmsOrderApi(object):
 
         Deletes an existing omsOrder tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_oms_order_tag_with_http_info(oms_order_id, oms_order_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_oms_order_tag_with_http_info(oms_order_id, oms_order_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to remove tag from (required)
         :param str oms_order_tag: The tag to delete (required)
         :return: None
@@ -700,7 +700,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['oms_order_id', 'oms_order_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -756,7 +756,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -767,18 +767,18 @@ class OmsOrderApi(object):
 
         Returns a duplicated omsOrder identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_oms_order_by_id(oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_oms_order_by_id(oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to be duplicated. (required)
         :return: OmsOrder
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_oms_order_by_id_with_http_info(oms_order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_oms_order_by_id_with_http_info(oms_order_id, **kwargs)  # noqa: E501
@@ -789,11 +789,11 @@ class OmsOrderApi(object):
 
         Returns a duplicated omsOrder identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_oms_order_by_id_with_http_info(oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_oms_order_by_id_with_http_info(oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to be duplicated. (required)
         :return: OmsOrder
                  If the method is called asynchronously,
@@ -801,7 +801,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['oms_order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type='OmsOrder',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class OmsOrderApi(object):
 
         Returns the list of omsOrders that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_oms_order_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_oms_order_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class OmsOrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_oms_order_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_oms_order_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class OmsOrderApi(object):
 
         Returns the list of omsOrders that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_oms_order_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_oms_order_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type='list[OmsOrder]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class OmsOrderApi(object):
 
         Returns the omsOrder identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_oms_order_by_id(oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_oms_order_by_id(oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to be returned. (required)
         :return: OmsOrder
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_oms_order_by_id_with_http_info(oms_order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_oms_order_by_id_with_http_info(oms_order_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class OmsOrderApi(object):
 
         Returns the omsOrder identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_oms_order_by_id_with_http_info(oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_oms_order_by_id_with_http_info(oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to be returned. (required)
         :return: OmsOrder
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['oms_order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type='OmsOrder',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class OmsOrderApi(object):
 
         Get all existing omsOrder files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_oms_order_files(oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_oms_order_files(oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_oms_order_files_with_http_info(oms_order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_oms_order_files_with_http_info(oms_order_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class OmsOrderApi(object):
 
         Get all existing omsOrder files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_oms_order_files_with_http_info(oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_oms_order_files_with_http_info(oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['oms_order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class OmsOrderApi(object):
 
         Get all existing omsOrder tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_oms_order_tags(oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_oms_order_tags(oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_oms_order_tags_with_http_info(oms_order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_oms_order_tags_with_http_info(oms_order_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class OmsOrderApi(object):
 
         Get all existing omsOrder tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_oms_order_tags_with_http_info(oms_order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_oms_order_tags_with_http_info(oms_order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int oms_order_id: Id of the omsOrder to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['oms_order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class OmsOrderApi(object):
 
         Updates an existing omsOrder using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_oms_order(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_oms_order(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OmsOrder body: OmsOrder to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_oms_order_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_oms_order_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class OmsOrderApi(object):
 
         Updates an existing omsOrder using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_oms_order_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_oms_order_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OmsOrder body: OmsOrder to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1349,18 +1349,18 @@ class OmsOrderApi(object):
 
         Updates an existing omsOrder custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_oms_order_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_oms_order_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OmsOrder body: OmsOrder to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_oms_order_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_oms_order_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1371,11 +1371,11 @@ class OmsOrderApi(object):
 
         Updates an existing omsOrder custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_oms_order_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_oms_order_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OmsOrder body: OmsOrder to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1383,7 +1383,7 @@ class OmsOrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1437,7 +1437,7 @@ class OmsOrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_activity_api.py
+++ b/Infoplus/api/order_activity_api.py
@@ -38,18 +38,18 @@ class OrderActivityApi(object):
 
         Inserts a new orderActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderActivity body: OrderActivity to be inserted. (required)
         :return: OrderActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class OrderActivityApi(object):
 
         Inserts a new orderActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderActivity body: OrderActivity to be inserted. (required)
         :return: OrderActivity
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type='OrderActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class OrderActivityApi(object):
 
         Adds an audit to an existing orderActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity_audit(order_activity_id, order_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity_audit(order_activity_id, order_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to add an audit to (required)
         :param str order_activity_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class OrderActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_activity_audit_with_http_info(order_activity_id, order_activity_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_activity_audit_with_http_info(order_activity_id, order_activity_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class OrderActivityApi(object):
 
         Adds an audit to an existing orderActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity_audit_with_http_info(order_activity_id, order_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity_audit_with_http_info(order_activity_id, order_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to add an audit to (required)
         :param str order_activity_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id', 'order_activity_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class OrderActivityApi(object):
 
         Adds a file to an existing orderActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity_file(order_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity_file(order_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class OrderActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_activity_file_with_http_info(order_activity_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_activity_file_with_http_info(order_activity_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class OrderActivityApi(object):
 
         Adds a file to an existing orderActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity_file_with_http_info(order_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity_file_with_http_info(order_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class OrderActivityApi(object):
 
         Adds a file to an existing orderActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity_file_by_url(body, order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity_file_by_url(body, order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param float order_activity_id: Id of the orderActivity to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class OrderActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_activity_file_by_url_with_http_info(body, order_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_activity_file_by_url_with_http_info(body, order_activity_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class OrderActivityApi(object):
 
         Adds a file to an existing orderActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity_file_by_url_with_http_info(body, order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity_file_by_url_with_http_info(body, order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param float order_activity_id: Id of the orderActivity to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['body', 'order_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class OrderActivityApi(object):
 
         Adds a tag to an existing orderActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity_tag(order_activity_id, order_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity_tag(order_activity_id, order_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to add a tag to (required)
         :param str order_activity_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class OrderActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_activity_tag_with_http_info(order_activity_id, order_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_activity_tag_with_http_info(order_activity_id, order_activity_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class OrderActivityApi(object):
 
         Adds a tag to an existing orderActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_activity_tag_with_http_info(order_activity_id, order_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_activity_tag_with_http_info(order_activity_id, order_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to add a tag to (required)
         :param str order_activity_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id', 'order_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class OrderActivityApi(object):
 
         Deletes the orderActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_activity(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_activity(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_activity_with_http_info(order_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_activity_with_http_info(order_activity_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class OrderActivityApi(object):
 
         Deletes the orderActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_activity_with_http_info(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_activity_with_http_info(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class OrderActivityApi(object):
 
         Deletes an existing orderActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_activity_file(order_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_activity_file(order_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class OrderActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_activity_file_with_http_info(order_activity_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_activity_file_with_http_info(order_activity_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class OrderActivityApi(object):
 
         Deletes an existing orderActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_activity_file_with_http_info(order_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_activity_file_with_http_info(order_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class OrderActivityApi(object):
 
         Deletes an existing orderActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_activity_tag(order_activity_id, order_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_activity_tag(order_activity_id, order_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to remove tag from (required)
         :param str order_activity_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class OrderActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_activity_tag_with_http_info(order_activity_id, order_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_activity_tag_with_http_info(order_activity_id, order_activity_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class OrderActivityApi(object):
 
         Deletes an existing orderActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_activity_tag_with_http_info(order_activity_id, order_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_activity_tag_with_http_info(order_activity_id, order_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to remove tag from (required)
         :param str order_activity_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id', 'order_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class OrderActivityApi(object):
 
         Returns a duplicated orderActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_activity_by_id(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_activity_by_id(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to be duplicated. (required)
         :return: OrderActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_order_activity_by_id_with_http_info(order_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_order_activity_by_id_with_http_info(order_activity_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class OrderActivityApi(object):
 
         Returns a duplicated orderActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_activity_by_id_with_http_info(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_activity_by_id_with_http_info(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to be duplicated. (required)
         :return: OrderActivity
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type='OrderActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class OrderActivityApi(object):
 
         Returns the list of orderActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_activity_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_activity_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class OrderActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class OrderActivityApi(object):
 
         Returns the list of orderActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_activity_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_activity_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type='list[OrderActivity]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class OrderActivityApi(object):
 
         Returns the orderActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_activity_by_id(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_activity_by_id(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to be returned. (required)
         :return: OrderActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_activity_by_id_with_http_info(order_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_activity_by_id_with_http_info(order_activity_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class OrderActivityApi(object):
 
         Returns the orderActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_activity_by_id_with_http_info(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_activity_by_id_with_http_info(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to be returned. (required)
         :return: OrderActivity
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type='OrderActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class OrderActivityApi(object):
 
         Get all existing orderActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_activity_files(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_activity_files(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_activity_files_with_http_info(order_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_activity_files_with_http_info(order_activity_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class OrderActivityApi(object):
 
         Get all existing orderActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_activity_files_with_http_info(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_activity_files_with_http_info(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class OrderActivityApi(object):
 
         Get all existing orderActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_activity_tags(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_activity_tags(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_activity_tags_with_http_info(order_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_activity_tags_with_http_info(order_activity_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class OrderActivityApi(object):
 
         Get all existing orderActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_activity_tags_with_http_info(order_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_activity_tags_with_http_info(order_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_activity_id: Id of the orderActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['order_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class OrderActivityApi(object):
 
         Updates an existing orderActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderActivity body: OrderActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class OrderActivityApi(object):
 
         Updates an existing orderActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderActivity body: OrderActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class OrderActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class OrderActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_api.py
+++ b/Infoplus/api/order_api.py
@@ -38,18 +38,18 @@ class OrderApi(object):
 
         Inserts a new order using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Order body: Order to be inserted. (required)
         :return: Order
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class OrderApi(object):
 
         Inserts a new order using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Order body: Order to be inserted. (required)
         :return: Order
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class OrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='Order',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class OrderApi(object):
 
         Adds an audit to an existing order.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_audit(order_id, order_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_audit(order_id, order_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to add an audit to (required)
         :param str order_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class OrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_audit_with_http_info(order_id, order_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_audit_with_http_info(order_id, order_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class OrderApi(object):
 
         Adds an audit to an existing order.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_audit_with_http_info(order_id, order_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_audit_with_http_info(order_id, order_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to add an audit to (required)
         :param str order_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id', 'order_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class OrderApi(object):
 
         Adds a file to an existing order.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_file(order_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_file(order_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class OrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_file_with_http_info(order_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_file_with_http_info(order_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class OrderApi(object):
 
         Adds a file to an existing order.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_file_with_http_info(order_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_file_with_http_info(order_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class OrderApi(object):
 
         Adds a file to an existing order by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_file_by_url(body, order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_file_by_url(body, order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param float order_id: Id of the order to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class OrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_file_by_url_with_http_info(body, order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_file_by_url_with_http_info(body, order_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class OrderApi(object):
 
         Adds a file to an existing order by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_file_by_url_with_http_info(body, order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_file_by_url_with_http_info(body, order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param float order_id: Id of the order to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class OrderApi(object):
         """
 
         all_params = ['body', 'order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class OrderApi(object):
 
         Adds a tag to an existing order.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_tag(order_id, order_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_tag(order_id, order_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to add a tag to (required)
         :param str order_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class OrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_tag_with_http_info(order_id, order_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_tag_with_http_info(order_id, order_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class OrderApi(object):
 
         Adds a tag to an existing order.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_tag_with_http_info(order_id, order_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_tag_with_http_info(order_id, order_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to add a tag to (required)
         :param str order_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id', 'order_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.apply_order_warehouse_fulfillment_plan(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.apply_order_warehouse_fulfillment_plan(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ApplyOrderWarehouseFulfillmentPlanInput body: Input data for Apply Order Warehouse Fulfillment Plan process. (required)
         :return: ApplyOrderWarehouseFulfillmentPlanOutput
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.apply_order_warehouse_fulfillment_plan_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.apply_order_warehouse_fulfillment_plan_with_http_info(body, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.apply_order_warehouse_fulfillment_plan_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.apply_order_warehouse_fulfillment_plan_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ApplyOrderWarehouseFulfillmentPlanInput body: Input data for Apply Order Warehouse Fulfillment Plan process. (required)
         :return: ApplyOrderWarehouseFulfillmentPlanOutput
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class OrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='ApplyOrderWarehouseFulfillmentPlanOutput',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,18 +656,18 @@ class OrderApi(object):
 
         Deletes the order identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
@@ -678,11 +678,11 @@ class OrderApi(object):
 
         Deletes the order identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_with_http_info(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_with_http_info(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -690,7 +690,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -740,7 +740,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -751,11 +751,11 @@ class OrderApi(object):
 
         Deletes an existing order file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_file(order_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_file(order_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -763,7 +763,7 @@ class OrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_file_with_http_info(order_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_file_with_http_info(order_id, file_id, **kwargs)  # noqa: E501
@@ -774,11 +774,11 @@ class OrderApi(object):
 
         Deletes an existing order file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_file_with_http_info(order_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_file_with_http_info(order_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -787,7 +787,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -843,7 +843,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -854,11 +854,11 @@ class OrderApi(object):
 
         Deletes an existing order tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_tag(order_id, order_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_tag(order_id, order_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to remove tag from (required)
         :param str order_tag: The tag to delete (required)
         :return: None
@@ -866,7 +866,7 @@ class OrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_tag_with_http_info(order_id, order_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_tag_with_http_info(order_id, order_tag, **kwargs)  # noqa: E501
@@ -877,11 +877,11 @@ class OrderApi(object):
 
         Deletes an existing order tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_tag_with_http_info(order_id, order_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_tag_with_http_info(order_id, order_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to remove tag from (required)
         :param str order_tag: The tag to delete (required)
         :return: None
@@ -890,7 +890,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id', 'order_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,18 +957,18 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.edit_fulfillment_channel(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.edit_fulfillment_channel(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EditLineItemFulfillmentStrategyInputAPIModel body: Input data for EditLineItemFulfillmentStrategy process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.edit_fulfillment_channel_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.edit_fulfillment_channel_with_http_info(body, **kwargs)  # noqa: E501
@@ -979,11 +979,11 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.edit_fulfillment_channel_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.edit_fulfillment_channel_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param EditLineItemFulfillmentStrategyInputAPIModel body: Input data for EditLineItemFulfillmentStrategy process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
@@ -991,7 +991,7 @@ class OrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1041,7 +1041,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='list[ProcessOutputAPIModel]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1052,18 +1052,18 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.edit_line_items(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.edit_line_items(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReqManualSubstitutionInputAPIModel body: Input data for ReqManualSubstitution process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.edit_line_items_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.edit_line_items_with_http_info(body, **kwargs)  # noqa: E501
@@ -1074,11 +1074,11 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.edit_line_items_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.edit_line_items_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReqManualSubstitutionInputAPIModel body: Input data for ReqManualSubstitution process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
@@ -1086,7 +1086,7 @@ class OrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1136,7 +1136,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='list[ProcessOutputAPIModel]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1147,18 +1147,18 @@ class OrderApi(object):
 
         Returns a duplicated order identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_by_id(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_by_id(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to be duplicated. (required)
         :return: Order
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
@@ -1169,11 +1169,11 @@ class OrderApi(object):
 
         Returns a duplicated order identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_by_id_with_http_info(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_by_id_with_http_info(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to be duplicated. (required)
         :return: Order
                  If the method is called asynchronously,
@@ -1181,7 +1181,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1231,7 +1231,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='Order',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1242,11 +1242,11 @@ class OrderApi(object):
 
         Returns the list of orders that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1256,7 +1256,7 @@ class OrderApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -1267,11 +1267,11 @@ class OrderApi(object):
 
         Returns the list of orders that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1282,7 +1282,7 @@ class OrderApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='list[Order]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class OrderApi(object):
 
         Returns the order identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_by_id(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_by_id(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to be returned. (required)
         :return: Order
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class OrderApi(object):
 
         Returns the order identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_by_id_with_http_info(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_by_id_with_http_info(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to be returned. (required)
         :return: Order
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1429,7 +1429,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='Order',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1440,18 +1440,18 @@ class OrderApi(object):
 
         Get all existing order files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_files(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_files(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_files_with_http_info(order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_files_with_http_info(order_id, **kwargs)  # noqa: E501
@@ -1462,11 +1462,11 @@ class OrderApi(object):
 
         Get all existing order files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_files_with_http_info(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_files_with_http_info(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1474,7 +1474,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1524,7 +1524,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1535,18 +1535,18 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_pack_data(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_pack_data(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param GetOrderPackDataInput body: Input data for Get Order Pack Data process. (required)
         :return: GetOrderPackDataOutput
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_pack_data_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_pack_data_with_http_info(body, **kwargs)  # noqa: E501
@@ -1557,11 +1557,11 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_pack_data_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_pack_data_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param GetOrderPackDataInput body: Input data for Get Order Pack Data process. (required)
         :return: GetOrderPackDataOutput
                  If the method is called asynchronously,
@@ -1569,7 +1569,7 @@ class OrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1619,7 +1619,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='GetOrderPackDataOutput',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1630,18 +1630,18 @@ class OrderApi(object):
 
         Get all existing order tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_tags(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_tags(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_tags_with_http_info(order_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_tags_with_http_info(order_id, **kwargs)  # noqa: E501
@@ -1652,11 +1652,11 @@ class OrderApi(object):
 
         Get all existing order tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_tags_with_http_info(order_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_tags_with_http_info(order_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param float order_id: Id of the order to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1664,7 +1664,7 @@ class OrderApi(object):
         """
 
         all_params = ['order_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1714,7 +1714,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1725,18 +1725,18 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_warehouse_fulfillment_data(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_warehouse_fulfillment_data(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param GetOrderWarehouseFulfillmentDataInput body: Input data for Get Order Warehouse Fulfillment Plan process. (required)
         :return: GetOrderWarehouseFulfillmentDataOutput
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_warehouse_fulfillment_data_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_warehouse_fulfillment_data_with_http_info(body, **kwargs)  # noqa: E501
@@ -1747,11 +1747,11 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_warehouse_fulfillment_data_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_warehouse_fulfillment_data_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param GetOrderWarehouseFulfillmentDataInput body: Input data for Get Order Warehouse Fulfillment Plan process. (required)
         :return: GetOrderWarehouseFulfillmentDataOutput
                  If the method is called asynchronously,
@@ -1759,7 +1759,7 @@ class OrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1809,7 +1809,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='GetOrderWarehouseFulfillmentDataOutput',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1820,18 +1820,18 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.run_fulfillment_plan(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.run_fulfillment_plan(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RunFulfillmentPlanInputAPIModel body: Input data for RunFulfillmentPlan process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.run_fulfillment_plan_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.run_fulfillment_plan_with_http_info(body, **kwargs)  # noqa: E501
@@ -1842,11 +1842,11 @@ class OrderApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.run_fulfillment_plan_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.run_fulfillment_plan_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RunFulfillmentPlanInputAPIModel body: Input data for RunFulfillmentPlan process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
@@ -1854,7 +1854,7 @@ class OrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1904,7 +1904,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type='list[ProcessOutputAPIModel]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1915,18 +1915,18 @@ class OrderApi(object):
 
         Updates an existing order using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Order body: Order to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_with_http_info(body, **kwargs)  # noqa: E501
@@ -1937,11 +1937,11 @@ class OrderApi(object):
 
         Updates an existing order using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Order body: Order to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1949,7 +1949,7 @@ class OrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -2003,7 +2003,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -2014,18 +2014,18 @@ class OrderApi(object):
 
         Updates an existing order custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Order body: Order to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -2036,11 +2036,11 @@ class OrderApi(object):
 
         Updates an existing order custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Order body: Order to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -2048,7 +2048,7 @@ class OrderApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -2102,7 +2102,7 @@ class OrderApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_invoice_template_line_item_description_enum_api.py
+++ b/Infoplus/api/order_invoice_template_line_item_description_enum_api.py
@@ -38,18 +38,18 @@ class OrderInvoiceTemplateLineItemDescriptionEnumApi(object):
 
         Returns the orderInvoiceTemplateLineItemDescriptionEnum identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_invoice_template_line_item_description_enum_by_id(order_invoice_template_line_item_description_enum_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_invoice_template_line_item_description_enum_by_id(order_invoice_template_line_item_description_enum_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str order_invoice_template_line_item_description_enum_id: Id of orderInvoiceTemplateLineItemDescriptionEnum to be returned. (required)
         :return: OrderInvoiceTemplateLineItemDescriptionEnum
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_invoice_template_line_item_description_enum_by_id_with_http_info(order_invoice_template_line_item_description_enum_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_invoice_template_line_item_description_enum_by_id_with_http_info(order_invoice_template_line_item_description_enum_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class OrderInvoiceTemplateLineItemDescriptionEnumApi(object):
 
         Returns the orderInvoiceTemplateLineItemDescriptionEnum identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_invoice_template_line_item_description_enum_by_id_with_http_info(order_invoice_template_line_item_description_enum_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_invoice_template_line_item_description_enum_by_id_with_http_info(order_invoice_template_line_item_description_enum_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str order_invoice_template_line_item_description_enum_id: Id of orderInvoiceTemplateLineItemDescriptionEnum to be returned. (required)
         :return: OrderInvoiceTemplateLineItemDescriptionEnum
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class OrderInvoiceTemplateLineItemDescriptionEnumApi(object):
         """
 
         all_params = ['order_invoice_template_line_item_description_enum_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class OrderInvoiceTemplateLineItemDescriptionEnumApi(object):
             files=local_var_files,
             response_type='OrderInvoiceTemplateLineItemDescriptionEnum',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class OrderInvoiceTemplateLineItemDescriptionEnumApi(object):
 
         Returns the list of orderInvoiceTemplateLineItemDescriptionEnums that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_invoice_template_line_item_description_enum_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_invoice_template_line_item_description_enum_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class OrderInvoiceTemplateLineItemDescriptionEnumApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_invoice_template_line_item_description_enum_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_invoice_template_line_item_description_enum_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class OrderInvoiceTemplateLineItemDescriptionEnumApi(object):
 
         Returns the list of orderInvoiceTemplateLineItemDescriptionEnums that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_invoice_template_line_item_description_enum_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_invoice_template_line_item_description_enum_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class OrderInvoiceTemplateLineItemDescriptionEnumApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class OrderInvoiceTemplateLineItemDescriptionEnumApi(object):
             files=local_var_files,
             response_type='list[OrderInvoiceTemplateLineItemDescriptionEnum]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_line_activity_api.py
+++ b/Infoplus/api/order_line_activity_api.py
@@ -38,18 +38,18 @@ class OrderLineActivityApi(object):
 
         Inserts a new orderLineActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderLineActivity body: OrderLineActivity to be inserted. (required)
         :return: OrderLineActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_line_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_line_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class OrderLineActivityApi(object):
 
         Inserts a new orderLineActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderLineActivity body: OrderLineActivity to be inserted. (required)
         :return: OrderLineActivity
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type='OrderLineActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class OrderLineActivityApi(object):
 
         Adds an audit to an existing orderLineActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity_audit(order_line_activity_id, order_line_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity_audit(order_line_activity_id, order_line_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to add an audit to (required)
         :param str order_line_activity_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class OrderLineActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_line_activity_audit_with_http_info(order_line_activity_id, order_line_activity_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_line_activity_audit_with_http_info(order_line_activity_id, order_line_activity_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class OrderLineActivityApi(object):
 
         Adds an audit to an existing orderLineActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity_audit_with_http_info(order_line_activity_id, order_line_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity_audit_with_http_info(order_line_activity_id, order_line_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to add an audit to (required)
         :param str order_line_activity_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id', 'order_line_activity_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class OrderLineActivityApi(object):
 
         Adds a file to an existing orderLineActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity_file(order_line_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity_file(order_line_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class OrderLineActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_line_activity_file_with_http_info(order_line_activity_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_line_activity_file_with_http_info(order_line_activity_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class OrderLineActivityApi(object):
 
         Adds a file to an existing orderLineActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity_file_with_http_info(order_line_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity_file_with_http_info(order_line_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class OrderLineActivityApi(object):
 
         Adds a file to an existing orderLineActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity_file_by_url(body, order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity_file_by_url(body, order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_line_activity_id: Id of the orderLineActivity to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class OrderLineActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_line_activity_file_by_url_with_http_info(body, order_line_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_line_activity_file_by_url_with_http_info(body, order_line_activity_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class OrderLineActivityApi(object):
 
         Adds a file to an existing orderLineActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity_file_by_url_with_http_info(body, order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity_file_by_url_with_http_info(body, order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_line_activity_id: Id of the orderLineActivity to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['body', 'order_line_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class OrderLineActivityApi(object):
 
         Adds a tag to an existing orderLineActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity_tag(order_line_activity_id, order_line_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity_tag(order_line_activity_id, order_line_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to add a tag to (required)
         :param str order_line_activity_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class OrderLineActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_line_activity_tag_with_http_info(order_line_activity_id, order_line_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_line_activity_tag_with_http_info(order_line_activity_id, order_line_activity_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class OrderLineActivityApi(object):
 
         Adds a tag to an existing orderLineActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_activity_tag_with_http_info(order_line_activity_id, order_line_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_activity_tag_with_http_info(order_line_activity_id, order_line_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to add a tag to (required)
         :param str order_line_activity_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id', 'order_line_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class OrderLineActivityApi(object):
 
         Deletes the orderLineActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_activity(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_activity(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_line_activity_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_line_activity_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class OrderLineActivityApi(object):
 
         Deletes the orderLineActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_activity_with_http_info(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_activity_with_http_info(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class OrderLineActivityApi(object):
 
         Deletes an existing orderLineActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_activity_file(order_line_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_activity_file(order_line_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class OrderLineActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_line_activity_file_with_http_info(order_line_activity_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_line_activity_file_with_http_info(order_line_activity_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class OrderLineActivityApi(object):
 
         Deletes an existing orderLineActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_activity_file_with_http_info(order_line_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_activity_file_with_http_info(order_line_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class OrderLineActivityApi(object):
 
         Deletes an existing orderLineActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_activity_tag(order_line_activity_id, order_line_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_activity_tag(order_line_activity_id, order_line_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to remove tag from (required)
         :param str order_line_activity_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class OrderLineActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_line_activity_tag_with_http_info(order_line_activity_id, order_line_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_line_activity_tag_with_http_info(order_line_activity_id, order_line_activity_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class OrderLineActivityApi(object):
 
         Deletes an existing orderLineActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_activity_tag_with_http_info(order_line_activity_id, order_line_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_activity_tag_with_http_info(order_line_activity_id, order_line_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to remove tag from (required)
         :param str order_line_activity_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id', 'order_line_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class OrderLineActivityApi(object):
 
         Returns a duplicated orderLineActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_line_activity_by_id(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_line_activity_by_id(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to be duplicated. (required)
         :return: OrderLineActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_order_line_activity_by_id_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_order_line_activity_by_id_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class OrderLineActivityApi(object):
 
         Returns a duplicated orderLineActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_line_activity_by_id_with_http_info(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_line_activity_by_id_with_http_info(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to be duplicated. (required)
         :return: OrderLineActivity
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type='OrderLineActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class OrderLineActivityApi(object):
 
         Returns the list of orderLineActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_activity_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_activity_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class OrderLineActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_line_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_line_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class OrderLineActivityApi(object):
 
         Returns the list of orderLineActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_activity_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_activity_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type='list[OrderLineActivity]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class OrderLineActivityApi(object):
 
         Returns the orderLineActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_activity_by_id(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_activity_by_id(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to be returned. (required)
         :return: OrderLineActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_line_activity_by_id_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_line_activity_by_id_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class OrderLineActivityApi(object):
 
         Returns the orderLineActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_activity_by_id_with_http_info(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_activity_by_id_with_http_info(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to be returned. (required)
         :return: OrderLineActivity
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type='OrderLineActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class OrderLineActivityApi(object):
 
         Get all existing orderLineActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_activity_files(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_activity_files(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_line_activity_files_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_line_activity_files_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class OrderLineActivityApi(object):
 
         Get all existing orderLineActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_activity_files_with_http_info(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_activity_files_with_http_info(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class OrderLineActivityApi(object):
 
         Get all existing orderLineActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_activity_tags(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_activity_tags(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_line_activity_tags_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_line_activity_tags_with_http_info(order_line_activity_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class OrderLineActivityApi(object):
 
         Get all existing orderLineActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_activity_tags_with_http_info(order_line_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_activity_tags_with_http_info(order_line_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_activity_id: Id of the orderLineActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['order_line_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class OrderLineActivityApi(object):
 
         Updates an existing orderLineActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_line_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_line_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderLineActivity body: OrderLineActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_line_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_line_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class OrderLineActivityApi(object):
 
         Updates an existing orderLineActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_line_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_line_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderLineActivity body: OrderLineActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class OrderLineActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class OrderLineActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_line_api.py
+++ b/Infoplus/api/order_line_api.py
@@ -38,11 +38,11 @@ class OrderLineApi(object):
 
         Adds an audit to an existing orderLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_audit(order_line_id, order_line_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_audit(order_line_id, order_line_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to add an audit to (required)
         :param str order_line_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class OrderLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_line_audit_with_http_info(order_line_id, order_line_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_line_audit_with_http_info(order_line_id, order_line_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class OrderLineApi(object):
 
         Adds an audit to an existing orderLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_audit_with_http_info(order_line_id, order_line_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_audit_with_http_info(order_line_id, order_line_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to add an audit to (required)
         :param str order_line_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['order_line_id', 'order_line_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class OrderLineApi(object):
 
         Adds a file to an existing orderLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_file(order_line_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_file(order_line_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class OrderLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_line_file_with_http_info(order_line_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_line_file_with_http_info(order_line_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class OrderLineApi(object):
 
         Adds a file to an existing orderLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_file_with_http_info(order_line_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_file_with_http_info(order_line_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['order_line_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class OrderLineApi(object):
 
         Adds a file to an existing orderLine by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_file_by_url(body, order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_file_by_url(body, order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_line_id: Id of the orderLine to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class OrderLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_line_file_by_url_with_http_info(body, order_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_line_file_by_url_with_http_info(body, order_line_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class OrderLineApi(object):
 
         Adds a file to an existing orderLine by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_file_by_url_with_http_info(body, order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_file_by_url_with_http_info(body, order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_line_id: Id of the orderLine to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['body', 'order_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class OrderLineApi(object):
 
         Adds a tag to an existing orderLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_tag(order_line_id, order_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_tag(order_line_id, order_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to add a tag to (required)
         :param str order_line_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class OrderLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_line_tag_with_http_info(order_line_id, order_line_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_line_tag_with_http_info(order_line_id, order_line_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class OrderLineApi(object):
 
         Adds a tag to an existing orderLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_line_tag_with_http_info(order_line_id, order_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_line_tag_with_http_info(order_line_id, order_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to add a tag to (required)
         :param str order_line_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['order_line_id', 'order_line_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class OrderLineApi(object):
 
         Deletes an existing orderLine file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_file(order_line_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_file(order_line_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class OrderLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_line_file_with_http_info(order_line_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_line_file_with_http_info(order_line_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class OrderLineApi(object):
 
         Deletes an existing orderLine file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_file_with_http_info(order_line_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_file_with_http_info(order_line_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['order_line_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class OrderLineApi(object):
 
         Deletes an existing orderLine tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_tag(order_line_id, order_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_tag(order_line_id, order_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to remove tag from (required)
         :param str order_line_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class OrderLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_line_tag_with_http_info(order_line_id, order_line_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_line_tag_with_http_info(order_line_id, order_line_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class OrderLineApi(object):
 
         Deletes an existing orderLine tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_line_tag_with_http_info(order_line_id, order_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_line_tag_with_http_info(order_line_id, order_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to remove tag from (required)
         :param str order_line_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['order_line_id', 'order_line_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class OrderLineApi(object):
 
         Returns a duplicated orderLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_line_by_id(order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_line_by_id(order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to be duplicated. (required)
         :return: OrderLine
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_order_line_by_id_with_http_info(order_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_order_line_by_id_with_http_info(order_line_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class OrderLineApi(object):
 
         Returns a duplicated orderLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_line_by_id_with_http_info(order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_line_by_id_with_http_info(order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to be duplicated. (required)
         :return: OrderLine
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['order_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type='OrderLine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class OrderLineApi(object):
 
         Returns the list of orderLines that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class OrderLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_line_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_line_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class OrderLineApi(object):
 
         Returns the list of orderLines that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type='list[OrderLine]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class OrderLineApi(object):
 
         Returns the orderLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_by_id(order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_by_id(order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to be returned. (required)
         :return: OrderLine
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_line_by_id_with_http_info(order_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_line_by_id_with_http_info(order_line_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class OrderLineApi(object):
 
         Returns the orderLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_by_id_with_http_info(order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_by_id_with_http_info(order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to be returned. (required)
         :return: OrderLine
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['order_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type='OrderLine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class OrderLineApi(object):
 
         Get all existing orderLine files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_files(order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_files(order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_line_files_with_http_info(order_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_line_files_with_http_info(order_line_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class OrderLineApi(object):
 
         Get all existing orderLine files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_files_with_http_info(order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_files_with_http_info(order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['order_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class OrderLineApi(object):
 
         Get all existing orderLine tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_tags(order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_tags(order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_line_tags_with_http_info(order_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_line_tags_with_http_info(order_line_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class OrderLineApi(object):
 
         Get all existing orderLine tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_line_tags_with_http_info(order_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_line_tags_with_http_info(order_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_line_id: Id of the orderLine to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['order_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class OrderLineApi(object):
 
         Updates an existing orderLine custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_line_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_line_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderLine body: OrderLine to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_line_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_line_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class OrderLineApi(object):
 
         Updates an existing orderLine custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_line_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_line_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderLine body: OrderLine to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class OrderLineApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class OrderLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_load_program_api.py
+++ b/Infoplus/api/order_load_program_api.py
@@ -38,11 +38,11 @@ class OrderLoadProgramApi(object):
 
         Returns the list of orderLoadPrograms that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_load_program_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_load_program_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -51,7 +51,7 @@ class OrderLoadProgramApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_load_program_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_load_program_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -62,11 +62,11 @@ class OrderLoadProgramApi(object):
 
         Returns the list of orderLoadPrograms that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_load_program_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_load_program_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -76,7 +76,7 @@ class OrderLoadProgramApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class OrderLoadProgramApi(object):
             files=local_var_files,
             response_type='list[OrderLoadProgram]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,18 +137,18 @@ class OrderLoadProgramApi(object):
 
         Returns the orderLoadProgram identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_req_load_program_by_id(order_load_program_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_req_load_program_by_id(order_load_program_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str order_load_program_id: Id of orderLoadProgram to be returned. (required)
         :return: OrderLoadProgram
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_req_load_program_by_id_with_http_info(order_load_program_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_req_load_program_by_id_with_http_info(order_load_program_id, **kwargs)  # noqa: E501
@@ -159,11 +159,11 @@ class OrderLoadProgramApi(object):
 
         Returns the orderLoadProgram identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_req_load_program_by_id_with_http_info(order_load_program_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_req_load_program_by_id_with_http_info(order_load_program_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str order_load_program_id: Id of orderLoadProgram to be returned. (required)
         :return: OrderLoadProgram
                  If the method is called asynchronously,
@@ -171,7 +171,7 @@ class OrderLoadProgramApi(object):
         """
 
         all_params = ['order_load_program_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class OrderLoadProgramApi(object):
             files=local_var_files,
             response_type='OrderLoadProgram',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_source_api.py
+++ b/Infoplus/api/order_source_api.py
@@ -38,18 +38,18 @@ class OrderSourceApi(object):
 
         Inserts a new orderSource using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSource body: OrderSource to be inserted. (required)
         :return: OrderSource
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class OrderSourceApi(object):
 
         Inserts a new orderSource using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSource body: OrderSource to be inserted. (required)
         :return: OrderSource
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type='OrderSource',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class OrderSourceApi(object):
 
         Adds an audit to an existing orderSource.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_audit(order_source_id, order_source_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_audit(order_source_id, order_source_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to add an audit to (required)
         :param str order_source_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class OrderSourceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_audit_with_http_info(order_source_id, order_source_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_audit_with_http_info(order_source_id, order_source_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class OrderSourceApi(object):
 
         Adds an audit to an existing orderSource.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_audit_with_http_info(order_source_id, order_source_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_audit_with_http_info(order_source_id, order_source_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to add an audit to (required)
         :param str order_source_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id', 'order_source_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class OrderSourceApi(object):
 
         Adds a file to an existing orderSource.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_file(order_source_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_file(order_source_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class OrderSourceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_file_with_http_info(order_source_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_file_with_http_info(order_source_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class OrderSourceApi(object):
 
         Adds a file to an existing orderSource.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_file_with_http_info(order_source_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_file_with_http_info(order_source_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class OrderSourceApi(object):
 
         Adds a file to an existing orderSource by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_file_by_url(body, order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_file_by_url(body, order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_source_id: Id of the orderSource to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class OrderSourceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_file_by_url_with_http_info(body, order_source_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_file_by_url_with_http_info(body, order_source_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class OrderSourceApi(object):
 
         Adds a file to an existing orderSource by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_file_by_url_with_http_info(body, order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_file_by_url_with_http_info(body, order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_source_id: Id of the orderSource to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['body', 'order_source_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class OrderSourceApi(object):
 
         Adds a tag to an existing orderSource.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_tag(order_source_id, order_source_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_tag(order_source_id, order_source_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to add a tag to (required)
         :param str order_source_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class OrderSourceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_tag_with_http_info(order_source_id, order_source_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_tag_with_http_info(order_source_id, order_source_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class OrderSourceApi(object):
 
         Adds a tag to an existing orderSource.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_tag_with_http_info(order_source_id, order_source_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_tag_with_http_info(order_source_id, order_source_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to add a tag to (required)
         :param str order_source_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id', 'order_source_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class OrderSourceApi(object):
 
         Deletes the orderSource identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_with_http_info(order_source_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_with_http_info(order_source_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class OrderSourceApi(object):
 
         Deletes the orderSource identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_with_http_info(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_with_http_info(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class OrderSourceApi(object):
 
         Deletes an existing orderSource file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_file(order_source_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_file(order_source_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class OrderSourceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_file_with_http_info(order_source_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_file_with_http_info(order_source_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class OrderSourceApi(object):
 
         Deletes an existing orderSource file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_file_with_http_info(order_source_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_file_with_http_info(order_source_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class OrderSourceApi(object):
 
         Deletes an existing orderSource tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_tag(order_source_id, order_source_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_tag(order_source_id, order_source_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to remove tag from (required)
         :param str order_source_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class OrderSourceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_tag_with_http_info(order_source_id, order_source_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_tag_with_http_info(order_source_id, order_source_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class OrderSourceApi(object):
 
         Deletes an existing orderSource tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_tag_with_http_info(order_source_id, order_source_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_tag_with_http_info(order_source_id, order_source_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to remove tag from (required)
         :param str order_source_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id', 'order_source_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class OrderSourceApi(object):
 
         Returns a duplicated orderSource identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_source_by_id(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_source_by_id(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to be duplicated. (required)
         :return: OrderSource
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_order_source_by_id_with_http_info(order_source_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_order_source_by_id_with_http_info(order_source_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class OrderSourceApi(object):
 
         Returns a duplicated orderSource identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_source_by_id_with_http_info(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_source_by_id_with_http_info(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to be duplicated. (required)
         :return: OrderSource
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type='OrderSource',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class OrderSourceApi(object):
 
         Returns the list of orderSources that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class OrderSourceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class OrderSourceApi(object):
 
         Returns the list of orderSources that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type='list[OrderSource]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class OrderSourceApi(object):
 
         Returns the orderSource identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_by_id(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_by_id(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to be returned. (required)
         :return: OrderSource
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_by_id_with_http_info(order_source_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_by_id_with_http_info(order_source_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class OrderSourceApi(object):
 
         Returns the orderSource identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_by_id_with_http_info(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_by_id_with_http_info(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to be returned. (required)
         :return: OrderSource
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type='OrderSource',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class OrderSourceApi(object):
 
         Get all existing orderSource files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_files(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_files(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_files_with_http_info(order_source_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_files_with_http_info(order_source_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class OrderSourceApi(object):
 
         Get all existing orderSource files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_files_with_http_info(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_files_with_http_info(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class OrderSourceApi(object):
 
         Get all existing orderSource tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_tags(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_tags(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_tags_with_http_info(order_source_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_tags_with_http_info(order_source_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class OrderSourceApi(object):
 
         Get all existing orderSource tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_tags_with_http_info(order_source_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_tags_with_http_info(order_source_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_id: Id of the orderSource to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['order_source_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class OrderSourceApi(object):
 
         Updates an existing orderSource using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSource body: OrderSource to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_source_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_source_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class OrderSourceApi(object):
 
         Updates an existing orderSource using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSource body: OrderSource to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class OrderSourceApi(object):
 
         Updates an existing orderSource custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSource body: OrderSource to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_source_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_source_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class OrderSourceApi(object):
 
         Updates an existing orderSource custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSource body: OrderSource to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class OrderSourceApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class OrderSourceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_source_item_setup_api.py
+++ b/Infoplus/api/order_source_item_setup_api.py
@@ -38,18 +38,18 @@ class OrderSourceItemSetupApi(object):
 
         Inserts a new orderSourceItemSetup using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceItemSetup body: OrderSourceItemSetup to be inserted. (required)
         :return: OrderSourceItemSetup
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_item_setup_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_item_setup_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class OrderSourceItemSetupApi(object):
 
         Inserts a new orderSourceItemSetup using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceItemSetup body: OrderSourceItemSetup to be inserted. (required)
         :return: OrderSourceItemSetup
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type='OrderSourceItemSetup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class OrderSourceItemSetupApi(object):
 
         Adds an audit to an existing orderSourceItemSetup.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup_audit(order_source_item_setup_id, order_source_item_setup_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup_audit(order_source_item_setup_id, order_source_item_setup_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to add an audit to (required)
         :param str order_source_item_setup_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class OrderSourceItemSetupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_item_setup_audit_with_http_info(order_source_item_setup_id, order_source_item_setup_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_item_setup_audit_with_http_info(order_source_item_setup_id, order_source_item_setup_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class OrderSourceItemSetupApi(object):
 
         Adds an audit to an existing orderSourceItemSetup.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup_audit_with_http_info(order_source_item_setup_id, order_source_item_setup_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup_audit_with_http_info(order_source_item_setup_id, order_source_item_setup_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to add an audit to (required)
         :param str order_source_item_setup_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id', 'order_source_item_setup_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class OrderSourceItemSetupApi(object):
 
         Adds a file to an existing orderSourceItemSetup.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup_file(order_source_item_setup_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup_file(order_source_item_setup_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class OrderSourceItemSetupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_item_setup_file_with_http_info(order_source_item_setup_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_item_setup_file_with_http_info(order_source_item_setup_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class OrderSourceItemSetupApi(object):
 
         Adds a file to an existing orderSourceItemSetup.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup_file_with_http_info(order_source_item_setup_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup_file_with_http_info(order_source_item_setup_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class OrderSourceItemSetupApi(object):
 
         Adds a file to an existing orderSourceItemSetup by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup_file_by_url(body, order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup_file_by_url(body, order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class OrderSourceItemSetupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_item_setup_file_by_url_with_http_info(body, order_source_item_setup_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_item_setup_file_by_url_with_http_info(body, order_source_item_setup_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class OrderSourceItemSetupApi(object):
 
         Adds a file to an existing orderSourceItemSetup by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup_file_by_url_with_http_info(body, order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup_file_by_url_with_http_info(body, order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['body', 'order_source_item_setup_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class OrderSourceItemSetupApi(object):
 
         Adds a tag to an existing orderSourceItemSetup.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup_tag(order_source_item_setup_id, order_source_item_setup_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup_tag(order_source_item_setup_id, order_source_item_setup_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to add a tag to (required)
         :param str order_source_item_setup_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class OrderSourceItemSetupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_item_setup_tag_with_http_info(order_source_item_setup_id, order_source_item_setup_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_item_setup_tag_with_http_info(order_source_item_setup_id, order_source_item_setup_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class OrderSourceItemSetupApi(object):
 
         Adds a tag to an existing orderSourceItemSetup.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_item_setup_tag_with_http_info(order_source_item_setup_id, order_source_item_setup_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_item_setup_tag_with_http_info(order_source_item_setup_id, order_source_item_setup_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to add a tag to (required)
         :param str order_source_item_setup_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id', 'order_source_item_setup_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class OrderSourceItemSetupApi(object):
 
         Deletes the orderSourceItemSetup identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_item_setup(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_item_setup(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_item_setup_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_item_setup_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class OrderSourceItemSetupApi(object):
 
         Deletes the orderSourceItemSetup identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_item_setup_with_http_info(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_item_setup_with_http_info(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class OrderSourceItemSetupApi(object):
 
         Deletes an existing orderSourceItemSetup file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_item_setup_file(order_source_item_setup_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_item_setup_file(order_source_item_setup_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class OrderSourceItemSetupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_item_setup_file_with_http_info(order_source_item_setup_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_item_setup_file_with_http_info(order_source_item_setup_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class OrderSourceItemSetupApi(object):
 
         Deletes an existing orderSourceItemSetup file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_item_setup_file_with_http_info(order_source_item_setup_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_item_setup_file_with_http_info(order_source_item_setup_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class OrderSourceItemSetupApi(object):
 
         Deletes an existing orderSourceItemSetup tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_item_setup_tag(order_source_item_setup_id, order_source_item_setup_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_item_setup_tag(order_source_item_setup_id, order_source_item_setup_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to remove tag from (required)
         :param str order_source_item_setup_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class OrderSourceItemSetupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_item_setup_tag_with_http_info(order_source_item_setup_id, order_source_item_setup_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_item_setup_tag_with_http_info(order_source_item_setup_id, order_source_item_setup_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class OrderSourceItemSetupApi(object):
 
         Deletes an existing orderSourceItemSetup tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_item_setup_tag_with_http_info(order_source_item_setup_id, order_source_item_setup_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_item_setup_tag_with_http_info(order_source_item_setup_id, order_source_item_setup_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to remove tag from (required)
         :param str order_source_item_setup_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id', 'order_source_item_setup_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class OrderSourceItemSetupApi(object):
 
         Returns a duplicated orderSourceItemSetup identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_source_item_setup_by_id(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_source_item_setup_by_id(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to be duplicated. (required)
         :return: OrderSourceItemSetup
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_order_source_item_setup_by_id_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_order_source_item_setup_by_id_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class OrderSourceItemSetupApi(object):
 
         Returns a duplicated orderSourceItemSetup identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_source_item_setup_by_id_with_http_info(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_source_item_setup_by_id_with_http_info(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to be duplicated. (required)
         :return: OrderSourceItemSetup
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type='OrderSourceItemSetup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class OrderSourceItemSetupApi(object):
 
         Returns the list of orderSourceItemSetups that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_item_setup_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_item_setup_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class OrderSourceItemSetupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_item_setup_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_item_setup_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class OrderSourceItemSetupApi(object):
 
         Returns the list of orderSourceItemSetups that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_item_setup_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_item_setup_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type='list[OrderSourceItemSetup]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class OrderSourceItemSetupApi(object):
 
         Returns the orderSourceItemSetup identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_item_setup_by_id(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_item_setup_by_id(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to be returned. (required)
         :return: OrderSourceItemSetup
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_item_setup_by_id_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_item_setup_by_id_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class OrderSourceItemSetupApi(object):
 
         Returns the orderSourceItemSetup identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_item_setup_by_id_with_http_info(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_item_setup_by_id_with_http_info(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to be returned. (required)
         :return: OrderSourceItemSetup
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type='OrderSourceItemSetup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class OrderSourceItemSetupApi(object):
 
         Get all existing orderSourceItemSetup files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_item_setup_files(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_item_setup_files(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_item_setup_files_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_item_setup_files_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class OrderSourceItemSetupApi(object):
 
         Get all existing orderSourceItemSetup files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_item_setup_files_with_http_info(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_item_setup_files_with_http_info(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class OrderSourceItemSetupApi(object):
 
         Get all existing orderSourceItemSetup tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_item_setup_tags(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_item_setup_tags(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_item_setup_tags_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_item_setup_tags_with_http_info(order_source_item_setup_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class OrderSourceItemSetupApi(object):
 
         Get all existing orderSourceItemSetup tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_item_setup_tags_with_http_info(order_source_item_setup_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_item_setup_tags_with_http_info(order_source_item_setup_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_item_setup_id: Id of the orderSourceItemSetup to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['order_source_item_setup_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class OrderSourceItemSetupApi(object):
 
         Updates an existing orderSourceItemSetup using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_item_setup(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_item_setup(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceItemSetup body: OrderSourceItemSetup to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_source_item_setup_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_source_item_setup_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class OrderSourceItemSetupApi(object):
 
         Updates an existing orderSourceItemSetup using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_item_setup_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_item_setup_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceItemSetup body: OrderSourceItemSetup to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class OrderSourceItemSetupApi(object):
 
         Updates an existing orderSourceItemSetup custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_item_setup_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_item_setup_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceItemSetup body: OrderSourceItemSetup to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_source_item_setup_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_source_item_setup_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class OrderSourceItemSetupApi(object):
 
         Updates an existing orderSourceItemSetup custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_item_setup_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_item_setup_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceItemSetup body: OrderSourceItemSetup to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class OrderSourceItemSetupApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class OrderSourceItemSetupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_source_reservation_api.py
+++ b/Infoplus/api/order_source_reservation_api.py
@@ -38,18 +38,18 @@ class OrderSourceReservationApi(object):
 
         Inserts a new orderSourceReservation using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceReservation body: OrderSourceReservation to be inserted. (required)
         :return: OrderSourceReservation
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_reservation_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_reservation_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class OrderSourceReservationApi(object):
 
         Inserts a new orderSourceReservation using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceReservation body: OrderSourceReservation to be inserted. (required)
         :return: OrderSourceReservation
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type='OrderSourceReservation',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class OrderSourceReservationApi(object):
 
         Adds an audit to an existing orderSourceReservation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation_audit(order_source_reservation_id, order_source_reservation_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation_audit(order_source_reservation_id, order_source_reservation_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to add an audit to (required)
         :param str order_source_reservation_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class OrderSourceReservationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_reservation_audit_with_http_info(order_source_reservation_id, order_source_reservation_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_reservation_audit_with_http_info(order_source_reservation_id, order_source_reservation_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class OrderSourceReservationApi(object):
 
         Adds an audit to an existing orderSourceReservation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation_audit_with_http_info(order_source_reservation_id, order_source_reservation_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation_audit_with_http_info(order_source_reservation_id, order_source_reservation_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to add an audit to (required)
         :param str order_source_reservation_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id', 'order_source_reservation_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class OrderSourceReservationApi(object):
 
         Adds a file to an existing orderSourceReservation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation_file(order_source_reservation_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation_file(order_source_reservation_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class OrderSourceReservationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_reservation_file_with_http_info(order_source_reservation_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_reservation_file_with_http_info(order_source_reservation_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class OrderSourceReservationApi(object):
 
         Adds a file to an existing orderSourceReservation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation_file_with_http_info(order_source_reservation_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation_file_with_http_info(order_source_reservation_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class OrderSourceReservationApi(object):
 
         Adds a file to an existing orderSourceReservation by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation_file_by_url(body, order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation_file_by_url(body, order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_source_reservation_id: Id of the orderSourceReservation to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class OrderSourceReservationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_reservation_file_by_url_with_http_info(body, order_source_reservation_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_reservation_file_by_url_with_http_info(body, order_source_reservation_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class OrderSourceReservationApi(object):
 
         Adds a file to an existing orderSourceReservation by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation_file_by_url_with_http_info(body, order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation_file_by_url_with_http_info(body, order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_source_reservation_id: Id of the orderSourceReservation to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['body', 'order_source_reservation_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class OrderSourceReservationApi(object):
 
         Adds a tag to an existing orderSourceReservation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation_tag(order_source_reservation_id, order_source_reservation_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation_tag(order_source_reservation_id, order_source_reservation_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to add a tag to (required)
         :param str order_source_reservation_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class OrderSourceReservationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_reservation_tag_with_http_info(order_source_reservation_id, order_source_reservation_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_reservation_tag_with_http_info(order_source_reservation_id, order_source_reservation_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class OrderSourceReservationApi(object):
 
         Adds a tag to an existing orderSourceReservation.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_reservation_tag_with_http_info(order_source_reservation_id, order_source_reservation_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_reservation_tag_with_http_info(order_source_reservation_id, order_source_reservation_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to add a tag to (required)
         :param str order_source_reservation_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id', 'order_source_reservation_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class OrderSourceReservationApi(object):
 
         Deletes the orderSourceReservation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_reservation(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_reservation(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_reservation_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_reservation_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class OrderSourceReservationApi(object):
 
         Deletes the orderSourceReservation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_reservation_with_http_info(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_reservation_with_http_info(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class OrderSourceReservationApi(object):
 
         Deletes an existing orderSourceReservation file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_reservation_file(order_source_reservation_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_reservation_file(order_source_reservation_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class OrderSourceReservationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_reservation_file_with_http_info(order_source_reservation_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_reservation_file_with_http_info(order_source_reservation_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class OrderSourceReservationApi(object):
 
         Deletes an existing orderSourceReservation file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_reservation_file_with_http_info(order_source_reservation_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_reservation_file_with_http_info(order_source_reservation_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class OrderSourceReservationApi(object):
 
         Deletes an existing orderSourceReservation tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_reservation_tag(order_source_reservation_id, order_source_reservation_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_reservation_tag(order_source_reservation_id, order_source_reservation_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to remove tag from (required)
         :param str order_source_reservation_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class OrderSourceReservationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_reservation_tag_with_http_info(order_source_reservation_id, order_source_reservation_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_reservation_tag_with_http_info(order_source_reservation_id, order_source_reservation_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class OrderSourceReservationApi(object):
 
         Deletes an existing orderSourceReservation tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_reservation_tag_with_http_info(order_source_reservation_id, order_source_reservation_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_reservation_tag_with_http_info(order_source_reservation_id, order_source_reservation_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to remove tag from (required)
         :param str order_source_reservation_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id', 'order_source_reservation_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class OrderSourceReservationApi(object):
 
         Returns a duplicated orderSourceReservation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_source_reservation_by_id(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_source_reservation_by_id(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to be duplicated. (required)
         :return: OrderSourceReservation
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_order_source_reservation_by_id_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_order_source_reservation_by_id_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class OrderSourceReservationApi(object):
 
         Returns a duplicated orderSourceReservation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_source_reservation_by_id_with_http_info(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_source_reservation_by_id_with_http_info(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to be duplicated. (required)
         :return: OrderSourceReservation
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type='OrderSourceReservation',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class OrderSourceReservationApi(object):
 
         Returns the list of orderSourceReservations that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_reservation_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_reservation_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class OrderSourceReservationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_reservation_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_reservation_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class OrderSourceReservationApi(object):
 
         Returns the list of orderSourceReservations that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_reservation_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_reservation_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type='list[OrderSourceReservation]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class OrderSourceReservationApi(object):
 
         Returns the orderSourceReservation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_reservation_by_id(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_reservation_by_id(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to be returned. (required)
         :return: OrderSourceReservation
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_reservation_by_id_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_reservation_by_id_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class OrderSourceReservationApi(object):
 
         Returns the orderSourceReservation identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_reservation_by_id_with_http_info(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_reservation_by_id_with_http_info(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to be returned. (required)
         :return: OrderSourceReservation
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type='OrderSourceReservation',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class OrderSourceReservationApi(object):
 
         Get all existing orderSourceReservation files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_reservation_files(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_reservation_files(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_reservation_files_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_reservation_files_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class OrderSourceReservationApi(object):
 
         Get all existing orderSourceReservation files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_reservation_files_with_http_info(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_reservation_files_with_http_info(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class OrderSourceReservationApi(object):
 
         Get all existing orderSourceReservation tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_reservation_tags(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_reservation_tags(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_reservation_tags_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_reservation_tags_with_http_info(order_source_reservation_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class OrderSourceReservationApi(object):
 
         Get all existing orderSourceReservation tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_reservation_tags_with_http_info(order_source_reservation_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_reservation_tags_with_http_info(order_source_reservation_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_reservation_id: Id of the orderSourceReservation to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['order_source_reservation_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class OrderSourceReservationApi(object):
 
         Updates an existing orderSourceReservation using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_reservation(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_reservation(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceReservation body: OrderSourceReservation to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_source_reservation_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_source_reservation_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class OrderSourceReservationApi(object):
 
         Updates an existing orderSourceReservation using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_reservation_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_reservation_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceReservation body: OrderSourceReservation to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class OrderSourceReservationApi(object):
 
         Updates an existing orderSourceReservation custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_reservation_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_reservation_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceReservation body: OrderSourceReservation to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_order_source_reservation_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_order_source_reservation_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class OrderSourceReservationApi(object):
 
         Updates an existing orderSourceReservation custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_order_source_reservation_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_order_source_reservation_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OrderSourceReservation body: OrderSourceReservation to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class OrderSourceReservationApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class OrderSourceReservationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/order_source_stock_status_api.py
+++ b/Infoplus/api/order_source_stock_status_api.py
@@ -38,11 +38,11 @@ class OrderSourceStockStatusApi(object):
 
         Adds an audit to an existing orderSourceStockStatus.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_stock_status_audit(order_source_stock_status_id, order_source_stock_status_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_stock_status_audit(order_source_stock_status_id, order_source_stock_status_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to add an audit to (required)
         :param str order_source_stock_status_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class OrderSourceStockStatusApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_stock_status_audit_with_http_info(order_source_stock_status_id, order_source_stock_status_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_stock_status_audit_with_http_info(order_source_stock_status_id, order_source_stock_status_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class OrderSourceStockStatusApi(object):
 
         Adds an audit to an existing orderSourceStockStatus.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_stock_status_audit_with_http_info(order_source_stock_status_id, order_source_stock_status_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_stock_status_audit_with_http_info(order_source_stock_status_id, order_source_stock_status_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to add an audit to (required)
         :param str order_source_stock_status_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['order_source_stock_status_id', 'order_source_stock_status_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class OrderSourceStockStatusApi(object):
 
         Adds a file to an existing orderSourceStockStatus.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_stock_status_file(order_source_stock_status_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_stock_status_file(order_source_stock_status_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class OrderSourceStockStatusApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_stock_status_file_with_http_info(order_source_stock_status_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_stock_status_file_with_http_info(order_source_stock_status_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class OrderSourceStockStatusApi(object):
 
         Adds a file to an existing orderSourceStockStatus.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_stock_status_file_with_http_info(order_source_stock_status_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_stock_status_file_with_http_info(order_source_stock_status_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['order_source_stock_status_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class OrderSourceStockStatusApi(object):
 
         Adds a file to an existing orderSourceStockStatus by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_stock_status_file_by_url(body, order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_stock_status_file_by_url(body, order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class OrderSourceStockStatusApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_stock_status_file_by_url_with_http_info(body, order_source_stock_status_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_stock_status_file_by_url_with_http_info(body, order_source_stock_status_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class OrderSourceStockStatusApi(object):
 
         Adds a file to an existing orderSourceStockStatus by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_stock_status_file_by_url_with_http_info(body, order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_stock_status_file_by_url_with_http_info(body, order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['body', 'order_source_stock_status_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class OrderSourceStockStatusApi(object):
 
         Adds a tag to an existing orderSourceStockStatus.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_stock_status_tag(order_source_stock_status_id, order_source_stock_status_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_stock_status_tag(order_source_stock_status_id, order_source_stock_status_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to add a tag to (required)
         :param str order_source_stock_status_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class OrderSourceStockStatusApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_order_source_stock_status_tag_with_http_info(order_source_stock_status_id, order_source_stock_status_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_order_source_stock_status_tag_with_http_info(order_source_stock_status_id, order_source_stock_status_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class OrderSourceStockStatusApi(object):
 
         Adds a tag to an existing orderSourceStockStatus.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_order_source_stock_status_tag_with_http_info(order_source_stock_status_id, order_source_stock_status_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_order_source_stock_status_tag_with_http_info(order_source_stock_status_id, order_source_stock_status_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to add a tag to (required)
         :param str order_source_stock_status_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['order_source_stock_status_id', 'order_source_stock_status_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class OrderSourceStockStatusApi(object):
 
         Deletes an existing orderSourceStockStatus file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_stock_status_file(order_source_stock_status_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_stock_status_file(order_source_stock_status_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class OrderSourceStockStatusApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_stock_status_file_with_http_info(order_source_stock_status_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_stock_status_file_with_http_info(order_source_stock_status_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class OrderSourceStockStatusApi(object):
 
         Deletes an existing orderSourceStockStatus file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_stock_status_file_with_http_info(order_source_stock_status_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_stock_status_file_with_http_info(order_source_stock_status_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['order_source_stock_status_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class OrderSourceStockStatusApi(object):
 
         Deletes an existing orderSourceStockStatus tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_stock_status_tag(order_source_stock_status_id, order_source_stock_status_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_stock_status_tag(order_source_stock_status_id, order_source_stock_status_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to remove tag from (required)
         :param str order_source_stock_status_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class OrderSourceStockStatusApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_order_source_stock_status_tag_with_http_info(order_source_stock_status_id, order_source_stock_status_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_order_source_stock_status_tag_with_http_info(order_source_stock_status_id, order_source_stock_status_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class OrderSourceStockStatusApi(object):
 
         Deletes an existing orderSourceStockStatus tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_order_source_stock_status_tag_with_http_info(order_source_stock_status_id, order_source_stock_status_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_order_source_stock_status_tag_with_http_info(order_source_stock_status_id, order_source_stock_status_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to remove tag from (required)
         :param str order_source_stock_status_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['order_source_stock_status_id', 'order_source_stock_status_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class OrderSourceStockStatusApi(object):
 
         Returns a duplicated orderSourceStockStatus identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_source_stock_status_by_id(order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_source_stock_status_by_id(order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to be duplicated. (required)
         :return: OrderSourceStockStatus
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_order_source_stock_status_by_id_with_http_info(order_source_stock_status_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_order_source_stock_status_by_id_with_http_info(order_source_stock_status_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class OrderSourceStockStatusApi(object):
 
         Returns a duplicated orderSourceStockStatus identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_order_source_stock_status_by_id_with_http_info(order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_order_source_stock_status_by_id_with_http_info(order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to be duplicated. (required)
         :return: OrderSourceStockStatus
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['order_source_stock_status_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type='OrderSourceStockStatus',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class OrderSourceStockStatusApi(object):
 
         Returns the list of orderSourceStockStatuses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_stock_status_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_stock_status_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class OrderSourceStockStatusApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_stock_status_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_stock_status_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class OrderSourceStockStatusApi(object):
 
         Returns the list of orderSourceStockStatuses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_stock_status_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_stock_status_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type='list[OrderSourceStockStatus]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class OrderSourceStockStatusApi(object):
 
         Returns the orderSourceStockStatus identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_stock_status_by_id(order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_stock_status_by_id(order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to be returned. (required)
         :return: OrderSourceStockStatus
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_stock_status_by_id_with_http_info(order_source_stock_status_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_stock_status_by_id_with_http_info(order_source_stock_status_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class OrderSourceStockStatusApi(object):
 
         Returns the orderSourceStockStatus identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_stock_status_by_id_with_http_info(order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_stock_status_by_id_with_http_info(order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to be returned. (required)
         :return: OrderSourceStockStatus
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['order_source_stock_status_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type='OrderSourceStockStatus',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class OrderSourceStockStatusApi(object):
 
         Get all existing orderSourceStockStatus files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_stock_status_files(order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_stock_status_files(order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_stock_status_files_with_http_info(order_source_stock_status_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_stock_status_files_with_http_info(order_source_stock_status_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class OrderSourceStockStatusApi(object):
 
         Get all existing orderSourceStockStatus files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_stock_status_files_with_http_info(order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_stock_status_files_with_http_info(order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['order_source_stock_status_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class OrderSourceStockStatusApi(object):
 
         Get all existing orderSourceStockStatus tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_stock_status_tags(order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_stock_status_tags(order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_order_source_stock_status_tags_with_http_info(order_source_stock_status_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_order_source_stock_status_tags_with_http_info(order_source_stock_status_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class OrderSourceStockStatusApi(object):
 
         Get all existing orderSourceStockStatus tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_order_source_stock_status_tags_with_http_info(order_source_stock_status_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_order_source_stock_status_tags_with_http_info(order_source_stock_status_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int order_source_stock_status_id: Id of the orderSourceStockStatus to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class OrderSourceStockStatusApi(object):
         """
 
         all_params = ['order_source_stock_status_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class OrderSourceStockStatusApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/override_return_address_api.py
+++ b/Infoplus/api/override_return_address_api.py
@@ -38,18 +38,18 @@ class OverrideReturnAddressApi(object):
 
         Inserts a new overrideReturnAddress using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OverrideReturnAddress body: OverrideReturnAddress to be inserted. (required)
         :return: OverrideReturnAddress
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_override_return_address_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_override_return_address_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class OverrideReturnAddressApi(object):
 
         Inserts a new overrideReturnAddress using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OverrideReturnAddress body: OverrideReturnAddress to be inserted. (required)
         :return: OverrideReturnAddress
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type='OverrideReturnAddress',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class OverrideReturnAddressApi(object):
 
         Adds an audit to an existing overrideReturnAddress.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address_audit(override_return_address_id, override_return_address_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address_audit(override_return_address_id, override_return_address_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to add an audit to (required)
         :param str override_return_address_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class OverrideReturnAddressApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_override_return_address_audit_with_http_info(override_return_address_id, override_return_address_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_override_return_address_audit_with_http_info(override_return_address_id, override_return_address_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class OverrideReturnAddressApi(object):
 
         Adds an audit to an existing overrideReturnAddress.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address_audit_with_http_info(override_return_address_id, override_return_address_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address_audit_with_http_info(override_return_address_id, override_return_address_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to add an audit to (required)
         :param str override_return_address_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id', 'override_return_address_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class OverrideReturnAddressApi(object):
 
         Adds a file to an existing overrideReturnAddress.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address_file(override_return_address_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address_file(override_return_address_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class OverrideReturnAddressApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_override_return_address_file_with_http_info(override_return_address_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_override_return_address_file_with_http_info(override_return_address_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class OverrideReturnAddressApi(object):
 
         Adds a file to an existing overrideReturnAddress.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address_file_with_http_info(override_return_address_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address_file_with_http_info(override_return_address_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class OverrideReturnAddressApi(object):
 
         Adds a file to an existing overrideReturnAddress by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address_file_by_url(body, override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address_file_by_url(body, override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int override_return_address_id: Id of the overrideReturnAddress to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class OverrideReturnAddressApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_override_return_address_file_by_url_with_http_info(body, override_return_address_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_override_return_address_file_by_url_with_http_info(body, override_return_address_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class OverrideReturnAddressApi(object):
 
         Adds a file to an existing overrideReturnAddress by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address_file_by_url_with_http_info(body, override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address_file_by_url_with_http_info(body, override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int override_return_address_id: Id of the overrideReturnAddress to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['body', 'override_return_address_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class OverrideReturnAddressApi(object):
 
         Adds a tag to an existing overrideReturnAddress.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address_tag(override_return_address_id, override_return_address_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address_tag(override_return_address_id, override_return_address_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to add a tag to (required)
         :param str override_return_address_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class OverrideReturnAddressApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_override_return_address_tag_with_http_info(override_return_address_id, override_return_address_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_override_return_address_tag_with_http_info(override_return_address_id, override_return_address_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class OverrideReturnAddressApi(object):
 
         Adds a tag to an existing overrideReturnAddress.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_override_return_address_tag_with_http_info(override_return_address_id, override_return_address_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_override_return_address_tag_with_http_info(override_return_address_id, override_return_address_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to add a tag to (required)
         :param str override_return_address_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id', 'override_return_address_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class OverrideReturnAddressApi(object):
 
         Deletes the overrideReturnAddress identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_override_return_address(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_override_return_address(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_override_return_address_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_override_return_address_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class OverrideReturnAddressApi(object):
 
         Deletes the overrideReturnAddress identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_override_return_address_with_http_info(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_override_return_address_with_http_info(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class OverrideReturnAddressApi(object):
 
         Deletes an existing overrideReturnAddress file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_override_return_address_file(override_return_address_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_override_return_address_file(override_return_address_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class OverrideReturnAddressApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_override_return_address_file_with_http_info(override_return_address_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_override_return_address_file_with_http_info(override_return_address_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class OverrideReturnAddressApi(object):
 
         Deletes an existing overrideReturnAddress file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_override_return_address_file_with_http_info(override_return_address_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_override_return_address_file_with_http_info(override_return_address_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class OverrideReturnAddressApi(object):
 
         Deletes an existing overrideReturnAddress tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_override_return_address_tag(override_return_address_id, override_return_address_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_override_return_address_tag(override_return_address_id, override_return_address_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to remove tag from (required)
         :param str override_return_address_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class OverrideReturnAddressApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_override_return_address_tag_with_http_info(override_return_address_id, override_return_address_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_override_return_address_tag_with_http_info(override_return_address_id, override_return_address_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class OverrideReturnAddressApi(object):
 
         Deletes an existing overrideReturnAddress tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_override_return_address_tag_with_http_info(override_return_address_id, override_return_address_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_override_return_address_tag_with_http_info(override_return_address_id, override_return_address_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to remove tag from (required)
         :param str override_return_address_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id', 'override_return_address_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class OverrideReturnAddressApi(object):
 
         Returns a duplicated overrideReturnAddress identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_override_return_address_by_id(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_override_return_address_by_id(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to be duplicated. (required)
         :return: OverrideReturnAddress
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_override_return_address_by_id_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_override_return_address_by_id_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class OverrideReturnAddressApi(object):
 
         Returns a duplicated overrideReturnAddress identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_override_return_address_by_id_with_http_info(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_override_return_address_by_id_with_http_info(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to be duplicated. (required)
         :return: OverrideReturnAddress
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type='OverrideReturnAddress',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class OverrideReturnAddressApi(object):
 
         Returns the list of overrideReturnAddresses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_override_return_address_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_override_return_address_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class OverrideReturnAddressApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_override_return_address_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_override_return_address_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class OverrideReturnAddressApi(object):
 
         Returns the list of overrideReturnAddresses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_override_return_address_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_override_return_address_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type='list[OverrideReturnAddress]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class OverrideReturnAddressApi(object):
 
         Returns the overrideReturnAddress identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_override_return_address_by_id(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_override_return_address_by_id(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to be returned. (required)
         :return: OverrideReturnAddress
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_override_return_address_by_id_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_override_return_address_by_id_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class OverrideReturnAddressApi(object):
 
         Returns the overrideReturnAddress identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_override_return_address_by_id_with_http_info(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_override_return_address_by_id_with_http_info(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to be returned. (required)
         :return: OverrideReturnAddress
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type='OverrideReturnAddress',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class OverrideReturnAddressApi(object):
 
         Get all existing overrideReturnAddress files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_override_return_address_files(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_override_return_address_files(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_override_return_address_files_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_override_return_address_files_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class OverrideReturnAddressApi(object):
 
         Get all existing overrideReturnAddress files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_override_return_address_files_with_http_info(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_override_return_address_files_with_http_info(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class OverrideReturnAddressApi(object):
 
         Get all existing overrideReturnAddress tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_override_return_address_tags(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_override_return_address_tags(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_override_return_address_tags_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_override_return_address_tags_with_http_info(override_return_address_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class OverrideReturnAddressApi(object):
 
         Get all existing overrideReturnAddress tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_override_return_address_tags_with_http_info(override_return_address_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_override_return_address_tags_with_http_info(override_return_address_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int override_return_address_id: Id of the overrideReturnAddress to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['override_return_address_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class OverrideReturnAddressApi(object):
 
         Updates an existing overrideReturnAddress using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_override_return_address(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_override_return_address(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OverrideReturnAddress body: OverrideReturnAddress to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_override_return_address_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_override_return_address_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class OverrideReturnAddressApi(object):
 
         Updates an existing overrideReturnAddress using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_override_return_address_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_override_return_address_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OverrideReturnAddress body: OverrideReturnAddress to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class OverrideReturnAddressApi(object):
 
         Updates an existing overrideReturnAddress custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_override_return_address_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_override_return_address_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OverrideReturnAddress body: OverrideReturnAddress to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_override_return_address_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_override_return_address_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class OverrideReturnAddressApi(object):
 
         Updates an existing overrideReturnAddress custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_override_return_address_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_override_return_address_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param OverrideReturnAddress body: OverrideReturnAddress to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class OverrideReturnAddressApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class OverrideReturnAddressApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/packing_detail_api.py
+++ b/Infoplus/api/packing_detail_api.py
@@ -38,11 +38,11 @@ class PackingDetailApi(object):
 
         Adds an audit to an existing packingDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_detail_audit(packing_detail_id, packing_detail_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_detail_audit(packing_detail_id, packing_detail_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to add an audit to (required)
         :param str packing_detail_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class PackingDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_detail_audit_with_http_info(packing_detail_id, packing_detail_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_detail_audit_with_http_info(packing_detail_id, packing_detail_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class PackingDetailApi(object):
 
         Adds an audit to an existing packingDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_detail_audit_with_http_info(packing_detail_id, packing_detail_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_detail_audit_with_http_info(packing_detail_id, packing_detail_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to add an audit to (required)
         :param str packing_detail_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['packing_detail_id', 'packing_detail_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class PackingDetailApi(object):
 
         Adds a file to an existing packingDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_detail_file(packing_detail_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_detail_file(packing_detail_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class PackingDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_detail_file_with_http_info(packing_detail_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_detail_file_with_http_info(packing_detail_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class PackingDetailApi(object):
 
         Adds a file to an existing packingDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_detail_file_with_http_info(packing_detail_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_detail_file_with_http_info(packing_detail_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['packing_detail_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class PackingDetailApi(object):
 
         Adds a file to an existing packingDetail by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_detail_file_by_url(body, packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_detail_file_by_url(body, packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int packing_detail_id: Id of the packingDetail to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class PackingDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_detail_file_by_url_with_http_info(body, packing_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_detail_file_by_url_with_http_info(body, packing_detail_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class PackingDetailApi(object):
 
         Adds a file to an existing packingDetail by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_detail_file_by_url_with_http_info(body, packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_detail_file_by_url_with_http_info(body, packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int packing_detail_id: Id of the packingDetail to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['body', 'packing_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class PackingDetailApi(object):
 
         Adds a tag to an existing packingDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_detail_tag(packing_detail_id, packing_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_detail_tag(packing_detail_id, packing_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to add a tag to (required)
         :param str packing_detail_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class PackingDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_detail_tag_with_http_info(packing_detail_id, packing_detail_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_detail_tag_with_http_info(packing_detail_id, packing_detail_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class PackingDetailApi(object):
 
         Adds a tag to an existing packingDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_detail_tag_with_http_info(packing_detail_id, packing_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_detail_tag_with_http_info(packing_detail_id, packing_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to add a tag to (required)
         :param str packing_detail_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['packing_detail_id', 'packing_detail_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class PackingDetailApi(object):
 
         Deletes an existing packingDetail file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_detail_file(packing_detail_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_detail_file(packing_detail_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class PackingDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_packing_detail_file_with_http_info(packing_detail_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_packing_detail_file_with_http_info(packing_detail_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class PackingDetailApi(object):
 
         Deletes an existing packingDetail file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_detail_file_with_http_info(packing_detail_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_detail_file_with_http_info(packing_detail_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['packing_detail_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class PackingDetailApi(object):
 
         Deletes an existing packingDetail tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_detail_tag(packing_detail_id, packing_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_detail_tag(packing_detail_id, packing_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to remove tag from (required)
         :param str packing_detail_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class PackingDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_packing_detail_tag_with_http_info(packing_detail_id, packing_detail_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_packing_detail_tag_with_http_info(packing_detail_id, packing_detail_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class PackingDetailApi(object):
 
         Deletes an existing packingDetail tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_detail_tag_with_http_info(packing_detail_id, packing_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_detail_tag_with_http_info(packing_detail_id, packing_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to remove tag from (required)
         :param str packing_detail_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['packing_detail_id', 'packing_detail_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class PackingDetailApi(object):
 
         Returns a duplicated packingDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_packing_detail_by_id(packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_packing_detail_by_id(packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to be duplicated. (required)
         :return: PackingDetail
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_packing_detail_by_id_with_http_info(packing_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_packing_detail_by_id_with_http_info(packing_detail_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class PackingDetailApi(object):
 
         Returns a duplicated packingDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_packing_detail_by_id_with_http_info(packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_packing_detail_by_id_with_http_info(packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to be duplicated. (required)
         :return: PackingDetail
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['packing_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type='PackingDetail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class PackingDetailApi(object):
 
         Returns the list of packingDetails that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_detail_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_detail_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class PackingDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_detail_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_detail_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class PackingDetailApi(object):
 
         Returns the list of packingDetails that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_detail_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_detail_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type='list[PackingDetail]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class PackingDetailApi(object):
 
         Returns the packingDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_detail_by_id(packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_detail_by_id(packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to be returned. (required)
         :return: PackingDetail
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_detail_by_id_with_http_info(packing_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_detail_by_id_with_http_info(packing_detail_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class PackingDetailApi(object):
 
         Returns the packingDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_detail_by_id_with_http_info(packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_detail_by_id_with_http_info(packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to be returned. (required)
         :return: PackingDetail
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['packing_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type='PackingDetail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class PackingDetailApi(object):
 
         Get all existing packingDetail files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_detail_files(packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_detail_files(packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_detail_files_with_http_info(packing_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_detail_files_with_http_info(packing_detail_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class PackingDetailApi(object):
 
         Get all existing packingDetail files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_detail_files_with_http_info(packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_detail_files_with_http_info(packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['packing_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class PackingDetailApi(object):
 
         Get all existing packingDetail tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_detail_tags(packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_detail_tags(packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_detail_tags_with_http_info(packing_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_detail_tags_with_http_info(packing_detail_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class PackingDetailApi(object):
 
         Get all existing packingDetail tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_detail_tags_with_http_info(packing_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_detail_tags_with_http_info(packing_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_detail_id: Id of the packingDetail to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['packing_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class PackingDetailApi(object):
 
         Updates an existing packingDetail custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_packing_detail_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_packing_detail_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingDetail body: PackingDetail to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_packing_detail_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_packing_detail_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class PackingDetailApi(object):
 
         Updates an existing packingDetail custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_packing_detail_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_packing_detail_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingDetail body: PackingDetail to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class PackingDetailApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class PackingDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/packing_plan_api.py
+++ b/Infoplus/api/packing_plan_api.py
@@ -38,18 +38,18 @@ class PackingPlanApi(object):
 
         Inserts a new packingPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingPlan body: PackingPlan to be inserted. (required)
         :return: PackingPlan
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_plan_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_plan_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class PackingPlanApi(object):
 
         Inserts a new packingPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingPlan body: PackingPlan to be inserted. (required)
         :return: PackingPlan
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type='PackingPlan',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class PackingPlanApi(object):
 
         Adds an audit to an existing packingPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_audit(packing_plan_id, packing_plan_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_audit(packing_plan_id, packing_plan_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to add an audit to (required)
         :param str packing_plan_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class PackingPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_plan_audit_with_http_info(packing_plan_id, packing_plan_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_plan_audit_with_http_info(packing_plan_id, packing_plan_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class PackingPlanApi(object):
 
         Adds an audit to an existing packingPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_audit_with_http_info(packing_plan_id, packing_plan_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_audit_with_http_info(packing_plan_id, packing_plan_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to add an audit to (required)
         :param str packing_plan_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id', 'packing_plan_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class PackingPlanApi(object):
 
         Adds a file to an existing packingPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_file(packing_plan_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_file(packing_plan_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class PackingPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_plan_file_with_http_info(packing_plan_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_plan_file_with_http_info(packing_plan_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class PackingPlanApi(object):
 
         Adds a file to an existing packingPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_file_with_http_info(packing_plan_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_file_with_http_info(packing_plan_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class PackingPlanApi(object):
 
         Adds a file to an existing packingPlan by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_file_by_url(body, packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_file_by_url(body, packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int packing_plan_id: Id of the packingPlan to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class PackingPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_plan_file_by_url_with_http_info(body, packing_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_plan_file_by_url_with_http_info(body, packing_plan_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class PackingPlanApi(object):
 
         Adds a file to an existing packingPlan by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_file_by_url_with_http_info(body, packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_file_by_url_with_http_info(body, packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int packing_plan_id: Id of the packingPlan to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['body', 'packing_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class PackingPlanApi(object):
 
         Adds a tag to an existing packingPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_tag(packing_plan_id, packing_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_tag(packing_plan_id, packing_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to add a tag to (required)
         :param str packing_plan_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class PackingPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_plan_tag_with_http_info(packing_plan_id, packing_plan_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_plan_tag_with_http_info(packing_plan_id, packing_plan_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class PackingPlanApi(object):
 
         Adds a tag to an existing packingPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_tag_with_http_info(packing_plan_id, packing_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_tag_with_http_info(packing_plan_id, packing_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to add a tag to (required)
         :param str packing_plan_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id', 'packing_plan_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class PackingPlanApi(object):
 
         Deletes the packingPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_packing_plan_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_packing_plan_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class PackingPlanApi(object):
 
         Deletes the packingPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan_with_http_info(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan_with_http_info(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class PackingPlanApi(object):
 
         Deletes an existing packingPlan file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan_file(packing_plan_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan_file(packing_plan_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class PackingPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_packing_plan_file_with_http_info(packing_plan_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_packing_plan_file_with_http_info(packing_plan_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class PackingPlanApi(object):
 
         Deletes an existing packingPlan file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan_file_with_http_info(packing_plan_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan_file_with_http_info(packing_plan_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class PackingPlanApi(object):
 
         Deletes an existing packingPlan tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan_tag(packing_plan_id, packing_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan_tag(packing_plan_id, packing_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to remove tag from (required)
         :param str packing_plan_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class PackingPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_packing_plan_tag_with_http_info(packing_plan_id, packing_plan_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_packing_plan_tag_with_http_info(packing_plan_id, packing_plan_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class PackingPlanApi(object):
 
         Deletes an existing packingPlan tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan_tag_with_http_info(packing_plan_id, packing_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan_tag_with_http_info(packing_plan_id, packing_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to remove tag from (required)
         :param str packing_plan_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id', 'packing_plan_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class PackingPlanApi(object):
 
         Returns a duplicated packingPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_packing_plan_by_id(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_packing_plan_by_id(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to be duplicated. (required)
         :return: PackingPlan
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_packing_plan_by_id_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_packing_plan_by_id_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class PackingPlanApi(object):
 
         Returns a duplicated packingPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_packing_plan_by_id_with_http_info(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_packing_plan_by_id_with_http_info(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to be duplicated. (required)
         :return: PackingPlan
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type='PackingPlan',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class PackingPlanApi(object):
 
         Returns the list of packingPlans that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class PackingPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_plan_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_plan_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class PackingPlanApi(object):
 
         Returns the list of packingPlans that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type='list[PackingPlan]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class PackingPlanApi(object):
 
         Returns the packingPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_by_id(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_by_id(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to be returned. (required)
         :return: PackingPlan
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_plan_by_id_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_plan_by_id_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class PackingPlanApi(object):
 
         Returns the packingPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_by_id_with_http_info(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_by_id_with_http_info(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to be returned. (required)
         :return: PackingPlan
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type='PackingPlan',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class PackingPlanApi(object):
 
         Get all existing packingPlan files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_files(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_files(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_plan_files_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_plan_files_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class PackingPlanApi(object):
 
         Get all existing packingPlan files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_files_with_http_info(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_files_with_http_info(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class PackingPlanApi(object):
 
         Get all existing packingPlan tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_tags(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_tags(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_plan_tags_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_plan_tags_with_http_info(packing_plan_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class PackingPlanApi(object):
 
         Get all existing packingPlan tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_tags_with_http_info(packing_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_tags_with_http_info(packing_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_id: Id of the packingPlan to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['packing_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class PackingPlanApi(object):
 
         Updates an existing packingPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_packing_plan(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_packing_plan(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingPlan body: PackingPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_packing_plan_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_packing_plan_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class PackingPlanApi(object):
 
         Updates an existing packingPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_packing_plan_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_packing_plan_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingPlan body: PackingPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class PackingPlanApi(object):
 
         Updates an existing packingPlan custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_packing_plan_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_packing_plan_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingPlan body: PackingPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_packing_plan_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_packing_plan_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class PackingPlanApi(object):
 
         Updates an existing packingPlan custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_packing_plan_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_packing_plan_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingPlan body: PackingPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class PackingPlanApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class PackingPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/packing_plan_detail_api.py
+++ b/Infoplus/api/packing_plan_detail_api.py
@@ -38,11 +38,11 @@ class PackingPlanDetailApi(object):
 
         Adds an audit to an existing packingPlanDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_detail_audit(packing_plan_detail_id, packing_plan_detail_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_detail_audit(packing_plan_detail_id, packing_plan_detail_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to add an audit to (required)
         :param str packing_plan_detail_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class PackingPlanDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_plan_detail_audit_with_http_info(packing_plan_detail_id, packing_plan_detail_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_plan_detail_audit_with_http_info(packing_plan_detail_id, packing_plan_detail_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class PackingPlanDetailApi(object):
 
         Adds an audit to an existing packingPlanDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_detail_audit_with_http_info(packing_plan_detail_id, packing_plan_detail_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_detail_audit_with_http_info(packing_plan_detail_id, packing_plan_detail_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to add an audit to (required)
         :param str packing_plan_detail_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['packing_plan_detail_id', 'packing_plan_detail_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class PackingPlanDetailApi(object):
 
         Adds a file to an existing packingPlanDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_detail_file(packing_plan_detail_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_detail_file(packing_plan_detail_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class PackingPlanDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_plan_detail_file_with_http_info(packing_plan_detail_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_plan_detail_file_with_http_info(packing_plan_detail_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class PackingPlanDetailApi(object):
 
         Adds a file to an existing packingPlanDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_detail_file_with_http_info(packing_plan_detail_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_detail_file_with_http_info(packing_plan_detail_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['packing_plan_detail_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class PackingPlanDetailApi(object):
 
         Adds a file to an existing packingPlanDetail by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_detail_file_by_url(body, packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_detail_file_by_url(body, packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int packing_plan_detail_id: Id of the packingPlanDetail to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class PackingPlanDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_plan_detail_file_by_url_with_http_info(body, packing_plan_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_plan_detail_file_by_url_with_http_info(body, packing_plan_detail_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class PackingPlanDetailApi(object):
 
         Adds a file to an existing packingPlanDetail by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_detail_file_by_url_with_http_info(body, packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_detail_file_by_url_with_http_info(body, packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int packing_plan_detail_id: Id of the packingPlanDetail to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['body', 'packing_plan_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class PackingPlanDetailApi(object):
 
         Adds a tag to an existing packingPlanDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_detail_tag(packing_plan_detail_id, packing_plan_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_detail_tag(packing_plan_detail_id, packing_plan_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to add a tag to (required)
         :param str packing_plan_detail_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class PackingPlanDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_packing_plan_detail_tag_with_http_info(packing_plan_detail_id, packing_plan_detail_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_packing_plan_detail_tag_with_http_info(packing_plan_detail_id, packing_plan_detail_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class PackingPlanDetailApi(object):
 
         Adds a tag to an existing packingPlanDetail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_packing_plan_detail_tag_with_http_info(packing_plan_detail_id, packing_plan_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_packing_plan_detail_tag_with_http_info(packing_plan_detail_id, packing_plan_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to add a tag to (required)
         :param str packing_plan_detail_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['packing_plan_detail_id', 'packing_plan_detail_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class PackingPlanDetailApi(object):
 
         Deletes an existing packingPlanDetail file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan_detail_file(packing_plan_detail_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan_detail_file(packing_plan_detail_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class PackingPlanDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_packing_plan_detail_file_with_http_info(packing_plan_detail_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_packing_plan_detail_file_with_http_info(packing_plan_detail_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class PackingPlanDetailApi(object):
 
         Deletes an existing packingPlanDetail file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan_detail_file_with_http_info(packing_plan_detail_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan_detail_file_with_http_info(packing_plan_detail_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['packing_plan_detail_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class PackingPlanDetailApi(object):
 
         Deletes an existing packingPlanDetail tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan_detail_tag(packing_plan_detail_id, packing_plan_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan_detail_tag(packing_plan_detail_id, packing_plan_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to remove tag from (required)
         :param str packing_plan_detail_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class PackingPlanDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_packing_plan_detail_tag_with_http_info(packing_plan_detail_id, packing_plan_detail_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_packing_plan_detail_tag_with_http_info(packing_plan_detail_id, packing_plan_detail_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class PackingPlanDetailApi(object):
 
         Deletes an existing packingPlanDetail tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_packing_plan_detail_tag_with_http_info(packing_plan_detail_id, packing_plan_detail_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_packing_plan_detail_tag_with_http_info(packing_plan_detail_id, packing_plan_detail_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to remove tag from (required)
         :param str packing_plan_detail_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['packing_plan_detail_id', 'packing_plan_detail_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class PackingPlanDetailApi(object):
 
         Returns a duplicated packingPlanDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_packing_plan_detail_by_id(packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_packing_plan_detail_by_id(packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to be duplicated. (required)
         :return: PackingPlanDetail
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_packing_plan_detail_by_id_with_http_info(packing_plan_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_packing_plan_detail_by_id_with_http_info(packing_plan_detail_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class PackingPlanDetailApi(object):
 
         Returns a duplicated packingPlanDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_packing_plan_detail_by_id_with_http_info(packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_packing_plan_detail_by_id_with_http_info(packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to be duplicated. (required)
         :return: PackingPlanDetail
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['packing_plan_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type='PackingPlanDetail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class PackingPlanDetailApi(object):
 
         Returns the list of packingPlanDetails that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_detail_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_detail_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class PackingPlanDetailApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_plan_detail_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_plan_detail_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class PackingPlanDetailApi(object):
 
         Returns the list of packingPlanDetails that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_detail_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_detail_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type='list[PackingPlanDetail]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class PackingPlanDetailApi(object):
 
         Returns the packingPlanDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_detail_by_id(packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_detail_by_id(packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to be returned. (required)
         :return: PackingPlanDetail
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_plan_detail_by_id_with_http_info(packing_plan_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_plan_detail_by_id_with_http_info(packing_plan_detail_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class PackingPlanDetailApi(object):
 
         Returns the packingPlanDetail identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_detail_by_id_with_http_info(packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_detail_by_id_with_http_info(packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to be returned. (required)
         :return: PackingPlanDetail
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['packing_plan_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type='PackingPlanDetail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class PackingPlanDetailApi(object):
 
         Get all existing packingPlanDetail files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_detail_files(packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_detail_files(packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_plan_detail_files_with_http_info(packing_plan_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_plan_detail_files_with_http_info(packing_plan_detail_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class PackingPlanDetailApi(object):
 
         Get all existing packingPlanDetail files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_detail_files_with_http_info(packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_detail_files_with_http_info(packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['packing_plan_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class PackingPlanDetailApi(object):
 
         Get all existing packingPlanDetail tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_detail_tags(packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_detail_tags(packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_plan_detail_tags_with_http_info(packing_plan_detail_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_plan_detail_tags_with_http_info(packing_plan_detail_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class PackingPlanDetailApi(object):
 
         Get all existing packingPlanDetail tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_plan_detail_tags_with_http_info(packing_plan_detail_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_plan_detail_tags_with_http_info(packing_plan_detail_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int packing_plan_detail_id: Id of the packingPlanDetail to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['packing_plan_detail_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class PackingPlanDetailApi(object):
 
         Updates an existing packingPlanDetail custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_packing_plan_detail_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_packing_plan_detail_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingPlanDetail body: PackingPlanDetail to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_packing_plan_detail_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_packing_plan_detail_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class PackingPlanDetailApi(object):
 
         Updates an existing packingPlanDetail custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_packing_plan_detail_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_packing_plan_detail_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PackingPlanDetail body: PackingPlanDetail to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class PackingPlanDetailApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class PackingPlanDetailApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/packing_slip_template_line_extra_data_enum_api.py
+++ b/Infoplus/api/packing_slip_template_line_extra_data_enum_api.py
@@ -38,18 +38,18 @@ class PackingSlipTemplateLineExtraDataEnumApi(object):
 
         Returns the packingSlipTemplateLineExtraDataEnum identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_slip_template_line_extra_data_enum_by_id(packing_slip_template_line_extra_data_enum_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_slip_template_line_extra_data_enum_by_id(packing_slip_template_line_extra_data_enum_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str packing_slip_template_line_extra_data_enum_id: Id of packingSlipTemplateLineExtraDataEnum to be returned. (required)
         :return: PackingSlipTemplateLineExtraDataEnum
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_slip_template_line_extra_data_enum_by_id_with_http_info(packing_slip_template_line_extra_data_enum_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_slip_template_line_extra_data_enum_by_id_with_http_info(packing_slip_template_line_extra_data_enum_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class PackingSlipTemplateLineExtraDataEnumApi(object):
 
         Returns the packingSlipTemplateLineExtraDataEnum identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_slip_template_line_extra_data_enum_by_id_with_http_info(packing_slip_template_line_extra_data_enum_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_slip_template_line_extra_data_enum_by_id_with_http_info(packing_slip_template_line_extra_data_enum_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str packing_slip_template_line_extra_data_enum_id: Id of packingSlipTemplateLineExtraDataEnum to be returned. (required)
         :return: PackingSlipTemplateLineExtraDataEnum
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class PackingSlipTemplateLineExtraDataEnumApi(object):
         """
 
         all_params = ['packing_slip_template_line_extra_data_enum_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class PackingSlipTemplateLineExtraDataEnumApi(object):
             files=local_var_files,
             response_type='PackingSlipTemplateLineExtraDataEnum',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class PackingSlipTemplateLineExtraDataEnumApi(object):
 
         Returns the list of packingSlipTemplateLineExtraDataEnums that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_slip_template_line_extra_data_enum_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_slip_template_line_extra_data_enum_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class PackingSlipTemplateLineExtraDataEnumApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_slip_template_line_extra_data_enum_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_slip_template_line_extra_data_enum_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class PackingSlipTemplateLineExtraDataEnumApi(object):
 
         Returns the list of packingSlipTemplateLineExtraDataEnums that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_slip_template_line_extra_data_enum_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_slip_template_line_extra_data_enum_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class PackingSlipTemplateLineExtraDataEnumApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class PackingSlipTemplateLineExtraDataEnumApi(object):
             files=local_var_files,
             response_type='list[PackingSlipTemplateLineExtraDataEnum]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/packing_slip_template_line_item_description_enum_api.py
+++ b/Infoplus/api/packing_slip_template_line_item_description_enum_api.py
@@ -38,18 +38,18 @@ class PackingSlipTemplateLineItemDescriptionEnumApi(object):
 
         Returns the packingSlipTemplateLineItemDescriptionEnum identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_slip_template_line_item_description_enum_by_id(packing_slip_template_line_item_description_enum_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_slip_template_line_item_description_enum_by_id(packing_slip_template_line_item_description_enum_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str packing_slip_template_line_item_description_enum_id: Id of packingSlipTemplateLineItemDescriptionEnum to be returned. (required)
         :return: PackingSlipTemplateLineItemDescriptionEnum
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_slip_template_line_item_description_enum_by_id_with_http_info(packing_slip_template_line_item_description_enum_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_slip_template_line_item_description_enum_by_id_with_http_info(packing_slip_template_line_item_description_enum_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class PackingSlipTemplateLineItemDescriptionEnumApi(object):
 
         Returns the packingSlipTemplateLineItemDescriptionEnum identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_slip_template_line_item_description_enum_by_id_with_http_info(packing_slip_template_line_item_description_enum_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_slip_template_line_item_description_enum_by_id_with_http_info(packing_slip_template_line_item_description_enum_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str packing_slip_template_line_item_description_enum_id: Id of packingSlipTemplateLineItemDescriptionEnum to be returned. (required)
         :return: PackingSlipTemplateLineItemDescriptionEnum
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class PackingSlipTemplateLineItemDescriptionEnumApi(object):
         """
 
         all_params = ['packing_slip_template_line_item_description_enum_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class PackingSlipTemplateLineItemDescriptionEnumApi(object):
             files=local_var_files,
             response_type='PackingSlipTemplateLineItemDescriptionEnum',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class PackingSlipTemplateLineItemDescriptionEnumApi(object):
 
         Returns the list of packingSlipTemplateLineItemDescriptionEnums that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_slip_template_line_item_description_enum_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_slip_template_line_item_description_enum_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class PackingSlipTemplateLineItemDescriptionEnumApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_packing_slip_template_line_item_description_enum_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_packing_slip_template_line_item_description_enum_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class PackingSlipTemplateLineItemDescriptionEnumApi(object):
 
         Returns the list of packingSlipTemplateLineItemDescriptionEnums that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_packing_slip_template_line_item_description_enum_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_packing_slip_template_line_item_description_enum_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class PackingSlipTemplateLineItemDescriptionEnumApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class PackingSlipTemplateLineItemDescriptionEnumApi(object):
             files=local_var_files,
             response_type='list[PackingSlipTemplateLineItemDescriptionEnum]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/pallet_type_api.py
+++ b/Infoplus/api/pallet_type_api.py
@@ -38,18 +38,18 @@ class PalletTypeApi(object):
 
         Inserts a new palletType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PalletType body: PalletType to be inserted. (required)
         :return: PalletType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pallet_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pallet_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class PalletTypeApi(object):
 
         Inserts a new palletType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PalletType body: PalletType to be inserted. (required)
         :return: PalletType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type='PalletType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class PalletTypeApi(object):
 
         Adds an audit to an existing palletType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type_audit(pallet_type_id, pallet_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type_audit(pallet_type_id, pallet_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to add an audit to (required)
         :param str pallet_type_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class PalletTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pallet_type_audit_with_http_info(pallet_type_id, pallet_type_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pallet_type_audit_with_http_info(pallet_type_id, pallet_type_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class PalletTypeApi(object):
 
         Adds an audit to an existing palletType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type_audit_with_http_info(pallet_type_id, pallet_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type_audit_with_http_info(pallet_type_id, pallet_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to add an audit to (required)
         :param str pallet_type_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id', 'pallet_type_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class PalletTypeApi(object):
 
         Adds a file to an existing palletType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type_file(pallet_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type_file(pallet_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class PalletTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pallet_type_file_with_http_info(pallet_type_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pallet_type_file_with_http_info(pallet_type_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class PalletTypeApi(object):
 
         Adds a file to an existing palletType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type_file_with_http_info(pallet_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type_file_with_http_info(pallet_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class PalletTypeApi(object):
 
         Adds a file to an existing palletType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type_file_by_url(body, pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type_file_by_url(body, pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int pallet_type_id: Id of the palletType to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class PalletTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pallet_type_file_by_url_with_http_info(body, pallet_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pallet_type_file_by_url_with_http_info(body, pallet_type_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class PalletTypeApi(object):
 
         Adds a file to an existing palletType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type_file_by_url_with_http_info(body, pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type_file_by_url_with_http_info(body, pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int pallet_type_id: Id of the palletType to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['body', 'pallet_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class PalletTypeApi(object):
 
         Adds a tag to an existing palletType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type_tag(pallet_type_id, pallet_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type_tag(pallet_type_id, pallet_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to add a tag to (required)
         :param str pallet_type_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class PalletTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pallet_type_tag_with_http_info(pallet_type_id, pallet_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pallet_type_tag_with_http_info(pallet_type_id, pallet_type_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class PalletTypeApi(object):
 
         Adds a tag to an existing palletType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pallet_type_tag_with_http_info(pallet_type_id, pallet_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pallet_type_tag_with_http_info(pallet_type_id, pallet_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to add a tag to (required)
         :param str pallet_type_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id', 'pallet_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class PalletTypeApi(object):
 
         Deletes the palletType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pallet_type(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pallet_type(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_pallet_type_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_pallet_type_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class PalletTypeApi(object):
 
         Deletes the palletType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pallet_type_with_http_info(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pallet_type_with_http_info(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class PalletTypeApi(object):
 
         Deletes an existing palletType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pallet_type_file(pallet_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pallet_type_file(pallet_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class PalletTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_pallet_type_file_with_http_info(pallet_type_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_pallet_type_file_with_http_info(pallet_type_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class PalletTypeApi(object):
 
         Deletes an existing palletType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pallet_type_file_with_http_info(pallet_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pallet_type_file_with_http_info(pallet_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class PalletTypeApi(object):
 
         Deletes an existing palletType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pallet_type_tag(pallet_type_id, pallet_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pallet_type_tag(pallet_type_id, pallet_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to remove tag from (required)
         :param str pallet_type_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class PalletTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_pallet_type_tag_with_http_info(pallet_type_id, pallet_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_pallet_type_tag_with_http_info(pallet_type_id, pallet_type_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class PalletTypeApi(object):
 
         Deletes an existing palletType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pallet_type_tag_with_http_info(pallet_type_id, pallet_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pallet_type_tag_with_http_info(pallet_type_id, pallet_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to remove tag from (required)
         :param str pallet_type_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id', 'pallet_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class PalletTypeApi(object):
 
         Returns a duplicated palletType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_pallet_type_by_id(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_pallet_type_by_id(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to be duplicated. (required)
         :return: PalletType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_pallet_type_by_id_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_pallet_type_by_id_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class PalletTypeApi(object):
 
         Returns a duplicated palletType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_pallet_type_by_id_with_http_info(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_pallet_type_by_id_with_http_info(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to be duplicated. (required)
         :return: PalletType
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type='PalletType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class PalletTypeApi(object):
 
         Returns the list of palletTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pallet_type_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pallet_type_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class PalletTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_pallet_type_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_pallet_type_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class PalletTypeApi(object):
 
         Returns the list of palletTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pallet_type_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pallet_type_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type='list[PalletType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class PalletTypeApi(object):
 
         Returns the palletType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pallet_type_by_id(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pallet_type_by_id(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to be returned. (required)
         :return: PalletType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_pallet_type_by_id_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_pallet_type_by_id_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class PalletTypeApi(object):
 
         Returns the palletType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pallet_type_by_id_with_http_info(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pallet_type_by_id_with_http_info(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to be returned. (required)
         :return: PalletType
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type='PalletType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class PalletTypeApi(object):
 
         Get all existing palletType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pallet_type_files(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pallet_type_files(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_pallet_type_files_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_pallet_type_files_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class PalletTypeApi(object):
 
         Get all existing palletType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pallet_type_files_with_http_info(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pallet_type_files_with_http_info(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class PalletTypeApi(object):
 
         Get all existing palletType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pallet_type_tags(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pallet_type_tags(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_pallet_type_tags_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_pallet_type_tags_with_http_info(pallet_type_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class PalletTypeApi(object):
 
         Get all existing palletType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pallet_type_tags_with_http_info(pallet_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pallet_type_tags_with_http_info(pallet_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pallet_type_id: Id of the palletType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['pallet_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class PalletTypeApi(object):
 
         Updates an existing palletType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_pallet_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_pallet_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PalletType body: PalletType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_pallet_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_pallet_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class PalletTypeApi(object):
 
         Updates an existing palletType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_pallet_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_pallet_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PalletType body: PalletType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class PalletTypeApi(object):
 
         Updates an existing palletType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_pallet_type_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_pallet_type_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PalletType body: PalletType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_pallet_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_pallet_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class PalletTypeApi(object):
 
         Updates an existing palletType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_pallet_type_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_pallet_type_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PalletType body: PalletType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class PalletTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class PalletTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/parcel_account_api.py
+++ b/Infoplus/api/parcel_account_api.py
@@ -38,18 +38,18 @@ class ParcelAccountApi(object):
 
         Inserts a new parcelAccount using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ParcelAccount body: ParcelAccount to be inserted. (required)
         :return: ParcelAccount
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_account_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_account_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ParcelAccountApi(object):
 
         Inserts a new parcelAccount using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ParcelAccount body: ParcelAccount to be inserted. (required)
         :return: ParcelAccount
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type='ParcelAccount',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ParcelAccountApi(object):
 
         Adds an audit to an existing parcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account_audit(parcel_account_id, parcel_account_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account_audit(parcel_account_id, parcel_account_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to add an audit to (required)
         :param str parcel_account_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_account_audit_with_http_info(parcel_account_id, parcel_account_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_account_audit_with_http_info(parcel_account_id, parcel_account_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ParcelAccountApi(object):
 
         Adds an audit to an existing parcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account_audit_with_http_info(parcel_account_id, parcel_account_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account_audit_with_http_info(parcel_account_id, parcel_account_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to add an audit to (required)
         :param str parcel_account_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['parcel_account_id', 'parcel_account_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ParcelAccountApi(object):
 
         Adds a file to an existing parcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account_file(parcel_account_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account_file(parcel_account_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_account_file_with_http_info(parcel_account_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_account_file_with_http_info(parcel_account_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ParcelAccountApi(object):
 
         Adds a file to an existing parcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account_file_with_http_info(parcel_account_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account_file_with_http_info(parcel_account_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['parcel_account_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ParcelAccountApi(object):
 
         Adds a file to an existing parcelAccount by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account_file_by_url(body, parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account_file_by_url(body, parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int parcel_account_id: Id of the parcelAccount to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_account_file_by_url_with_http_info(body, parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_account_file_by_url_with_http_info(body, parcel_account_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ParcelAccountApi(object):
 
         Adds a file to an existing parcelAccount by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account_file_by_url_with_http_info(body, parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account_file_by_url_with_http_info(body, parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int parcel_account_id: Id of the parcelAccount to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['body', 'parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ParcelAccountApi(object):
 
         Adds a tag to an existing parcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account_tag(parcel_account_id, parcel_account_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account_tag(parcel_account_id, parcel_account_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to add a tag to (required)
         :param str parcel_account_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_account_tag_with_http_info(parcel_account_id, parcel_account_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_account_tag_with_http_info(parcel_account_id, parcel_account_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ParcelAccountApi(object):
 
         Adds a tag to an existing parcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_account_tag_with_http_info(parcel_account_id, parcel_account_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_account_tag_with_http_info(parcel_account_id, parcel_account_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to add a tag to (required)
         :param str parcel_account_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['parcel_account_id', 'parcel_account_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,11 +561,11 @@ class ParcelAccountApi(object):
 
         Deletes an existing parcelAccount file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_account_file(parcel_account_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_account_file(parcel_account_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -573,7 +573,7 @@ class ParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_parcel_account_file_with_http_info(parcel_account_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_parcel_account_file_with_http_info(parcel_account_id, file_id, **kwargs)  # noqa: E501
@@ -584,11 +584,11 @@ class ParcelAccountApi(object):
 
         Deletes an existing parcelAccount file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_account_file_with_http_info(parcel_account_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_account_file_with_http_info(parcel_account_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -597,7 +597,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['parcel_account_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -653,7 +653,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -664,11 +664,11 @@ class ParcelAccountApi(object):
 
         Deletes an existing parcelAccount tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_account_tag(parcel_account_id, parcel_account_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_account_tag(parcel_account_id, parcel_account_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to remove tag from (required)
         :param str parcel_account_tag: The tag to delete (required)
         :return: None
@@ -676,7 +676,7 @@ class ParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_parcel_account_tag_with_http_info(parcel_account_id, parcel_account_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_parcel_account_tag_with_http_info(parcel_account_id, parcel_account_tag, **kwargs)  # noqa: E501
@@ -687,11 +687,11 @@ class ParcelAccountApi(object):
 
         Deletes an existing parcelAccount tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_account_tag_with_http_info(parcel_account_id, parcel_account_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_account_tag_with_http_info(parcel_account_id, parcel_account_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to remove tag from (required)
         :param str parcel_account_tag: The tag to delete (required)
         :return: None
@@ -700,7 +700,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['parcel_account_id', 'parcel_account_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -756,7 +756,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -767,18 +767,18 @@ class ParcelAccountApi(object):
 
         Returns a duplicated parcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_parcel_account_by_id(parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_parcel_account_by_id(parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to be duplicated. (required)
         :return: ParcelAccount
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_parcel_account_by_id_with_http_info(parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_parcel_account_by_id_with_http_info(parcel_account_id, **kwargs)  # noqa: E501
@@ -789,11 +789,11 @@ class ParcelAccountApi(object):
 
         Returns a duplicated parcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_parcel_account_by_id_with_http_info(parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_parcel_account_by_id_with_http_info(parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to be duplicated. (required)
         :return: ParcelAccount
                  If the method is called asynchronously,
@@ -801,7 +801,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type='ParcelAccount',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class ParcelAccountApi(object):
 
         Returns the list of parcelAccounts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_account_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_account_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class ParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_account_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_account_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class ParcelAccountApi(object):
 
         Returns the list of parcelAccounts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_account_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_account_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type='list[ParcelAccount]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class ParcelAccountApi(object):
 
         Returns the parcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_account_by_id(parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_account_by_id(parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to be returned. (required)
         :return: ParcelAccount
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_account_by_id_with_http_info(parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_account_by_id_with_http_info(parcel_account_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class ParcelAccountApi(object):
 
         Returns the parcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_account_by_id_with_http_info(parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_account_by_id_with_http_info(parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to be returned. (required)
         :return: ParcelAccount
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type='ParcelAccount',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ParcelAccountApi(object):
 
         Get all existing parcelAccount files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_account_files(parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_account_files(parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_account_files_with_http_info(parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_account_files_with_http_info(parcel_account_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ParcelAccountApi(object):
 
         Get all existing parcelAccount files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_account_files_with_http_info(parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_account_files_with_http_info(parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ParcelAccountApi(object):
 
         Get all existing parcelAccount tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_account_tags(parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_account_tags(parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_account_tags_with_http_info(parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_account_tags_with_http_info(parcel_account_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ParcelAccountApi(object):
 
         Get all existing parcelAccount tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_account_tags_with_http_info(parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_account_tags_with_http_info(parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_account_id: Id of the parcelAccount to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ParcelAccountApi(object):
 
         Updates an existing parcelAccount using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_parcel_account(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_parcel_account(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ParcelAccount body: ParcelAccount to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_parcel_account_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_parcel_account_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ParcelAccountApi(object):
 
         Updates an existing parcelAccount using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_parcel_account_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_parcel_account_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ParcelAccount body: ParcelAccount to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1349,18 +1349,18 @@ class ParcelAccountApi(object):
 
         Updates an existing parcelAccount custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_parcel_account_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_parcel_account_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ParcelAccount body: ParcelAccount to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_parcel_account_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_parcel_account_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1371,11 +1371,11 @@ class ParcelAccountApi(object):
 
         Updates an existing parcelAccount custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_parcel_account_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_parcel_account_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ParcelAccount body: ParcelAccount to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1383,7 +1383,7 @@ class ParcelAccountApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1437,7 +1437,7 @@ class ParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/parcel_invoice_api.py
+++ b/Infoplus/api/parcel_invoice_api.py
@@ -38,11 +38,11 @@ class ParcelInvoiceApi(object):
 
         Adds an audit to an existing parcelInvoice.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_audit(parcel_invoice_id, parcel_invoice_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_audit(parcel_invoice_id, parcel_invoice_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to add an audit to (required)
         :param str parcel_invoice_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ParcelInvoiceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_invoice_audit_with_http_info(parcel_invoice_id, parcel_invoice_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_invoice_audit_with_http_info(parcel_invoice_id, parcel_invoice_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ParcelInvoiceApi(object):
 
         Adds an audit to an existing parcelInvoice.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_audit_with_http_info(parcel_invoice_id, parcel_invoice_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_audit_with_http_info(parcel_invoice_id, parcel_invoice_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to add an audit to (required)
         :param str parcel_invoice_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id', 'parcel_invoice_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ParcelInvoiceApi(object):
 
         Adds a file to an existing parcelInvoice.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_file(parcel_invoice_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_file(parcel_invoice_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ParcelInvoiceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_invoice_file_with_http_info(parcel_invoice_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_invoice_file_with_http_info(parcel_invoice_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ParcelInvoiceApi(object):
 
         Adds a file to an existing parcelInvoice.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_file_with_http_info(parcel_invoice_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_file_with_http_info(parcel_invoice_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ParcelInvoiceApi(object):
 
         Adds a file to an existing parcelInvoice by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_file_by_url(body, parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_file_by_url(body, parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int parcel_invoice_id: Id of the parcelInvoice to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ParcelInvoiceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_invoice_file_by_url_with_http_info(body, parcel_invoice_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_invoice_file_by_url_with_http_info(body, parcel_invoice_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ParcelInvoiceApi(object):
 
         Adds a file to an existing parcelInvoice by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_file_by_url_with_http_info(body, parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_file_by_url_with_http_info(body, parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int parcel_invoice_id: Id of the parcelInvoice to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['body', 'parcel_invoice_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ParcelInvoiceApi(object):
 
         Adds a tag to an existing parcelInvoice.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_tag(parcel_invoice_id, parcel_invoice_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_tag(parcel_invoice_id, parcel_invoice_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to add a tag to (required)
         :param str parcel_invoice_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ParcelInvoiceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_invoice_tag_with_http_info(parcel_invoice_id, parcel_invoice_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_invoice_tag_with_http_info(parcel_invoice_id, parcel_invoice_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ParcelInvoiceApi(object):
 
         Adds a tag to an existing parcelInvoice.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_tag_with_http_info(parcel_invoice_id, parcel_invoice_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_tag_with_http_info(parcel_invoice_id, parcel_invoice_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to add a tag to (required)
         :param str parcel_invoice_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id', 'parcel_invoice_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,18 +462,18 @@ class ParcelInvoiceApi(object):
 
         Deletes the parcelInvoice identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_parcel_invoice_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_parcel_invoice_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
@@ -484,11 +484,11 @@ class ParcelInvoiceApi(object):
 
         Deletes the parcelInvoice identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice_with_http_info(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice_with_http_info(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -496,7 +496,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -546,7 +546,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -557,11 +557,11 @@ class ParcelInvoiceApi(object):
 
         Deletes an existing parcelInvoice file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice_file(parcel_invoice_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice_file(parcel_invoice_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -569,7 +569,7 @@ class ParcelInvoiceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_parcel_invoice_file_with_http_info(parcel_invoice_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_parcel_invoice_file_with_http_info(parcel_invoice_id, file_id, **kwargs)  # noqa: E501
@@ -580,11 +580,11 @@ class ParcelInvoiceApi(object):
 
         Deletes an existing parcelInvoice file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice_file_with_http_info(parcel_invoice_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice_file_with_http_info(parcel_invoice_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -593,7 +593,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -649,7 +649,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -660,11 +660,11 @@ class ParcelInvoiceApi(object):
 
         Deletes an existing parcelInvoice tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice_tag(parcel_invoice_id, parcel_invoice_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice_tag(parcel_invoice_id, parcel_invoice_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to remove tag from (required)
         :param str parcel_invoice_tag: The tag to delete (required)
         :return: None
@@ -672,7 +672,7 @@ class ParcelInvoiceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_parcel_invoice_tag_with_http_info(parcel_invoice_id, parcel_invoice_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_parcel_invoice_tag_with_http_info(parcel_invoice_id, parcel_invoice_tag, **kwargs)  # noqa: E501
@@ -683,11 +683,11 @@ class ParcelInvoiceApi(object):
 
         Deletes an existing parcelInvoice tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice_tag_with_http_info(parcel_invoice_id, parcel_invoice_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice_tag_with_http_info(parcel_invoice_id, parcel_invoice_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to remove tag from (required)
         :param str parcel_invoice_tag: The tag to delete (required)
         :return: None
@@ -696,7 +696,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id', 'parcel_invoice_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,18 +763,18 @@ class ParcelInvoiceApi(object):
 
         Returns a duplicated parcelInvoice identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_parcel_invoice_by_id(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_parcel_invoice_by_id(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to be duplicated. (required)
         :return: ParcelInvoice
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_parcel_invoice_by_id_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_parcel_invoice_by_id_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
@@ -785,11 +785,11 @@ class ParcelInvoiceApi(object):
 
         Returns a duplicated parcelInvoice identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_parcel_invoice_by_id_with_http_info(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_parcel_invoice_by_id_with_http_info(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to be duplicated. (required)
         :return: ParcelInvoice
                  If the method is called asynchronously,
@@ -797,7 +797,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -847,7 +847,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type='ParcelInvoice',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -858,11 +858,11 @@ class ParcelInvoiceApi(object):
 
         Returns the list of parcelInvoices that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -872,7 +872,7 @@ class ParcelInvoiceApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_invoice_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_invoice_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -883,11 +883,11 @@ class ParcelInvoiceApi(object):
 
         Returns the list of parcelInvoices that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -898,7 +898,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type='list[ParcelInvoice]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ParcelInvoiceApi(object):
 
         Returns the parcelInvoice identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_by_id(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_by_id(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to be returned. (required)
         :return: ParcelInvoice
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_invoice_by_id_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_invoice_by_id_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ParcelInvoiceApi(object):
 
         Returns the parcelInvoice identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_by_id_with_http_info(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_by_id_with_http_info(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to be returned. (required)
         :return: ParcelInvoice
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type='ParcelInvoice',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ParcelInvoiceApi(object):
 
         Get all existing parcelInvoice files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_files(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_files(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_invoice_files_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_invoice_files_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ParcelInvoiceApi(object):
 
         Get all existing parcelInvoice files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_files_with_http_info(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_files_with_http_info(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class ParcelInvoiceApi(object):
 
         Get all existing parcelInvoice tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_tags(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_tags(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_invoice_tags_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_invoice_tags_with_http_info(parcel_invoice_id, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class ParcelInvoiceApi(object):
 
         Get all existing parcelInvoice tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_tags_with_http_info(parcel_invoice_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_tags_with_http_info(parcel_invoice_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_id: Id of the parcelInvoice to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class ParcelInvoiceApi(object):
         """
 
         all_params = ['parcel_invoice_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1235,7 +1235,7 @@ class ParcelInvoiceApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/parcel_invoice_line_api.py
+++ b/Infoplus/api/parcel_invoice_line_api.py
@@ -38,11 +38,11 @@ class ParcelInvoiceLineApi(object):
 
         Adds an audit to an existing parcelInvoiceLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_line_audit(parcel_invoice_line_id, parcel_invoice_line_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_line_audit(parcel_invoice_line_id, parcel_invoice_line_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to add an audit to (required)
         :param str parcel_invoice_line_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ParcelInvoiceLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_invoice_line_audit_with_http_info(parcel_invoice_line_id, parcel_invoice_line_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_invoice_line_audit_with_http_info(parcel_invoice_line_id, parcel_invoice_line_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ParcelInvoiceLineApi(object):
 
         Adds an audit to an existing parcelInvoiceLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_line_audit_with_http_info(parcel_invoice_line_id, parcel_invoice_line_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_line_audit_with_http_info(parcel_invoice_line_id, parcel_invoice_line_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to add an audit to (required)
         :param str parcel_invoice_line_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['parcel_invoice_line_id', 'parcel_invoice_line_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ParcelInvoiceLineApi(object):
 
         Adds a file to an existing parcelInvoiceLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_line_file(parcel_invoice_line_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_line_file(parcel_invoice_line_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ParcelInvoiceLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_invoice_line_file_with_http_info(parcel_invoice_line_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_invoice_line_file_with_http_info(parcel_invoice_line_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ParcelInvoiceLineApi(object):
 
         Adds a file to an existing parcelInvoiceLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_line_file_with_http_info(parcel_invoice_line_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_line_file_with_http_info(parcel_invoice_line_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['parcel_invoice_line_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ParcelInvoiceLineApi(object):
 
         Adds a file to an existing parcelInvoiceLine by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_line_file_by_url(body, parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_line_file_by_url(body, parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ParcelInvoiceLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_invoice_line_file_by_url_with_http_info(body, parcel_invoice_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_invoice_line_file_by_url_with_http_info(body, parcel_invoice_line_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ParcelInvoiceLineApi(object):
 
         Adds a file to an existing parcelInvoiceLine by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_line_file_by_url_with_http_info(body, parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_line_file_by_url_with_http_info(body, parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['body', 'parcel_invoice_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ParcelInvoiceLineApi(object):
 
         Adds a tag to an existing parcelInvoiceLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_line_tag(parcel_invoice_line_id, parcel_invoice_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_line_tag(parcel_invoice_line_id, parcel_invoice_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to add a tag to (required)
         :param str parcel_invoice_line_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ParcelInvoiceLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_parcel_invoice_line_tag_with_http_info(parcel_invoice_line_id, parcel_invoice_line_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_parcel_invoice_line_tag_with_http_info(parcel_invoice_line_id, parcel_invoice_line_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ParcelInvoiceLineApi(object):
 
         Adds a tag to an existing parcelInvoiceLine.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_parcel_invoice_line_tag_with_http_info(parcel_invoice_line_id, parcel_invoice_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_parcel_invoice_line_tag_with_http_info(parcel_invoice_line_id, parcel_invoice_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to add a tag to (required)
         :param str parcel_invoice_line_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['parcel_invoice_line_id', 'parcel_invoice_line_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class ParcelInvoiceLineApi(object):
 
         Deletes an existing parcelInvoiceLine file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice_line_file(parcel_invoice_line_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice_line_file(parcel_invoice_line_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class ParcelInvoiceLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_parcel_invoice_line_file_with_http_info(parcel_invoice_line_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_parcel_invoice_line_file_with_http_info(parcel_invoice_line_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class ParcelInvoiceLineApi(object):
 
         Deletes an existing parcelInvoiceLine file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice_line_file_with_http_info(parcel_invoice_line_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice_line_file_with_http_info(parcel_invoice_line_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['parcel_invoice_line_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class ParcelInvoiceLineApi(object):
 
         Deletes an existing parcelInvoiceLine tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice_line_tag(parcel_invoice_line_id, parcel_invoice_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice_line_tag(parcel_invoice_line_id, parcel_invoice_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to remove tag from (required)
         :param str parcel_invoice_line_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class ParcelInvoiceLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_parcel_invoice_line_tag_with_http_info(parcel_invoice_line_id, parcel_invoice_line_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_parcel_invoice_line_tag_with_http_info(parcel_invoice_line_id, parcel_invoice_line_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class ParcelInvoiceLineApi(object):
 
         Deletes an existing parcelInvoiceLine tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_parcel_invoice_line_tag_with_http_info(parcel_invoice_line_id, parcel_invoice_line_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_parcel_invoice_line_tag_with_http_info(parcel_invoice_line_id, parcel_invoice_line_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to remove tag from (required)
         :param str parcel_invoice_line_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['parcel_invoice_line_id', 'parcel_invoice_line_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class ParcelInvoiceLineApi(object):
 
         Returns a duplicated parcelInvoiceLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_parcel_invoice_line_by_id(parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_parcel_invoice_line_by_id(parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to be duplicated. (required)
         :return: ParcelInvoiceLine
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_parcel_invoice_line_by_id_with_http_info(parcel_invoice_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_parcel_invoice_line_by_id_with_http_info(parcel_invoice_line_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class ParcelInvoiceLineApi(object):
 
         Returns a duplicated parcelInvoiceLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_parcel_invoice_line_by_id_with_http_info(parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_parcel_invoice_line_by_id_with_http_info(parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to be duplicated. (required)
         :return: ParcelInvoiceLine
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['parcel_invoice_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type='ParcelInvoiceLine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class ParcelInvoiceLineApi(object):
 
         Returns the list of parcelInvoiceLines that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_line_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_line_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class ParcelInvoiceLineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_invoice_line_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_invoice_line_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class ParcelInvoiceLineApi(object):
 
         Returns the list of parcelInvoiceLines that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_line_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_line_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type='list[ParcelInvoiceLine]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class ParcelInvoiceLineApi(object):
 
         Returns the parcelInvoiceLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_line_by_id(parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_line_by_id(parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to be returned. (required)
         :return: ParcelInvoiceLine
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_invoice_line_by_id_with_http_info(parcel_invoice_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_invoice_line_by_id_with_http_info(parcel_invoice_line_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class ParcelInvoiceLineApi(object):
 
         Returns the parcelInvoiceLine identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_line_by_id_with_http_info(parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_line_by_id_with_http_info(parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to be returned. (required)
         :return: ParcelInvoiceLine
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['parcel_invoice_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type='ParcelInvoiceLine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ParcelInvoiceLineApi(object):
 
         Get all existing parcelInvoiceLine files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_line_files(parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_line_files(parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_invoice_line_files_with_http_info(parcel_invoice_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_invoice_line_files_with_http_info(parcel_invoice_line_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ParcelInvoiceLineApi(object):
 
         Get all existing parcelInvoiceLine files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_line_files_with_http_info(parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_line_files_with_http_info(parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['parcel_invoice_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ParcelInvoiceLineApi(object):
 
         Get all existing parcelInvoiceLine tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_line_tags(parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_line_tags(parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_parcel_invoice_line_tags_with_http_info(parcel_invoice_line_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_parcel_invoice_line_tags_with_http_info(parcel_invoice_line_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ParcelInvoiceLineApi(object):
 
         Get all existing parcelInvoiceLine tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_parcel_invoice_line_tags_with_http_info(parcel_invoice_line_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_parcel_invoice_line_tags_with_http_info(parcel_invoice_line_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int parcel_invoice_line_id: Id of the parcelInvoiceLine to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['parcel_invoice_line_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class ParcelInvoiceLineApi(object):
 
         Updates an existing parcelInvoiceLine using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_parcel_invoice_line(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_parcel_invoice_line(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ParcelInvoiceLine body: ParcelInvoiceLine to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_parcel_invoice_line_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_parcel_invoice_line_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class ParcelInvoiceLineApi(object):
 
         Updates an existing parcelInvoiceLine using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_parcel_invoice_line_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_parcel_invoice_line_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ParcelInvoiceLine body: ParcelInvoiceLine to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class ParcelInvoiceLineApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ParcelInvoiceLineApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/perpetual_inventory_log_api.py
+++ b/Infoplus/api/perpetual_inventory_log_api.py
@@ -38,11 +38,11 @@ class PerpetualInventoryLogApi(object):
 
         Adds an audit to an existing perpetualInventoryLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_perpetual_inventory_log_audit(perpetual_inventory_log_id, perpetual_inventory_log_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_perpetual_inventory_log_audit(perpetual_inventory_log_id, perpetual_inventory_log_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to add an audit to (required)
         :param str perpetual_inventory_log_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class PerpetualInventoryLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_perpetual_inventory_log_audit_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_perpetual_inventory_log_audit_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class PerpetualInventoryLogApi(object):
 
         Adds an audit to an existing perpetualInventoryLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_perpetual_inventory_log_audit_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_perpetual_inventory_log_audit_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to add an audit to (required)
         :param str perpetual_inventory_log_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['perpetual_inventory_log_id', 'perpetual_inventory_log_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class PerpetualInventoryLogApi(object):
 
         Adds a file to an existing perpetualInventoryLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_perpetual_inventory_log_file(perpetual_inventory_log_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_perpetual_inventory_log_file(perpetual_inventory_log_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class PerpetualInventoryLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_perpetual_inventory_log_file_with_http_info(perpetual_inventory_log_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_perpetual_inventory_log_file_with_http_info(perpetual_inventory_log_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class PerpetualInventoryLogApi(object):
 
         Adds a file to an existing perpetualInventoryLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_perpetual_inventory_log_file_with_http_info(perpetual_inventory_log_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_perpetual_inventory_log_file_with_http_info(perpetual_inventory_log_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['perpetual_inventory_log_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class PerpetualInventoryLogApi(object):
 
         Adds a file to an existing perpetualInventoryLog by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_perpetual_inventory_log_file_by_url(body, perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_perpetual_inventory_log_file_by_url(body, perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class PerpetualInventoryLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_perpetual_inventory_log_file_by_url_with_http_info(body, perpetual_inventory_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_perpetual_inventory_log_file_by_url_with_http_info(body, perpetual_inventory_log_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class PerpetualInventoryLogApi(object):
 
         Adds a file to an existing perpetualInventoryLog by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_perpetual_inventory_log_file_by_url_with_http_info(body, perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_perpetual_inventory_log_file_by_url_with_http_info(body, perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['body', 'perpetual_inventory_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class PerpetualInventoryLogApi(object):
 
         Adds a tag to an existing perpetualInventoryLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_perpetual_inventory_log_tag(perpetual_inventory_log_id, perpetual_inventory_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_perpetual_inventory_log_tag(perpetual_inventory_log_id, perpetual_inventory_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to add a tag to (required)
         :param str perpetual_inventory_log_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class PerpetualInventoryLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_perpetual_inventory_log_tag_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_perpetual_inventory_log_tag_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class PerpetualInventoryLogApi(object):
 
         Adds a tag to an existing perpetualInventoryLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_perpetual_inventory_log_tag_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_perpetual_inventory_log_tag_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to add a tag to (required)
         :param str perpetual_inventory_log_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['perpetual_inventory_log_id', 'perpetual_inventory_log_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class PerpetualInventoryLogApi(object):
 
         Deletes an existing perpetualInventoryLog file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_perpetual_inventory_log_file(perpetual_inventory_log_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_perpetual_inventory_log_file(perpetual_inventory_log_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class PerpetualInventoryLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_perpetual_inventory_log_file_with_http_info(perpetual_inventory_log_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_perpetual_inventory_log_file_with_http_info(perpetual_inventory_log_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class PerpetualInventoryLogApi(object):
 
         Deletes an existing perpetualInventoryLog file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_perpetual_inventory_log_file_with_http_info(perpetual_inventory_log_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_perpetual_inventory_log_file_with_http_info(perpetual_inventory_log_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['perpetual_inventory_log_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class PerpetualInventoryLogApi(object):
 
         Deletes an existing perpetualInventoryLog tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_perpetual_inventory_log_tag(perpetual_inventory_log_id, perpetual_inventory_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_perpetual_inventory_log_tag(perpetual_inventory_log_id, perpetual_inventory_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to remove tag from (required)
         :param str perpetual_inventory_log_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class PerpetualInventoryLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_perpetual_inventory_log_tag_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_perpetual_inventory_log_tag_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class PerpetualInventoryLogApi(object):
 
         Deletes an existing perpetualInventoryLog tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_perpetual_inventory_log_tag_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_perpetual_inventory_log_tag_with_http_info(perpetual_inventory_log_id, perpetual_inventory_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to remove tag from (required)
         :param str perpetual_inventory_log_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['perpetual_inventory_log_id', 'perpetual_inventory_log_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class PerpetualInventoryLogApi(object):
 
         Returns a duplicated perpetualInventoryLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_perpetual_inventory_log_by_id(perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_perpetual_inventory_log_by_id(perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to be duplicated. (required)
         :return: PerpetualInventoryLog
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_perpetual_inventory_log_by_id_with_http_info(perpetual_inventory_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_perpetual_inventory_log_by_id_with_http_info(perpetual_inventory_log_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class PerpetualInventoryLogApi(object):
 
         Returns a duplicated perpetualInventoryLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_perpetual_inventory_log_by_id_with_http_info(perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_perpetual_inventory_log_by_id_with_http_info(perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to be duplicated. (required)
         :return: PerpetualInventoryLog
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['perpetual_inventory_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type='PerpetualInventoryLog',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class PerpetualInventoryLogApi(object):
 
         Returns the list of perpetualInventoryLogs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_perpetual_inventory_log_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_perpetual_inventory_log_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class PerpetualInventoryLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_perpetual_inventory_log_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_perpetual_inventory_log_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class PerpetualInventoryLogApi(object):
 
         Returns the list of perpetualInventoryLogs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_perpetual_inventory_log_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_perpetual_inventory_log_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type='list[PerpetualInventoryLog]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class PerpetualInventoryLogApi(object):
 
         Returns the perpetualInventoryLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_perpetual_inventory_log_by_id(perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_perpetual_inventory_log_by_id(perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to be returned. (required)
         :return: PerpetualInventoryLog
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_perpetual_inventory_log_by_id_with_http_info(perpetual_inventory_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_perpetual_inventory_log_by_id_with_http_info(perpetual_inventory_log_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class PerpetualInventoryLogApi(object):
 
         Returns the perpetualInventoryLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_perpetual_inventory_log_by_id_with_http_info(perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_perpetual_inventory_log_by_id_with_http_info(perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to be returned. (required)
         :return: PerpetualInventoryLog
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['perpetual_inventory_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type='PerpetualInventoryLog',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class PerpetualInventoryLogApi(object):
 
         Get all existing perpetualInventoryLog files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_perpetual_inventory_log_files(perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_perpetual_inventory_log_files(perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_perpetual_inventory_log_files_with_http_info(perpetual_inventory_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_perpetual_inventory_log_files_with_http_info(perpetual_inventory_log_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class PerpetualInventoryLogApi(object):
 
         Get all existing perpetualInventoryLog files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_perpetual_inventory_log_files_with_http_info(perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_perpetual_inventory_log_files_with_http_info(perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['perpetual_inventory_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class PerpetualInventoryLogApi(object):
 
         Get all existing perpetualInventoryLog tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_perpetual_inventory_log_tags(perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_perpetual_inventory_log_tags(perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_perpetual_inventory_log_tags_with_http_info(perpetual_inventory_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_perpetual_inventory_log_tags_with_http_info(perpetual_inventory_log_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class PerpetualInventoryLogApi(object):
 
         Get all existing perpetualInventoryLog tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_perpetual_inventory_log_tags_with_http_info(perpetual_inventory_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_perpetual_inventory_log_tags_with_http_info(perpetual_inventory_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int perpetual_inventory_log_id: Id of the perpetualInventoryLog to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class PerpetualInventoryLogApi(object):
         """
 
         all_params = ['perpetual_inventory_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class PerpetualInventoryLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/pick_face_assignment_api.py
+++ b/Infoplus/api/pick_face_assignment_api.py
@@ -38,18 +38,18 @@ class PickFaceAssignmentApi(object):
 
         Inserts a new pickFaceAssignment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PickFaceAssignment body: PickFaceAssignment to be inserted. (required)
         :return: PickFaceAssignment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pick_face_assignment_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pick_face_assignment_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class PickFaceAssignmentApi(object):
 
         Inserts a new pickFaceAssignment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PickFaceAssignment body: PickFaceAssignment to be inserted. (required)
         :return: PickFaceAssignment
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type='PickFaceAssignment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class PickFaceAssignmentApi(object):
 
         Adds an audit to an existing pickFaceAssignment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment_audit(pick_face_assignment_id, pick_face_assignment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment_audit(pick_face_assignment_id, pick_face_assignment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to add an audit to (required)
         :param str pick_face_assignment_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class PickFaceAssignmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pick_face_assignment_audit_with_http_info(pick_face_assignment_id, pick_face_assignment_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pick_face_assignment_audit_with_http_info(pick_face_assignment_id, pick_face_assignment_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class PickFaceAssignmentApi(object):
 
         Adds an audit to an existing pickFaceAssignment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment_audit_with_http_info(pick_face_assignment_id, pick_face_assignment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment_audit_with_http_info(pick_face_assignment_id, pick_face_assignment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to add an audit to (required)
         :param str pick_face_assignment_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id', 'pick_face_assignment_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class PickFaceAssignmentApi(object):
 
         Adds a file to an existing pickFaceAssignment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment_file(pick_face_assignment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment_file(pick_face_assignment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class PickFaceAssignmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pick_face_assignment_file_with_http_info(pick_face_assignment_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pick_face_assignment_file_with_http_info(pick_face_assignment_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class PickFaceAssignmentApi(object):
 
         Adds a file to an existing pickFaceAssignment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment_file_with_http_info(pick_face_assignment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment_file_with_http_info(pick_face_assignment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class PickFaceAssignmentApi(object):
 
         Adds a file to an existing pickFaceAssignment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment_file_by_url(body, pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment_file_by_url(body, pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class PickFaceAssignmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pick_face_assignment_file_by_url_with_http_info(body, pick_face_assignment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pick_face_assignment_file_by_url_with_http_info(body, pick_face_assignment_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class PickFaceAssignmentApi(object):
 
         Adds a file to an existing pickFaceAssignment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment_file_by_url_with_http_info(body, pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment_file_by_url_with_http_info(body, pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['body', 'pick_face_assignment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class PickFaceAssignmentApi(object):
 
         Adds a tag to an existing pickFaceAssignment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment_tag(pick_face_assignment_id, pick_face_assignment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment_tag(pick_face_assignment_id, pick_face_assignment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to add a tag to (required)
         :param str pick_face_assignment_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class PickFaceAssignmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_pick_face_assignment_tag_with_http_info(pick_face_assignment_id, pick_face_assignment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_pick_face_assignment_tag_with_http_info(pick_face_assignment_id, pick_face_assignment_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class PickFaceAssignmentApi(object):
 
         Adds a tag to an existing pickFaceAssignment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_pick_face_assignment_tag_with_http_info(pick_face_assignment_id, pick_face_assignment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_pick_face_assignment_tag_with_http_info(pick_face_assignment_id, pick_face_assignment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to add a tag to (required)
         :param str pick_face_assignment_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id', 'pick_face_assignment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class PickFaceAssignmentApi(object):
 
         Deletes the pickFaceAssignment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pick_face_assignment(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pick_face_assignment(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_pick_face_assignment_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_pick_face_assignment_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class PickFaceAssignmentApi(object):
 
         Deletes the pickFaceAssignment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pick_face_assignment_with_http_info(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pick_face_assignment_with_http_info(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class PickFaceAssignmentApi(object):
 
         Deletes an existing pickFaceAssignment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pick_face_assignment_file(pick_face_assignment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pick_face_assignment_file(pick_face_assignment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class PickFaceAssignmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_pick_face_assignment_file_with_http_info(pick_face_assignment_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_pick_face_assignment_file_with_http_info(pick_face_assignment_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class PickFaceAssignmentApi(object):
 
         Deletes an existing pickFaceAssignment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pick_face_assignment_file_with_http_info(pick_face_assignment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pick_face_assignment_file_with_http_info(pick_face_assignment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class PickFaceAssignmentApi(object):
 
         Deletes an existing pickFaceAssignment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pick_face_assignment_tag(pick_face_assignment_id, pick_face_assignment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pick_face_assignment_tag(pick_face_assignment_id, pick_face_assignment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to remove tag from (required)
         :param str pick_face_assignment_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class PickFaceAssignmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_pick_face_assignment_tag_with_http_info(pick_face_assignment_id, pick_face_assignment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_pick_face_assignment_tag_with_http_info(pick_face_assignment_id, pick_face_assignment_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class PickFaceAssignmentApi(object):
 
         Deletes an existing pickFaceAssignment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_pick_face_assignment_tag_with_http_info(pick_face_assignment_id, pick_face_assignment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_pick_face_assignment_tag_with_http_info(pick_face_assignment_id, pick_face_assignment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to remove tag from (required)
         :param str pick_face_assignment_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id', 'pick_face_assignment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class PickFaceAssignmentApi(object):
 
         Returns a duplicated pickFaceAssignment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_pick_face_assignment_by_id(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_pick_face_assignment_by_id(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to be duplicated. (required)
         :return: PickFaceAssignment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_pick_face_assignment_by_id_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_pick_face_assignment_by_id_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class PickFaceAssignmentApi(object):
 
         Returns a duplicated pickFaceAssignment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_pick_face_assignment_by_id_with_http_info(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_pick_face_assignment_by_id_with_http_info(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to be duplicated. (required)
         :return: PickFaceAssignment
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type='PickFaceAssignment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class PickFaceAssignmentApi(object):
 
         Returns the list of pickFaceAssignments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pick_face_assignment_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pick_face_assignment_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class PickFaceAssignmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_pick_face_assignment_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_pick_face_assignment_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class PickFaceAssignmentApi(object):
 
         Returns the list of pickFaceAssignments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pick_face_assignment_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pick_face_assignment_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type='list[PickFaceAssignment]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class PickFaceAssignmentApi(object):
 
         Returns the pickFaceAssignment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pick_face_assignment_by_id(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pick_face_assignment_by_id(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to be returned. (required)
         :return: PickFaceAssignment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_pick_face_assignment_by_id_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_pick_face_assignment_by_id_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class PickFaceAssignmentApi(object):
 
         Returns the pickFaceAssignment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pick_face_assignment_by_id_with_http_info(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pick_face_assignment_by_id_with_http_info(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to be returned. (required)
         :return: PickFaceAssignment
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type='PickFaceAssignment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class PickFaceAssignmentApi(object):
 
         Get all existing pickFaceAssignment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pick_face_assignment_files(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pick_face_assignment_files(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_pick_face_assignment_files_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_pick_face_assignment_files_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class PickFaceAssignmentApi(object):
 
         Get all existing pickFaceAssignment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pick_face_assignment_files_with_http_info(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pick_face_assignment_files_with_http_info(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class PickFaceAssignmentApi(object):
 
         Get all existing pickFaceAssignment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pick_face_assignment_tags(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pick_face_assignment_tags(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_pick_face_assignment_tags_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_pick_face_assignment_tags_with_http_info(pick_face_assignment_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class PickFaceAssignmentApi(object):
 
         Get all existing pickFaceAssignment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_pick_face_assignment_tags_with_http_info(pick_face_assignment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_pick_face_assignment_tags_with_http_info(pick_face_assignment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int pick_face_assignment_id: Id of the pickFaceAssignment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['pick_face_assignment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class PickFaceAssignmentApi(object):
 
         Updates an existing pickFaceAssignment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_pick_face_assignment(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_pick_face_assignment(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PickFaceAssignment body: PickFaceAssignment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_pick_face_assignment_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_pick_face_assignment_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class PickFaceAssignmentApi(object):
 
         Updates an existing pickFaceAssignment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_pick_face_assignment_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_pick_face_assignment_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PickFaceAssignment body: PickFaceAssignment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class PickFaceAssignmentApi(object):
 
         Updates an existing pickFaceAssignment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_pick_face_assignment_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_pick_face_assignment_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PickFaceAssignment body: PickFaceAssignment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_pick_face_assignment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_pick_face_assignment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class PickFaceAssignmentApi(object):
 
         Updates an existing pickFaceAssignment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_pick_face_assignment_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_pick_face_assignment_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param PickFaceAssignment body: PickFaceAssignment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class PickFaceAssignmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class PickFaceAssignmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/predefined_carton_api.py
+++ b/Infoplus/api/predefined_carton_api.py
@@ -38,18 +38,18 @@ class PredefinedCartonApi(object):
 
         Returns the predefinedCarton identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_predefined_carton_by_id(predefined_carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_predefined_carton_by_id(predefined_carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str predefined_carton_id: Id of predefinedCarton to be returned. (required)
         :return: PredefinedCarton
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_predefined_carton_by_id_with_http_info(predefined_carton_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_predefined_carton_by_id_with_http_info(predefined_carton_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class PredefinedCartonApi(object):
 
         Returns the predefinedCarton identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_predefined_carton_by_id_with_http_info(predefined_carton_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_predefined_carton_by_id_with_http_info(predefined_carton_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str predefined_carton_id: Id of predefinedCarton to be returned. (required)
         :return: PredefinedCarton
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class PredefinedCartonApi(object):
         """
 
         all_params = ['predefined_carton_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class PredefinedCartonApi(object):
             files=local_var_files,
             response_type='PredefinedCarton',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class PredefinedCartonApi(object):
 
         Returns the list of predefinedCartons that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_predefined_carton_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_predefined_carton_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class PredefinedCartonApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_predefined_carton_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_predefined_carton_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class PredefinedCartonApi(object):
 
         Returns the list of predefinedCartons that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_predefined_carton_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_predefined_carton_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class PredefinedCartonApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class PredefinedCartonApi(object):
             files=local_var_files,
             response_type='list[PredefinedCarton]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/product_type_api.py
+++ b/Infoplus/api/product_type_api.py
@@ -38,18 +38,18 @@ class ProductTypeApi(object):
 
         Returns the productType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_product_type_by_id(product_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_product_type_by_id(product_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str product_type_id: Id of productType to be returned. (required)
         :return: ProductType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_product_type_by_id_with_http_info(product_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_product_type_by_id_with_http_info(product_type_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ProductTypeApi(object):
 
         Returns the productType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_product_type_by_id_with_http_info(product_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_product_type_by_id_with_http_info(product_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str product_type_id: Id of productType to be returned. (required)
         :return: ProductType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ProductTypeApi(object):
         """
 
         all_params = ['product_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class ProductTypeApi(object):
             files=local_var_files,
             response_type='ProductType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class ProductTypeApi(object):
 
         Returns the list of productTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_product_type_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_product_type_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class ProductTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_product_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_product_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class ProductTypeApi(object):
 
         Returns the list of productTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_product_type_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_product_type_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class ProductTypeApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class ProductTypeApi(object):
             files=local_var_files,
             response_type='list[ProductType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/production_lot_api.py
+++ b/Infoplus/api/production_lot_api.py
@@ -38,18 +38,18 @@ class ProductionLotApi(object):
 
         Inserts a new productionLot using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionLot body: ProductionLot to be inserted. (required)
         :return: ProductionLot
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_lot_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_lot_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ProductionLotApi(object):
 
         Inserts a new productionLot using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionLot body: ProductionLot to be inserted. (required)
         :return: ProductionLot
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type='ProductionLot',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ProductionLotApi(object):
 
         Adds an audit to an existing productionLot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot_audit(production_lot_id, production_lot_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot_audit(production_lot_id, production_lot_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to add an audit to (required)
         :param str production_lot_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ProductionLotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_lot_audit_with_http_info(production_lot_id, production_lot_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_lot_audit_with_http_info(production_lot_id, production_lot_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ProductionLotApi(object):
 
         Adds an audit to an existing productionLot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot_audit_with_http_info(production_lot_id, production_lot_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot_audit_with_http_info(production_lot_id, production_lot_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to add an audit to (required)
         :param str production_lot_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id', 'production_lot_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ProductionLotApi(object):
 
         Adds a file to an existing productionLot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot_file(production_lot_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot_file(production_lot_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ProductionLotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_lot_file_with_http_info(production_lot_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_lot_file_with_http_info(production_lot_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ProductionLotApi(object):
 
         Adds a file to an existing productionLot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot_file_with_http_info(production_lot_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot_file_with_http_info(production_lot_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ProductionLotApi(object):
 
         Adds a file to an existing productionLot by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot_file_by_url(body, production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot_file_by_url(body, production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int production_lot_id: Id of the productionLot to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ProductionLotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_lot_file_by_url_with_http_info(body, production_lot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_lot_file_by_url_with_http_info(body, production_lot_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ProductionLotApi(object):
 
         Adds a file to an existing productionLot by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot_file_by_url_with_http_info(body, production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot_file_by_url_with_http_info(body, production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int production_lot_id: Id of the productionLot to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['body', 'production_lot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ProductionLotApi(object):
 
         Adds a tag to an existing productionLot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot_tag(production_lot_id, production_lot_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot_tag(production_lot_id, production_lot_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to add a tag to (required)
         :param str production_lot_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ProductionLotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_lot_tag_with_http_info(production_lot_id, production_lot_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_lot_tag_with_http_info(production_lot_id, production_lot_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ProductionLotApi(object):
 
         Adds a tag to an existing productionLot.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_lot_tag_with_http_info(production_lot_id, production_lot_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_lot_tag_with_http_info(production_lot_id, production_lot_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to add a tag to (required)
         :param str production_lot_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id', 'production_lot_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ProductionLotApi(object):
 
         Deletes the productionLot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_lot(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_lot(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_production_lot_with_http_info(production_lot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_production_lot_with_http_info(production_lot_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ProductionLotApi(object):
 
         Deletes the productionLot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_lot_with_http_info(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_lot_with_http_info(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ProductionLotApi(object):
 
         Deletes an existing productionLot file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_lot_file(production_lot_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_lot_file(production_lot_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ProductionLotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_production_lot_file_with_http_info(production_lot_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_production_lot_file_with_http_info(production_lot_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ProductionLotApi(object):
 
         Deletes an existing productionLot file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_lot_file_with_http_info(production_lot_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_lot_file_with_http_info(production_lot_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ProductionLotApi(object):
 
         Deletes an existing productionLot tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_lot_tag(production_lot_id, production_lot_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_lot_tag(production_lot_id, production_lot_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to remove tag from (required)
         :param str production_lot_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ProductionLotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_production_lot_tag_with_http_info(production_lot_id, production_lot_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_production_lot_tag_with_http_info(production_lot_id, production_lot_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ProductionLotApi(object):
 
         Deletes an existing productionLot tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_lot_tag_with_http_info(production_lot_id, production_lot_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_lot_tag_with_http_info(production_lot_id, production_lot_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to remove tag from (required)
         :param str production_lot_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id', 'production_lot_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ProductionLotApi(object):
 
         Returns a duplicated productionLot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_production_lot_by_id(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_production_lot_by_id(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to be duplicated. (required)
         :return: ProductionLot
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_production_lot_by_id_with_http_info(production_lot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_production_lot_by_id_with_http_info(production_lot_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ProductionLotApi(object):
 
         Returns a duplicated productionLot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_production_lot_by_id_with_http_info(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_production_lot_by_id_with_http_info(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to be duplicated. (required)
         :return: ProductionLot
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type='ProductionLot',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ProductionLotApi(object):
 
         Returns the list of productionLots that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_lot_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_lot_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ProductionLotApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_production_lot_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_production_lot_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ProductionLotApi(object):
 
         Returns the list of productionLots that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_lot_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_lot_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type='list[ProductionLot]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ProductionLotApi(object):
 
         Returns the productionLot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_lot_by_id(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_lot_by_id(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to be returned. (required)
         :return: ProductionLot
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_production_lot_by_id_with_http_info(production_lot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_production_lot_by_id_with_http_info(production_lot_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ProductionLotApi(object):
 
         Returns the productionLot identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_lot_by_id_with_http_info(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_lot_by_id_with_http_info(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to be returned. (required)
         :return: ProductionLot
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type='ProductionLot',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ProductionLotApi(object):
 
         Get all existing productionLot files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_lot_files(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_lot_files(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_production_lot_files_with_http_info(production_lot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_production_lot_files_with_http_info(production_lot_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ProductionLotApi(object):
 
         Get all existing productionLot files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_lot_files_with_http_info(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_lot_files_with_http_info(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ProductionLotApi(object):
 
         Get all existing productionLot tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_lot_tags(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_lot_tags(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_production_lot_tags_with_http_info(production_lot_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_production_lot_tags_with_http_info(production_lot_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ProductionLotApi(object):
 
         Get all existing productionLot tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_lot_tags_with_http_info(production_lot_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_lot_tags_with_http_info(production_lot_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_lot_id: Id of the productionLot to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['production_lot_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ProductionLotApi(object):
 
         Updates an existing productionLot using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_production_lot(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_production_lot(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionLot body: ProductionLot to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_production_lot_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_production_lot_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ProductionLotApi(object):
 
         Updates an existing productionLot using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_production_lot_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_production_lot_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionLot body: ProductionLot to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class ProductionLotApi(object):
 
         Updates an existing productionLot custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_production_lot_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_production_lot_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionLot body: ProductionLot to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_production_lot_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_production_lot_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class ProductionLotApi(object):
 
         Updates an existing productionLot custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_production_lot_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_production_lot_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionLot body: ProductionLot to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class ProductionLotApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class ProductionLotApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/production_model_api.py
+++ b/Infoplus/api/production_model_api.py
@@ -38,18 +38,18 @@ class ProductionModelApi(object):
 
         Inserts a new productionModel using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionModel body: ProductionModel to be inserted. (required)
         :return: ProductionModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_model_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_model_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ProductionModelApi(object):
 
         Inserts a new productionModel using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionModel body: ProductionModel to be inserted. (required)
         :return: ProductionModel
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type='ProductionModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ProductionModelApi(object):
 
         Adds an audit to an existing productionModel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model_audit(production_model_id, production_model_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model_audit(production_model_id, production_model_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to add an audit to (required)
         :param str production_model_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ProductionModelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_model_audit_with_http_info(production_model_id, production_model_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_model_audit_with_http_info(production_model_id, production_model_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ProductionModelApi(object):
 
         Adds an audit to an existing productionModel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model_audit_with_http_info(production_model_id, production_model_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model_audit_with_http_info(production_model_id, production_model_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to add an audit to (required)
         :param str production_model_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id', 'production_model_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ProductionModelApi(object):
 
         Adds a file to an existing productionModel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model_file(production_model_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model_file(production_model_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ProductionModelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_model_file_with_http_info(production_model_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_model_file_with_http_info(production_model_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ProductionModelApi(object):
 
         Adds a file to an existing productionModel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model_file_with_http_info(production_model_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model_file_with_http_info(production_model_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ProductionModelApi(object):
 
         Adds a file to an existing productionModel by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model_file_by_url(body, production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model_file_by_url(body, production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int production_model_id: Id of the productionModel to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ProductionModelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_model_file_by_url_with_http_info(body, production_model_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_model_file_by_url_with_http_info(body, production_model_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ProductionModelApi(object):
 
         Adds a file to an existing productionModel by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model_file_by_url_with_http_info(body, production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model_file_by_url_with_http_info(body, production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int production_model_id: Id of the productionModel to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['body', 'production_model_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ProductionModelApi(object):
 
         Adds a tag to an existing productionModel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model_tag(production_model_id, production_model_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model_tag(production_model_id, production_model_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to add a tag to (required)
         :param str production_model_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ProductionModelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_production_model_tag_with_http_info(production_model_id, production_model_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_production_model_tag_with_http_info(production_model_id, production_model_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ProductionModelApi(object):
 
         Adds a tag to an existing productionModel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_production_model_tag_with_http_info(production_model_id, production_model_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_production_model_tag_with_http_info(production_model_id, production_model_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to add a tag to (required)
         :param str production_model_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id', 'production_model_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ProductionModelApi(object):
 
         Deletes the productionModel identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_model(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_model(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_production_model_with_http_info(production_model_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_production_model_with_http_info(production_model_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ProductionModelApi(object):
 
         Deletes the productionModel identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_model_with_http_info(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_model_with_http_info(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ProductionModelApi(object):
 
         Deletes an existing productionModel file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_model_file(production_model_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_model_file(production_model_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ProductionModelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_production_model_file_with_http_info(production_model_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_production_model_file_with_http_info(production_model_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ProductionModelApi(object):
 
         Deletes an existing productionModel file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_model_file_with_http_info(production_model_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_model_file_with_http_info(production_model_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ProductionModelApi(object):
 
         Deletes an existing productionModel tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_model_tag(production_model_id, production_model_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_model_tag(production_model_id, production_model_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to remove tag from (required)
         :param str production_model_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ProductionModelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_production_model_tag_with_http_info(production_model_id, production_model_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_production_model_tag_with_http_info(production_model_id, production_model_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ProductionModelApi(object):
 
         Deletes an existing productionModel tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_production_model_tag_with_http_info(production_model_id, production_model_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_production_model_tag_with_http_info(production_model_id, production_model_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to remove tag from (required)
         :param str production_model_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id', 'production_model_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ProductionModelApi(object):
 
         Returns a duplicated productionModel identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_production_model_by_id(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_production_model_by_id(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to be duplicated. (required)
         :return: ProductionModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_production_model_by_id_with_http_info(production_model_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_production_model_by_id_with_http_info(production_model_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ProductionModelApi(object):
 
         Returns a duplicated productionModel identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_production_model_by_id_with_http_info(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_production_model_by_id_with_http_info(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to be duplicated. (required)
         :return: ProductionModel
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type='ProductionModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ProductionModelApi(object):
 
         Returns the list of productionModels that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_model_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_model_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ProductionModelApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_production_model_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_production_model_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ProductionModelApi(object):
 
         Returns the list of productionModels that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_model_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_model_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type='list[ProductionModel]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ProductionModelApi(object):
 
         Returns the productionModel identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_model_by_id(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_model_by_id(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to be returned. (required)
         :return: ProductionModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_production_model_by_id_with_http_info(production_model_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_production_model_by_id_with_http_info(production_model_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ProductionModelApi(object):
 
         Returns the productionModel identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_model_by_id_with_http_info(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_model_by_id_with_http_info(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to be returned. (required)
         :return: ProductionModel
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type='ProductionModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ProductionModelApi(object):
 
         Get all existing productionModel files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_model_files(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_model_files(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_production_model_files_with_http_info(production_model_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_production_model_files_with_http_info(production_model_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ProductionModelApi(object):
 
         Get all existing productionModel files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_model_files_with_http_info(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_model_files_with_http_info(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ProductionModelApi(object):
 
         Get all existing productionModel tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_model_tags(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_model_tags(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_production_model_tags_with_http_info(production_model_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_production_model_tags_with_http_info(production_model_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ProductionModelApi(object):
 
         Get all existing productionModel tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_production_model_tags_with_http_info(production_model_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_production_model_tags_with_http_info(production_model_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int production_model_id: Id of the productionModel to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['production_model_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ProductionModelApi(object):
 
         Updates an existing productionModel using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_production_model(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_production_model(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionModel body: ProductionModel to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_production_model_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_production_model_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ProductionModelApi(object):
 
         Updates an existing productionModel using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_production_model_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_production_model_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionModel body: ProductionModel to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class ProductionModelApi(object):
 
         Updates an existing productionModel custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_production_model_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_production_model_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionModel body: ProductionModel to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_production_model_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_production_model_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class ProductionModelApi(object):
 
         Updates an existing productionModel custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_production_model_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_production_model_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ProductionModel body: ProductionModel to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class ProductionModelApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class ProductionModelApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/quick_adjustment_api.py
+++ b/Infoplus/api/quick_adjustment_api.py
@@ -38,18 +38,18 @@ class QuickAdjustmentApi(object):
 
         Inserts a new quickAdjustment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickAdjustment body: QuickAdjustment to be inserted. (required)
         :return: QuickAdjustment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_adjustment_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_adjustment_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class QuickAdjustmentApi(object):
 
         Inserts a new quickAdjustment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickAdjustment body: QuickAdjustment to be inserted. (required)
         :return: QuickAdjustment
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type='QuickAdjustment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class QuickAdjustmentApi(object):
 
         Adds an audit to an existing quickAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment_audit(quick_adjustment_id, quick_adjustment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment_audit(quick_adjustment_id, quick_adjustment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to add an audit to (required)
         :param str quick_adjustment_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class QuickAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_adjustment_audit_with_http_info(quick_adjustment_id, quick_adjustment_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_adjustment_audit_with_http_info(quick_adjustment_id, quick_adjustment_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class QuickAdjustmentApi(object):
 
         Adds an audit to an existing quickAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment_audit_with_http_info(quick_adjustment_id, quick_adjustment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment_audit_with_http_info(quick_adjustment_id, quick_adjustment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to add an audit to (required)
         :param str quick_adjustment_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id', 'quick_adjustment_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class QuickAdjustmentApi(object):
 
         Adds a file to an existing quickAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment_file(quick_adjustment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment_file(quick_adjustment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class QuickAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_adjustment_file_with_http_info(quick_adjustment_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_adjustment_file_with_http_info(quick_adjustment_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class QuickAdjustmentApi(object):
 
         Adds a file to an existing quickAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment_file_with_http_info(quick_adjustment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment_file_with_http_info(quick_adjustment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class QuickAdjustmentApi(object):
 
         Adds a file to an existing quickAdjustment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment_file_by_url(body, quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment_file_by_url(body, quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int quick_adjustment_id: Id of the quickAdjustment to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class QuickAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_adjustment_file_by_url_with_http_info(body, quick_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_adjustment_file_by_url_with_http_info(body, quick_adjustment_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class QuickAdjustmentApi(object):
 
         Adds a file to an existing quickAdjustment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment_file_by_url_with_http_info(body, quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment_file_by_url_with_http_info(body, quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int quick_adjustment_id: Id of the quickAdjustment to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['body', 'quick_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class QuickAdjustmentApi(object):
 
         Adds a tag to an existing quickAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment_tag(quick_adjustment_id, quick_adjustment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment_tag(quick_adjustment_id, quick_adjustment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to add a tag to (required)
         :param str quick_adjustment_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class QuickAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_adjustment_tag_with_http_info(quick_adjustment_id, quick_adjustment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_adjustment_tag_with_http_info(quick_adjustment_id, quick_adjustment_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class QuickAdjustmentApi(object):
 
         Adds a tag to an existing quickAdjustment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_adjustment_tag_with_http_info(quick_adjustment_id, quick_adjustment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_adjustment_tag_with_http_info(quick_adjustment_id, quick_adjustment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to add a tag to (required)
         :param str quick_adjustment_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id', 'quick_adjustment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class QuickAdjustmentApi(object):
 
         Deletes the quickAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_adjustment(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_adjustment(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_quick_adjustment_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_quick_adjustment_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class QuickAdjustmentApi(object):
 
         Deletes the quickAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_adjustment_with_http_info(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_adjustment_with_http_info(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class QuickAdjustmentApi(object):
 
         Deletes an existing quickAdjustment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_adjustment_file(quick_adjustment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_adjustment_file(quick_adjustment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class QuickAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_quick_adjustment_file_with_http_info(quick_adjustment_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_quick_adjustment_file_with_http_info(quick_adjustment_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class QuickAdjustmentApi(object):
 
         Deletes an existing quickAdjustment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_adjustment_file_with_http_info(quick_adjustment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_adjustment_file_with_http_info(quick_adjustment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class QuickAdjustmentApi(object):
 
         Deletes an existing quickAdjustment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_adjustment_tag(quick_adjustment_id, quick_adjustment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_adjustment_tag(quick_adjustment_id, quick_adjustment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to remove tag from (required)
         :param str quick_adjustment_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class QuickAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_quick_adjustment_tag_with_http_info(quick_adjustment_id, quick_adjustment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_quick_adjustment_tag_with_http_info(quick_adjustment_id, quick_adjustment_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class QuickAdjustmentApi(object):
 
         Deletes an existing quickAdjustment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_adjustment_tag_with_http_info(quick_adjustment_id, quick_adjustment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_adjustment_tag_with_http_info(quick_adjustment_id, quick_adjustment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to remove tag from (required)
         :param str quick_adjustment_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id', 'quick_adjustment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class QuickAdjustmentApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.execute_quick_adjustment(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.execute_quick_adjustment(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExecuteQuickAdjustmentInputAPIModel body: Input data for ExecuteQuickAdjustment process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.execute_quick_adjustment_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.execute_quick_adjustment_with_http_info(body, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class QuickAdjustmentApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.execute_quick_adjustment_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.execute_quick_adjustment_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExecuteQuickAdjustmentInputAPIModel body: Input data for ExecuteQuickAdjustment process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type='list[ProcessOutputAPIModel]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,18 +957,18 @@ class QuickAdjustmentApi(object):
 
         Returns a duplicated quickAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_quick_adjustment_by_id(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_quick_adjustment_by_id(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to be duplicated. (required)
         :return: QuickAdjustment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_quick_adjustment_by_id_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_quick_adjustment_by_id_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
@@ -979,11 +979,11 @@ class QuickAdjustmentApi(object):
 
         Returns a duplicated quickAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_quick_adjustment_by_id_with_http_info(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_quick_adjustment_by_id_with_http_info(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to be duplicated. (required)
         :return: QuickAdjustment
                  If the method is called asynchronously,
@@ -991,7 +991,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1041,7 +1041,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type='QuickAdjustment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1052,11 +1052,11 @@ class QuickAdjustmentApi(object):
 
         Returns the list of quickAdjustments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_adjustment_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_adjustment_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1066,7 +1066,7 @@ class QuickAdjustmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_quick_adjustment_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_quick_adjustment_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -1077,11 +1077,11 @@ class QuickAdjustmentApi(object):
 
         Returns the list of quickAdjustments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_adjustment_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_adjustment_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1092,7 +1092,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type='list[QuickAdjustment]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class QuickAdjustmentApi(object):
 
         Returns the quickAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_adjustment_by_id(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_adjustment_by_id(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to be returned. (required)
         :return: QuickAdjustment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_quick_adjustment_by_id_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_quick_adjustment_by_id_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class QuickAdjustmentApi(object):
 
         Returns the quickAdjustment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_adjustment_by_id_with_http_info(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_adjustment_by_id_with_http_info(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to be returned. (required)
         :return: QuickAdjustment
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type='QuickAdjustment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class QuickAdjustmentApi(object):
 
         Get all existing quickAdjustment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_adjustment_files(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_adjustment_files(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_quick_adjustment_files_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_quick_adjustment_files_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class QuickAdjustmentApi(object):
 
         Get all existing quickAdjustment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_adjustment_files_with_http_info(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_adjustment_files_with_http_info(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class QuickAdjustmentApi(object):
 
         Get all existing quickAdjustment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_adjustment_tags(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_adjustment_tags(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_quick_adjustment_tags_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_quick_adjustment_tags_with_http_info(quick_adjustment_id, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class QuickAdjustmentApi(object):
 
         Get all existing quickAdjustment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_adjustment_tags_with_http_info(quick_adjustment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_adjustment_tags_with_http_info(quick_adjustment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_adjustment_id: Id of the quickAdjustment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['quick_adjustment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1429,7 +1429,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1440,18 +1440,18 @@ class QuickAdjustmentApi(object):
 
         Updates an existing quickAdjustment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_quick_adjustment(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_quick_adjustment(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickAdjustment body: QuickAdjustment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_quick_adjustment_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_quick_adjustment_with_http_info(body, **kwargs)  # noqa: E501
@@ -1462,11 +1462,11 @@ class QuickAdjustmentApi(object):
 
         Updates an existing quickAdjustment using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_quick_adjustment_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_quick_adjustment_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickAdjustment body: QuickAdjustment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1474,7 +1474,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1528,7 +1528,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1539,18 +1539,18 @@ class QuickAdjustmentApi(object):
 
         Updates an existing quickAdjustment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_quick_adjustment_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_quick_adjustment_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickAdjustment body: QuickAdjustment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_quick_adjustment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_quick_adjustment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1561,11 +1561,11 @@ class QuickAdjustmentApi(object):
 
         Updates an existing quickAdjustment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_quick_adjustment_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_quick_adjustment_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickAdjustment body: QuickAdjustment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1573,7 +1573,7 @@ class QuickAdjustmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1627,7 +1627,7 @@ class QuickAdjustmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/quick_receipt_api.py
+++ b/Infoplus/api/quick_receipt_api.py
@@ -38,18 +38,18 @@ class QuickReceiptApi(object):
 
         Inserts a new quickReceipt using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickReceipt body: QuickReceipt to be inserted. (required)
         :return: QuickReceipt
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_receipt_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_receipt_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class QuickReceiptApi(object):
 
         Inserts a new quickReceipt using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickReceipt body: QuickReceipt to be inserted. (required)
         :return: QuickReceipt
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type='QuickReceipt',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class QuickReceiptApi(object):
 
         Adds an audit to an existing quickReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt_audit(quick_receipt_id, quick_receipt_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt_audit(quick_receipt_id, quick_receipt_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to add an audit to (required)
         :param str quick_receipt_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class QuickReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_receipt_audit_with_http_info(quick_receipt_id, quick_receipt_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_receipt_audit_with_http_info(quick_receipt_id, quick_receipt_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class QuickReceiptApi(object):
 
         Adds an audit to an existing quickReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt_audit_with_http_info(quick_receipt_id, quick_receipt_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt_audit_with_http_info(quick_receipt_id, quick_receipt_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to add an audit to (required)
         :param str quick_receipt_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id', 'quick_receipt_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class QuickReceiptApi(object):
 
         Adds a file to an existing quickReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt_file(quick_receipt_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt_file(quick_receipt_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class QuickReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_receipt_file_with_http_info(quick_receipt_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_receipt_file_with_http_info(quick_receipt_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class QuickReceiptApi(object):
 
         Adds a file to an existing quickReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt_file_with_http_info(quick_receipt_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt_file_with_http_info(quick_receipt_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class QuickReceiptApi(object):
 
         Adds a file to an existing quickReceipt by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt_file_by_url(body, quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt_file_by_url(body, quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int quick_receipt_id: Id of the quickReceipt to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class QuickReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_receipt_file_by_url_with_http_info(body, quick_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_receipt_file_by_url_with_http_info(body, quick_receipt_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class QuickReceiptApi(object):
 
         Adds a file to an existing quickReceipt by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt_file_by_url_with_http_info(body, quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt_file_by_url_with_http_info(body, quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int quick_receipt_id: Id of the quickReceipt to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['body', 'quick_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class QuickReceiptApi(object):
 
         Adds a tag to an existing quickReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt_tag(quick_receipt_id, quick_receipt_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt_tag(quick_receipt_id, quick_receipt_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to add a tag to (required)
         :param str quick_receipt_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class QuickReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_quick_receipt_tag_with_http_info(quick_receipt_id, quick_receipt_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_quick_receipt_tag_with_http_info(quick_receipt_id, quick_receipt_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class QuickReceiptApi(object):
 
         Adds a tag to an existing quickReceipt.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_quick_receipt_tag_with_http_info(quick_receipt_id, quick_receipt_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_quick_receipt_tag_with_http_info(quick_receipt_id, quick_receipt_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to add a tag to (required)
         :param str quick_receipt_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id', 'quick_receipt_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class QuickReceiptApi(object):
 
         Deletes the quickReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_receipt(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_receipt(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_quick_receipt_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_quick_receipt_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class QuickReceiptApi(object):
 
         Deletes the quickReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_receipt_with_http_info(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_receipt_with_http_info(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class QuickReceiptApi(object):
 
         Deletes an existing quickReceipt file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_receipt_file(quick_receipt_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_receipt_file(quick_receipt_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class QuickReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_quick_receipt_file_with_http_info(quick_receipt_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_quick_receipt_file_with_http_info(quick_receipt_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class QuickReceiptApi(object):
 
         Deletes an existing quickReceipt file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_receipt_file_with_http_info(quick_receipt_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_receipt_file_with_http_info(quick_receipt_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class QuickReceiptApi(object):
 
         Deletes an existing quickReceipt tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_receipt_tag(quick_receipt_id, quick_receipt_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_receipt_tag(quick_receipt_id, quick_receipt_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to remove tag from (required)
         :param str quick_receipt_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class QuickReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_quick_receipt_tag_with_http_info(quick_receipt_id, quick_receipt_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_quick_receipt_tag_with_http_info(quick_receipt_id, quick_receipt_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class QuickReceiptApi(object):
 
         Deletes an existing quickReceipt tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_quick_receipt_tag_with_http_info(quick_receipt_id, quick_receipt_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_quick_receipt_tag_with_http_info(quick_receipt_id, quick_receipt_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to remove tag from (required)
         :param str quick_receipt_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id', 'quick_receipt_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class QuickReceiptApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.execute_quick_receipt(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.execute_quick_receipt(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExecuteQuickReceiptInputAPIModel body: Input data for ExecuteQuickReceipt process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.execute_quick_receipt_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.execute_quick_receipt_with_http_info(body, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class QuickReceiptApi(object):
 
           # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.execute_quick_receipt_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.execute_quick_receipt_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ExecuteQuickReceiptInputAPIModel body: Input data for ExecuteQuickReceipt process. (required)
         :return: list[ProcessOutputAPIModel]
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type='list[ProcessOutputAPIModel]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,18 +957,18 @@ class QuickReceiptApi(object):
 
         Returns a duplicated quickReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_quick_receipt_by_id(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_quick_receipt_by_id(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to be duplicated. (required)
         :return: QuickReceipt
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_quick_receipt_by_id_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_quick_receipt_by_id_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
@@ -979,11 +979,11 @@ class QuickReceiptApi(object):
 
         Returns a duplicated quickReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_quick_receipt_by_id_with_http_info(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_quick_receipt_by_id_with_http_info(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to be duplicated. (required)
         :return: QuickReceipt
                  If the method is called asynchronously,
@@ -991,7 +991,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1041,7 +1041,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type='QuickReceipt',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1052,11 +1052,11 @@ class QuickReceiptApi(object):
 
         Returns the list of quickReceipts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_receipt_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_receipt_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1066,7 +1066,7 @@ class QuickReceiptApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_quick_receipt_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_quick_receipt_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -1077,11 +1077,11 @@ class QuickReceiptApi(object):
 
         Returns the list of quickReceipts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_receipt_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_receipt_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -1092,7 +1092,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type='list[QuickReceipt]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class QuickReceiptApi(object):
 
         Returns the quickReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_receipt_by_id(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_receipt_by_id(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to be returned. (required)
         :return: QuickReceipt
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_quick_receipt_by_id_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_quick_receipt_by_id_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class QuickReceiptApi(object):
 
         Returns the quickReceipt identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_receipt_by_id_with_http_info(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_receipt_by_id_with_http_info(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to be returned. (required)
         :return: QuickReceipt
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type='QuickReceipt',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class QuickReceiptApi(object):
 
         Get all existing quickReceipt files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_receipt_files(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_receipt_files(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_quick_receipt_files_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_quick_receipt_files_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class QuickReceiptApi(object):
 
         Get all existing quickReceipt files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_receipt_files_with_http_info(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_receipt_files_with_http_info(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class QuickReceiptApi(object):
 
         Get all existing quickReceipt tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_receipt_tags(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_receipt_tags(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_quick_receipt_tags_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_quick_receipt_tags_with_http_info(quick_receipt_id, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class QuickReceiptApi(object):
 
         Get all existing quickReceipt tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_quick_receipt_tags_with_http_info(quick_receipt_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_quick_receipt_tags_with_http_info(quick_receipt_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int quick_receipt_id: Id of the quickReceipt to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['quick_receipt_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1429,7 +1429,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1440,18 +1440,18 @@ class QuickReceiptApi(object):
 
         Updates an existing quickReceipt using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_quick_receipt(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_quick_receipt(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickReceipt body: QuickReceipt to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_quick_receipt_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_quick_receipt_with_http_info(body, **kwargs)  # noqa: E501
@@ -1462,11 +1462,11 @@ class QuickReceiptApi(object):
 
         Updates an existing quickReceipt using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_quick_receipt_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_quick_receipt_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickReceipt body: QuickReceipt to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1474,7 +1474,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1528,7 +1528,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1539,18 +1539,18 @@ class QuickReceiptApi(object):
 
         Updates an existing quickReceipt custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_quick_receipt_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_quick_receipt_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickReceipt body: QuickReceipt to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_quick_receipt_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_quick_receipt_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1561,11 +1561,11 @@ class QuickReceiptApi(object):
 
         Updates an existing quickReceipt custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_quick_receipt_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_quick_receipt_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param QuickReceipt body: QuickReceipt to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1573,7 +1573,7 @@ class QuickReceiptApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1627,7 +1627,7 @@ class QuickReceiptApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/receiving_process_api.py
+++ b/Infoplus/api/receiving_process_api.py
@@ -38,11 +38,11 @@ class ReceivingProcessApi(object):
 
         Adds an audit to an existing receivingProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_process_audit(receiving_process_id, receiving_process_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_process_audit(receiving_process_id, receiving_process_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to add an audit to (required)
         :param str receiving_process_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ReceivingProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_receiving_process_audit_with_http_info(receiving_process_id, receiving_process_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_receiving_process_audit_with_http_info(receiving_process_id, receiving_process_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ReceivingProcessApi(object):
 
         Adds an audit to an existing receivingProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_process_audit_with_http_info(receiving_process_id, receiving_process_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_process_audit_with_http_info(receiving_process_id, receiving_process_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to add an audit to (required)
         :param str receiving_process_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['receiving_process_id', 'receiving_process_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ReceivingProcessApi(object):
 
         Adds a file to an existing receivingProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_process_file(receiving_process_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_process_file(receiving_process_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ReceivingProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_receiving_process_file_with_http_info(receiving_process_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_receiving_process_file_with_http_info(receiving_process_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ReceivingProcessApi(object):
 
         Adds a file to an existing receivingProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_process_file_with_http_info(receiving_process_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_process_file_with_http_info(receiving_process_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['receiving_process_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ReceivingProcessApi(object):
 
         Adds a file to an existing receivingProcess by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_process_file_by_url(body, receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_process_file_by_url(body, receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int receiving_process_id: Id of the receivingProcess to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ReceivingProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_receiving_process_file_by_url_with_http_info(body, receiving_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_receiving_process_file_by_url_with_http_info(body, receiving_process_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ReceivingProcessApi(object):
 
         Adds a file to an existing receivingProcess by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_process_file_by_url_with_http_info(body, receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_process_file_by_url_with_http_info(body, receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int receiving_process_id: Id of the receivingProcess to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['body', 'receiving_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ReceivingProcessApi(object):
 
         Adds a tag to an existing receivingProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_process_tag(receiving_process_id, receiving_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_process_tag(receiving_process_id, receiving_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to add a tag to (required)
         :param str receiving_process_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ReceivingProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_receiving_process_tag_with_http_info(receiving_process_id, receiving_process_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_receiving_process_tag_with_http_info(receiving_process_id, receiving_process_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ReceivingProcessApi(object):
 
         Adds a tag to an existing receivingProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_process_tag_with_http_info(receiving_process_id, receiving_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_process_tag_with_http_info(receiving_process_id, receiving_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to add a tag to (required)
         :param str receiving_process_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['receiving_process_id', 'receiving_process_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class ReceivingProcessApi(object):
 
         Deletes an existing receivingProcess file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_process_file(receiving_process_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_process_file(receiving_process_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class ReceivingProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_receiving_process_file_with_http_info(receiving_process_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_receiving_process_file_with_http_info(receiving_process_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class ReceivingProcessApi(object):
 
         Deletes an existing receivingProcess file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_process_file_with_http_info(receiving_process_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_process_file_with_http_info(receiving_process_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['receiving_process_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class ReceivingProcessApi(object):
 
         Deletes an existing receivingProcess tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_process_tag(receiving_process_id, receiving_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_process_tag(receiving_process_id, receiving_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to remove tag from (required)
         :param str receiving_process_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class ReceivingProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_receiving_process_tag_with_http_info(receiving_process_id, receiving_process_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_receiving_process_tag_with_http_info(receiving_process_id, receiving_process_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class ReceivingProcessApi(object):
 
         Deletes an existing receivingProcess tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_process_tag_with_http_info(receiving_process_id, receiving_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_process_tag_with_http_info(receiving_process_id, receiving_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to remove tag from (required)
         :param str receiving_process_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['receiving_process_id', 'receiving_process_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class ReceivingProcessApi(object):
 
         Returns a duplicated receivingProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_receiving_process_by_id(receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_receiving_process_by_id(receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to be duplicated. (required)
         :return: ReceivingProcess
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_receiving_process_by_id_with_http_info(receiving_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_receiving_process_by_id_with_http_info(receiving_process_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class ReceivingProcessApi(object):
 
         Returns a duplicated receivingProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_receiving_process_by_id_with_http_info(receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_receiving_process_by_id_with_http_info(receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to be duplicated. (required)
         :return: ReceivingProcess
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['receiving_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type='ReceivingProcess',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class ReceivingProcessApi(object):
 
         Returns the list of receivingProcesses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_process_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_process_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class ReceivingProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_receiving_process_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_receiving_process_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class ReceivingProcessApi(object):
 
         Returns the list of receivingProcesses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_process_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_process_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type='list[ReceivingProcess]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class ReceivingProcessApi(object):
 
         Returns the receivingProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_process_by_id(receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_process_by_id(receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to be returned. (required)
         :return: ReceivingProcess
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_receiving_process_by_id_with_http_info(receiving_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_receiving_process_by_id_with_http_info(receiving_process_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class ReceivingProcessApi(object):
 
         Returns the receivingProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_process_by_id_with_http_info(receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_process_by_id_with_http_info(receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to be returned. (required)
         :return: ReceivingProcess
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['receiving_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type='ReceivingProcess',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ReceivingProcessApi(object):
 
         Get all existing receivingProcess files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_process_files(receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_process_files(receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_receiving_process_files_with_http_info(receiving_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_receiving_process_files_with_http_info(receiving_process_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ReceivingProcessApi(object):
 
         Get all existing receivingProcess files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_process_files_with_http_info(receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_process_files_with_http_info(receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['receiving_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ReceivingProcessApi(object):
 
         Get all existing receivingProcess tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_process_tags(receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_process_tags(receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_receiving_process_tags_with_http_info(receiving_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_receiving_process_tags_with_http_info(receiving_process_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ReceivingProcessApi(object):
 
         Get all existing receivingProcess tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_process_tags_with_http_info(receiving_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_process_tags_with_http_info(receiving_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_process_id: Id of the receivingProcess to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['receiving_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class ReceivingProcessApi(object):
 
         Updates an existing receivingProcess custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_receiving_process_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_receiving_process_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReceivingProcess body: ReceivingProcess to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_receiving_process_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_receiving_process_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class ReceivingProcessApi(object):
 
         Updates an existing receivingProcess custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_receiving_process_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_receiving_process_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReceivingProcess body: ReceivingProcess to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class ReceivingProcessApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ReceivingProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/receiving_worksheet_api.py
+++ b/Infoplus/api/receiving_worksheet_api.py
@@ -38,18 +38,18 @@ class ReceivingWorksheetApi(object):
 
         Inserts a new receivingWorksheet using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReceivingWorksheet body: ReceivingWorksheet to be inserted. (required)
         :return: ReceivingWorksheet
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_receiving_worksheet_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_receiving_worksheet_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ReceivingWorksheetApi(object):
 
         Inserts a new receivingWorksheet using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReceivingWorksheet body: ReceivingWorksheet to be inserted. (required)
         :return: ReceivingWorksheet
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type='ReceivingWorksheet',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ReceivingWorksheetApi(object):
 
         Adds an audit to an existing receivingWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet_audit(receiving_worksheet_id, receiving_worksheet_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet_audit(receiving_worksheet_id, receiving_worksheet_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to add an audit to (required)
         :param str receiving_worksheet_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ReceivingWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_receiving_worksheet_audit_with_http_info(receiving_worksheet_id, receiving_worksheet_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_receiving_worksheet_audit_with_http_info(receiving_worksheet_id, receiving_worksheet_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ReceivingWorksheetApi(object):
 
         Adds an audit to an existing receivingWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet_audit_with_http_info(receiving_worksheet_id, receiving_worksheet_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet_audit_with_http_info(receiving_worksheet_id, receiving_worksheet_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to add an audit to (required)
         :param str receiving_worksheet_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id', 'receiving_worksheet_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ReceivingWorksheetApi(object):
 
         Adds a file to an existing receivingWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet_file(receiving_worksheet_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet_file(receiving_worksheet_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ReceivingWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_receiving_worksheet_file_with_http_info(receiving_worksheet_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_receiving_worksheet_file_with_http_info(receiving_worksheet_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ReceivingWorksheetApi(object):
 
         Adds a file to an existing receivingWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet_file_with_http_info(receiving_worksheet_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet_file_with_http_info(receiving_worksheet_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ReceivingWorksheetApi(object):
 
         Adds a file to an existing receivingWorksheet by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet_file_by_url(body, receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet_file_by_url(body, receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int receiving_worksheet_id: Id of the receivingWorksheet to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ReceivingWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_receiving_worksheet_file_by_url_with_http_info(body, receiving_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_receiving_worksheet_file_by_url_with_http_info(body, receiving_worksheet_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ReceivingWorksheetApi(object):
 
         Adds a file to an existing receivingWorksheet by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet_file_by_url_with_http_info(body, receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet_file_by_url_with_http_info(body, receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int receiving_worksheet_id: Id of the receivingWorksheet to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['body', 'receiving_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ReceivingWorksheetApi(object):
 
         Adds a tag to an existing receivingWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet_tag(receiving_worksheet_id, receiving_worksheet_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet_tag(receiving_worksheet_id, receiving_worksheet_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to add a tag to (required)
         :param str receiving_worksheet_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ReceivingWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_receiving_worksheet_tag_with_http_info(receiving_worksheet_id, receiving_worksheet_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_receiving_worksheet_tag_with_http_info(receiving_worksheet_id, receiving_worksheet_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ReceivingWorksheetApi(object):
 
         Adds a tag to an existing receivingWorksheet.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_receiving_worksheet_tag_with_http_info(receiving_worksheet_id, receiving_worksheet_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_receiving_worksheet_tag_with_http_info(receiving_worksheet_id, receiving_worksheet_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to add a tag to (required)
         :param str receiving_worksheet_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id', 'receiving_worksheet_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ReceivingWorksheetApi(object):
 
         Deletes the receivingWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_worksheet(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_worksheet(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_receiving_worksheet_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_receiving_worksheet_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ReceivingWorksheetApi(object):
 
         Deletes the receivingWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_worksheet_with_http_info(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_worksheet_with_http_info(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ReceivingWorksheetApi(object):
 
         Deletes an existing receivingWorksheet file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_worksheet_file(receiving_worksheet_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_worksheet_file(receiving_worksheet_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ReceivingWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_receiving_worksheet_file_with_http_info(receiving_worksheet_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_receiving_worksheet_file_with_http_info(receiving_worksheet_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ReceivingWorksheetApi(object):
 
         Deletes an existing receivingWorksheet file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_worksheet_file_with_http_info(receiving_worksheet_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_worksheet_file_with_http_info(receiving_worksheet_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ReceivingWorksheetApi(object):
 
         Deletes an existing receivingWorksheet tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_worksheet_tag(receiving_worksheet_id, receiving_worksheet_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_worksheet_tag(receiving_worksheet_id, receiving_worksheet_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to remove tag from (required)
         :param str receiving_worksheet_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ReceivingWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_receiving_worksheet_tag_with_http_info(receiving_worksheet_id, receiving_worksheet_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_receiving_worksheet_tag_with_http_info(receiving_worksheet_id, receiving_worksheet_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ReceivingWorksheetApi(object):
 
         Deletes an existing receivingWorksheet tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_receiving_worksheet_tag_with_http_info(receiving_worksheet_id, receiving_worksheet_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_receiving_worksheet_tag_with_http_info(receiving_worksheet_id, receiving_worksheet_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to remove tag from (required)
         :param str receiving_worksheet_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id', 'receiving_worksheet_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ReceivingWorksheetApi(object):
 
         Returns a duplicated receivingWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_receiving_worksheet_by_id(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_receiving_worksheet_by_id(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to be duplicated. (required)
         :return: ReceivingWorksheet
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_receiving_worksheet_by_id_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_receiving_worksheet_by_id_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ReceivingWorksheetApi(object):
 
         Returns a duplicated receivingWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_receiving_worksheet_by_id_with_http_info(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_receiving_worksheet_by_id_with_http_info(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to be duplicated. (required)
         :return: ReceivingWorksheet
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type='ReceivingWorksheet',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ReceivingWorksheetApi(object):
 
         Returns the list of receivingWorksheets that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_worksheet_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_worksheet_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ReceivingWorksheetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_receiving_worksheet_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_receiving_worksheet_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ReceivingWorksheetApi(object):
 
         Returns the list of receivingWorksheets that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_worksheet_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_worksheet_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type='list[ReceivingWorksheet]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ReceivingWorksheetApi(object):
 
         Returns the receivingWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_worksheet_by_id(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_worksheet_by_id(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to be returned. (required)
         :return: ReceivingWorksheet
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_receiving_worksheet_by_id_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_receiving_worksheet_by_id_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ReceivingWorksheetApi(object):
 
         Returns the receivingWorksheet identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_worksheet_by_id_with_http_info(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_worksheet_by_id_with_http_info(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to be returned. (required)
         :return: ReceivingWorksheet
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type='ReceivingWorksheet',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ReceivingWorksheetApi(object):
 
         Get all existing receivingWorksheet files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_worksheet_files(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_worksheet_files(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_receiving_worksheet_files_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_receiving_worksheet_files_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ReceivingWorksheetApi(object):
 
         Get all existing receivingWorksheet files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_worksheet_files_with_http_info(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_worksheet_files_with_http_info(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ReceivingWorksheetApi(object):
 
         Get all existing receivingWorksheet tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_worksheet_tags(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_worksheet_tags(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_receiving_worksheet_tags_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_receiving_worksheet_tags_with_http_info(receiving_worksheet_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ReceivingWorksheetApi(object):
 
         Get all existing receivingWorksheet tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_receiving_worksheet_tags_with_http_info(receiving_worksheet_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_receiving_worksheet_tags_with_http_info(receiving_worksheet_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int receiving_worksheet_id: Id of the receivingWorksheet to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['receiving_worksheet_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ReceivingWorksheetApi(object):
 
         Updates an existing receivingWorksheet using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_receiving_worksheet(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_receiving_worksheet(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReceivingWorksheet body: ReceivingWorksheet to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_receiving_worksheet_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_receiving_worksheet_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ReceivingWorksheetApi(object):
 
         Updates an existing receivingWorksheet using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_receiving_worksheet_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_receiving_worksheet_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReceivingWorksheet body: ReceivingWorksheet to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class ReceivingWorksheetApi(object):
 
         Updates an existing receivingWorksheet custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_receiving_worksheet_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_receiving_worksheet_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReceivingWorksheet body: ReceivingWorksheet to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_receiving_worksheet_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_receiving_worksheet_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class ReceivingWorksheetApi(object):
 
         Updates an existing receivingWorksheet custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_receiving_worksheet_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_receiving_worksheet_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReceivingWorksheet body: ReceivingWorksheet to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class ReceivingWorksheetApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class ReceivingWorksheetApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/replenishment_api.py
+++ b/Infoplus/api/replenishment_api.py
@@ -38,11 +38,11 @@ class ReplenishmentApi(object):
 
         Adds an audit to an existing replenishment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_audit(replenishment_id, replenishment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_audit(replenishment_id, replenishment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to add an audit to (required)
         :param str replenishment_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ReplenishmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_audit_with_http_info(replenishment_id, replenishment_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_audit_with_http_info(replenishment_id, replenishment_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ReplenishmentApi(object):
 
         Adds an audit to an existing replenishment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_audit_with_http_info(replenishment_id, replenishment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_audit_with_http_info(replenishment_id, replenishment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to add an audit to (required)
         :param str replenishment_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['replenishment_id', 'replenishment_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ReplenishmentApi(object):
 
         Adds a file to an existing replenishment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_file(replenishment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_file(replenishment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ReplenishmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_file_with_http_info(replenishment_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_file_with_http_info(replenishment_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ReplenishmentApi(object):
 
         Adds a file to an existing replenishment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_file_with_http_info(replenishment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_file_with_http_info(replenishment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['replenishment_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ReplenishmentApi(object):
 
         Adds a file to an existing replenishment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_file_by_url(body, replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_file_by_url(body, replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int replenishment_id: Id of the replenishment to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ReplenishmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_file_by_url_with_http_info(body, replenishment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_file_by_url_with_http_info(body, replenishment_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ReplenishmentApi(object):
 
         Adds a file to an existing replenishment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_file_by_url_with_http_info(body, replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_file_by_url_with_http_info(body, replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int replenishment_id: Id of the replenishment to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['body', 'replenishment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ReplenishmentApi(object):
 
         Adds a tag to an existing replenishment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_tag(replenishment_id, replenishment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_tag(replenishment_id, replenishment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to add a tag to (required)
         :param str replenishment_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ReplenishmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_tag_with_http_info(replenishment_id, replenishment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_tag_with_http_info(replenishment_id, replenishment_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ReplenishmentApi(object):
 
         Adds a tag to an existing replenishment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_tag_with_http_info(replenishment_id, replenishment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_tag_with_http_info(replenishment_id, replenishment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to add a tag to (required)
         :param str replenishment_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['replenishment_id', 'replenishment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class ReplenishmentApi(object):
 
         Deletes an existing replenishment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_file(replenishment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_file(replenishment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class ReplenishmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_replenishment_file_with_http_info(replenishment_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_replenishment_file_with_http_info(replenishment_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class ReplenishmentApi(object):
 
         Deletes an existing replenishment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_file_with_http_info(replenishment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_file_with_http_info(replenishment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['replenishment_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class ReplenishmentApi(object):
 
         Deletes an existing replenishment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_tag(replenishment_id, replenishment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_tag(replenishment_id, replenishment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to remove tag from (required)
         :param str replenishment_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class ReplenishmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_replenishment_tag_with_http_info(replenishment_id, replenishment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_replenishment_tag_with_http_info(replenishment_id, replenishment_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class ReplenishmentApi(object):
 
         Deletes an existing replenishment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_tag_with_http_info(replenishment_id, replenishment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_tag_with_http_info(replenishment_id, replenishment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to remove tag from (required)
         :param str replenishment_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['replenishment_id', 'replenishment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class ReplenishmentApi(object):
 
         Returns a duplicated replenishment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_replenishment_by_id(replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_replenishment_by_id(replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to be duplicated. (required)
         :return: Replenishment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_replenishment_by_id_with_http_info(replenishment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_replenishment_by_id_with_http_info(replenishment_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class ReplenishmentApi(object):
 
         Returns a duplicated replenishment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_replenishment_by_id_with_http_info(replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_replenishment_by_id_with_http_info(replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to be duplicated. (required)
         :return: Replenishment
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['replenishment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type='Replenishment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class ReplenishmentApi(object):
 
         Returns the list of replenishments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class ReplenishmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class ReplenishmentApi(object):
 
         Returns the list of replenishments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type='list[Replenishment]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class ReplenishmentApi(object):
 
         Returns the replenishment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_by_id(replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_by_id(replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to be returned. (required)
         :return: Replenishment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_by_id_with_http_info(replenishment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_by_id_with_http_info(replenishment_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class ReplenishmentApi(object):
 
         Returns the replenishment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_by_id_with_http_info(replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_by_id_with_http_info(replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to be returned. (required)
         :return: Replenishment
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['replenishment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type='Replenishment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ReplenishmentApi(object):
 
         Get all existing replenishment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_files(replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_files(replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_files_with_http_info(replenishment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_files_with_http_info(replenishment_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ReplenishmentApi(object):
 
         Get all existing replenishment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_files_with_http_info(replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_files_with_http_info(replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['replenishment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ReplenishmentApi(object):
 
         Get all existing replenishment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_tags(replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_tags(replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_tags_with_http_info(replenishment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_tags_with_http_info(replenishment_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ReplenishmentApi(object):
 
         Get all existing replenishment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_tags_with_http_info(replenishment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_tags_with_http_info(replenishment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_id: Id of the replenishment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['replenishment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class ReplenishmentApi(object):
 
         Updates an existing replenishment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_replenishment_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_replenishment_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Replenishment body: Replenishment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_replenishment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_replenishment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class ReplenishmentApi(object):
 
         Updates an existing replenishment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_replenishment_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_replenishment_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Replenishment body: Replenishment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class ReplenishmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ReplenishmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/replenishment_plan_api.py
+++ b/Infoplus/api/replenishment_plan_api.py
@@ -38,18 +38,18 @@ class ReplenishmentPlanApi(object):
 
         Inserts a new replenishmentPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReplenishmentPlan body: ReplenishmentPlan to be inserted. (required)
         :return: ReplenishmentPlan
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_plan_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_plan_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ReplenishmentPlanApi(object):
 
         Inserts a new replenishmentPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReplenishmentPlan body: ReplenishmentPlan to be inserted. (required)
         :return: ReplenishmentPlan
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type='ReplenishmentPlan',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ReplenishmentPlanApi(object):
 
         Adds an audit to an existing replenishmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan_audit(replenishment_plan_id, replenishment_plan_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan_audit(replenishment_plan_id, replenishment_plan_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to add an audit to (required)
         :param str replenishment_plan_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ReplenishmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_plan_audit_with_http_info(replenishment_plan_id, replenishment_plan_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_plan_audit_with_http_info(replenishment_plan_id, replenishment_plan_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ReplenishmentPlanApi(object):
 
         Adds an audit to an existing replenishmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan_audit_with_http_info(replenishment_plan_id, replenishment_plan_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan_audit_with_http_info(replenishment_plan_id, replenishment_plan_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to add an audit to (required)
         :param str replenishment_plan_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id', 'replenishment_plan_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ReplenishmentPlanApi(object):
 
         Adds a file to an existing replenishmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan_file(replenishment_plan_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan_file(replenishment_plan_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ReplenishmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_plan_file_with_http_info(replenishment_plan_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_plan_file_with_http_info(replenishment_plan_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ReplenishmentPlanApi(object):
 
         Adds a file to an existing replenishmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan_file_with_http_info(replenishment_plan_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan_file_with_http_info(replenishment_plan_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ReplenishmentPlanApi(object):
 
         Adds a file to an existing replenishmentPlan by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan_file_by_url(body, replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan_file_by_url(body, replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int replenishment_plan_id: Id of the replenishmentPlan to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ReplenishmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_plan_file_by_url_with_http_info(body, replenishment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_plan_file_by_url_with_http_info(body, replenishment_plan_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ReplenishmentPlanApi(object):
 
         Adds a file to an existing replenishmentPlan by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan_file_by_url_with_http_info(body, replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan_file_by_url_with_http_info(body, replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int replenishment_plan_id: Id of the replenishmentPlan to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['body', 'replenishment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ReplenishmentPlanApi(object):
 
         Adds a tag to an existing replenishmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan_tag(replenishment_plan_id, replenishment_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan_tag(replenishment_plan_id, replenishment_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to add a tag to (required)
         :param str replenishment_plan_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ReplenishmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_plan_tag_with_http_info(replenishment_plan_id, replenishment_plan_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_plan_tag_with_http_info(replenishment_plan_id, replenishment_plan_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ReplenishmentPlanApi(object):
 
         Adds a tag to an existing replenishmentPlan.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_plan_tag_with_http_info(replenishment_plan_id, replenishment_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_plan_tag_with_http_info(replenishment_plan_id, replenishment_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to add a tag to (required)
         :param str replenishment_plan_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id', 'replenishment_plan_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ReplenishmentPlanApi(object):
 
         Deletes the replenishmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_plan(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_plan(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_replenishment_plan_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_replenishment_plan_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ReplenishmentPlanApi(object):
 
         Deletes the replenishmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_plan_with_http_info(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_plan_with_http_info(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ReplenishmentPlanApi(object):
 
         Deletes an existing replenishmentPlan file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_plan_file(replenishment_plan_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_plan_file(replenishment_plan_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ReplenishmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_replenishment_plan_file_with_http_info(replenishment_plan_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_replenishment_plan_file_with_http_info(replenishment_plan_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ReplenishmentPlanApi(object):
 
         Deletes an existing replenishmentPlan file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_plan_file_with_http_info(replenishment_plan_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_plan_file_with_http_info(replenishment_plan_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ReplenishmentPlanApi(object):
 
         Deletes an existing replenishmentPlan tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_plan_tag(replenishment_plan_id, replenishment_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_plan_tag(replenishment_plan_id, replenishment_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to remove tag from (required)
         :param str replenishment_plan_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ReplenishmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_replenishment_plan_tag_with_http_info(replenishment_plan_id, replenishment_plan_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_replenishment_plan_tag_with_http_info(replenishment_plan_id, replenishment_plan_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ReplenishmentPlanApi(object):
 
         Deletes an existing replenishmentPlan tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_plan_tag_with_http_info(replenishment_plan_id, replenishment_plan_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_plan_tag_with_http_info(replenishment_plan_id, replenishment_plan_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to remove tag from (required)
         :param str replenishment_plan_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id', 'replenishment_plan_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ReplenishmentPlanApi(object):
 
         Returns a duplicated replenishmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_replenishment_plan_by_id(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_replenishment_plan_by_id(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to be duplicated. (required)
         :return: ReplenishmentPlan
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_replenishment_plan_by_id_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_replenishment_plan_by_id_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ReplenishmentPlanApi(object):
 
         Returns a duplicated replenishmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_replenishment_plan_by_id_with_http_info(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_replenishment_plan_by_id_with_http_info(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to be duplicated. (required)
         :return: ReplenishmentPlan
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type='ReplenishmentPlan',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ReplenishmentPlanApi(object):
 
         Returns the list of replenishmentPlans that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_plan_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_plan_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ReplenishmentPlanApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_plan_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_plan_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ReplenishmentPlanApi(object):
 
         Returns the list of replenishmentPlans that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_plan_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_plan_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type='list[ReplenishmentPlan]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ReplenishmentPlanApi(object):
 
         Returns the replenishmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_plan_by_id(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_plan_by_id(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to be returned. (required)
         :return: ReplenishmentPlan
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_plan_by_id_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_plan_by_id_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ReplenishmentPlanApi(object):
 
         Returns the replenishmentPlan identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_plan_by_id_with_http_info(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_plan_by_id_with_http_info(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to be returned. (required)
         :return: ReplenishmentPlan
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type='ReplenishmentPlan',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ReplenishmentPlanApi(object):
 
         Get all existing replenishmentPlan files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_plan_files(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_plan_files(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_plan_files_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_plan_files_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ReplenishmentPlanApi(object):
 
         Get all existing replenishmentPlan files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_plan_files_with_http_info(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_plan_files_with_http_info(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ReplenishmentPlanApi(object):
 
         Get all existing replenishmentPlan tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_plan_tags(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_plan_tags(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_plan_tags_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_plan_tags_with_http_info(replenishment_plan_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ReplenishmentPlanApi(object):
 
         Get all existing replenishmentPlan tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_plan_tags_with_http_info(replenishment_plan_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_plan_tags_with_http_info(replenishment_plan_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_plan_id: Id of the replenishmentPlan to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['replenishment_plan_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ReplenishmentPlanApi(object):
 
         Updates an existing replenishmentPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_replenishment_plan(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_replenishment_plan(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReplenishmentPlan body: ReplenishmentPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_replenishment_plan_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_replenishment_plan_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ReplenishmentPlanApi(object):
 
         Updates an existing replenishmentPlan using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_replenishment_plan_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_replenishment_plan_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReplenishmentPlan body: ReplenishmentPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class ReplenishmentPlanApi(object):
 
         Updates an existing replenishmentPlan custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_replenishment_plan_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_replenishment_plan_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReplenishmentPlan body: ReplenishmentPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_replenishment_plan_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_replenishment_plan_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class ReplenishmentPlanApi(object):
 
         Updates an existing replenishmentPlan custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_replenishment_plan_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_replenishment_plan_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReplenishmentPlan body: ReplenishmentPlan to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class ReplenishmentPlanApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class ReplenishmentPlanApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/replenishment_process_api.py
+++ b/Infoplus/api/replenishment_process_api.py
@@ -38,11 +38,11 @@ class ReplenishmentProcessApi(object):
 
         Adds an audit to an existing replenishmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_process_audit(replenishment_process_id, replenishment_process_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_process_audit(replenishment_process_id, replenishment_process_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to add an audit to (required)
         :param str replenishment_process_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ReplenishmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_process_audit_with_http_info(replenishment_process_id, replenishment_process_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_process_audit_with_http_info(replenishment_process_id, replenishment_process_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ReplenishmentProcessApi(object):
 
         Adds an audit to an existing replenishmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_process_audit_with_http_info(replenishment_process_id, replenishment_process_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_process_audit_with_http_info(replenishment_process_id, replenishment_process_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to add an audit to (required)
         :param str replenishment_process_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['replenishment_process_id', 'replenishment_process_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ReplenishmentProcessApi(object):
 
         Adds a file to an existing replenishmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_process_file(replenishment_process_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_process_file(replenishment_process_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ReplenishmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_process_file_with_http_info(replenishment_process_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_process_file_with_http_info(replenishment_process_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ReplenishmentProcessApi(object):
 
         Adds a file to an existing replenishmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_process_file_with_http_info(replenishment_process_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_process_file_with_http_info(replenishment_process_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['replenishment_process_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ReplenishmentProcessApi(object):
 
         Adds a file to an existing replenishmentProcess by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_process_file_by_url(body, replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_process_file_by_url(body, replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int replenishment_process_id: Id of the replenishmentProcess to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ReplenishmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_process_file_by_url_with_http_info(body, replenishment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_process_file_by_url_with_http_info(body, replenishment_process_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ReplenishmentProcessApi(object):
 
         Adds a file to an existing replenishmentProcess by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_process_file_by_url_with_http_info(body, replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_process_file_by_url_with_http_info(body, replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int replenishment_process_id: Id of the replenishmentProcess to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['body', 'replenishment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ReplenishmentProcessApi(object):
 
         Adds a tag to an existing replenishmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_process_tag(replenishment_process_id, replenishment_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_process_tag(replenishment_process_id, replenishment_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to add a tag to (required)
         :param str replenishment_process_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ReplenishmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_replenishment_process_tag_with_http_info(replenishment_process_id, replenishment_process_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_replenishment_process_tag_with_http_info(replenishment_process_id, replenishment_process_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ReplenishmentProcessApi(object):
 
         Adds a tag to an existing replenishmentProcess.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_replenishment_process_tag_with_http_info(replenishment_process_id, replenishment_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_replenishment_process_tag_with_http_info(replenishment_process_id, replenishment_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to add a tag to (required)
         :param str replenishment_process_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['replenishment_process_id', 'replenishment_process_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class ReplenishmentProcessApi(object):
 
         Deletes an existing replenishmentProcess file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_process_file(replenishment_process_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_process_file(replenishment_process_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class ReplenishmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_replenishment_process_file_with_http_info(replenishment_process_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_replenishment_process_file_with_http_info(replenishment_process_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class ReplenishmentProcessApi(object):
 
         Deletes an existing replenishmentProcess file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_process_file_with_http_info(replenishment_process_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_process_file_with_http_info(replenishment_process_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['replenishment_process_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class ReplenishmentProcessApi(object):
 
         Deletes an existing replenishmentProcess tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_process_tag(replenishment_process_id, replenishment_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_process_tag(replenishment_process_id, replenishment_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to remove tag from (required)
         :param str replenishment_process_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class ReplenishmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_replenishment_process_tag_with_http_info(replenishment_process_id, replenishment_process_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_replenishment_process_tag_with_http_info(replenishment_process_id, replenishment_process_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class ReplenishmentProcessApi(object):
 
         Deletes an existing replenishmentProcess tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_replenishment_process_tag_with_http_info(replenishment_process_id, replenishment_process_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_replenishment_process_tag_with_http_info(replenishment_process_id, replenishment_process_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to remove tag from (required)
         :param str replenishment_process_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['replenishment_process_id', 'replenishment_process_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class ReplenishmentProcessApi(object):
 
         Returns a duplicated replenishmentProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_replenishment_process_by_id(replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_replenishment_process_by_id(replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to be duplicated. (required)
         :return: ReplenishmentProcess
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_replenishment_process_by_id_with_http_info(replenishment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_replenishment_process_by_id_with_http_info(replenishment_process_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class ReplenishmentProcessApi(object):
 
         Returns a duplicated replenishmentProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_replenishment_process_by_id_with_http_info(replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_replenishment_process_by_id_with_http_info(replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to be duplicated. (required)
         :return: ReplenishmentProcess
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['replenishment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type='ReplenishmentProcess',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class ReplenishmentProcessApi(object):
 
         Returns the list of replenishmentProcesses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_process_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_process_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class ReplenishmentProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_process_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_process_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class ReplenishmentProcessApi(object):
 
         Returns the list of replenishmentProcesses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_process_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_process_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type='list[ReplenishmentProcess]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class ReplenishmentProcessApi(object):
 
         Returns the replenishmentProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_process_by_id(replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_process_by_id(replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to be returned. (required)
         :return: ReplenishmentProcess
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_process_by_id_with_http_info(replenishment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_process_by_id_with_http_info(replenishment_process_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class ReplenishmentProcessApi(object):
 
         Returns the replenishmentProcess identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_process_by_id_with_http_info(replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_process_by_id_with_http_info(replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to be returned. (required)
         :return: ReplenishmentProcess
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['replenishment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type='ReplenishmentProcess',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ReplenishmentProcessApi(object):
 
         Get all existing replenishmentProcess files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_process_files(replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_process_files(replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_process_files_with_http_info(replenishment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_process_files_with_http_info(replenishment_process_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ReplenishmentProcessApi(object):
 
         Get all existing replenishmentProcess files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_process_files_with_http_info(replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_process_files_with_http_info(replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['replenishment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ReplenishmentProcessApi(object):
 
         Get all existing replenishmentProcess tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_process_tags(replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_process_tags(replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_replenishment_process_tags_with_http_info(replenishment_process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_replenishment_process_tags_with_http_info(replenishment_process_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ReplenishmentProcessApi(object):
 
         Get all existing replenishmentProcess tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_replenishment_process_tags_with_http_info(replenishment_process_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_replenishment_process_tags_with_http_info(replenishment_process_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int replenishment_process_id: Id of the replenishmentProcess to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['replenishment_process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class ReplenishmentProcessApi(object):
 
         Updates an existing replenishmentProcess custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_replenishment_process_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_replenishment_process_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReplenishmentProcess body: ReplenishmentProcess to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_replenishment_process_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_replenishment_process_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class ReplenishmentProcessApi(object):
 
         Updates an existing replenishmentProcess custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_replenishment_process_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_replenishment_process_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReplenishmentProcess body: ReplenishmentProcess to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class ReplenishmentProcessApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ReplenishmentProcessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/report_api.py
+++ b/Infoplus/api/report_api.py
@@ -38,11 +38,11 @@ class ReportApi(object):
 
         Run a specified report  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.run_report(report_id, format, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.run_report(report_id, format, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int report_id: Id of the report to run. (required)
         :param str format: Format of the report. (required)
         :return: None
@@ -50,7 +50,7 @@ class ReportApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.run_report_with_http_info(report_id, format, **kwargs)  # noqa: E501
         else:
             (data) = self.run_report_with_http_info(report_id, format, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ReportApi(object):
 
         Run a specified report  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.run_report_with_http_info(report_id, format, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.run_report_with_http_info(report_id, format, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int report_id: Id of the report to run. (required)
         :param str format: Format of the report. (required)
         :return: None
@@ -74,7 +74,7 @@ class ReportApi(object):
         """
 
         all_params = ['report_id', 'format']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -130,7 +130,7 @@ class ReportApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/return_shipment_api.py
+++ b/Infoplus/api/return_shipment_api.py
@@ -38,11 +38,11 @@ class ReturnShipmentApi(object):
 
         Adds an audit to an existing returnShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_return_shipment_audit(return_shipment_id, return_shipment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_return_shipment_audit(return_shipment_id, return_shipment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to add an audit to (required)
         :param str return_shipment_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ReturnShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_return_shipment_audit_with_http_info(return_shipment_id, return_shipment_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_return_shipment_audit_with_http_info(return_shipment_id, return_shipment_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ReturnShipmentApi(object):
 
         Adds an audit to an existing returnShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_return_shipment_audit_with_http_info(return_shipment_id, return_shipment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_return_shipment_audit_with_http_info(return_shipment_id, return_shipment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to add an audit to (required)
         :param str return_shipment_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['return_shipment_id', 'return_shipment_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ReturnShipmentApi(object):
 
         Adds a file to an existing returnShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_return_shipment_file(return_shipment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_return_shipment_file(return_shipment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ReturnShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_return_shipment_file_with_http_info(return_shipment_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_return_shipment_file_with_http_info(return_shipment_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ReturnShipmentApi(object):
 
         Adds a file to an existing returnShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_return_shipment_file_with_http_info(return_shipment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_return_shipment_file_with_http_info(return_shipment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['return_shipment_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ReturnShipmentApi(object):
 
         Adds a file to an existing returnShipment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_return_shipment_file_by_url(body, return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_return_shipment_file_by_url(body, return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int return_shipment_id: Id of the returnShipment to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ReturnShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_return_shipment_file_by_url_with_http_info(body, return_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_return_shipment_file_by_url_with_http_info(body, return_shipment_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ReturnShipmentApi(object):
 
         Adds a file to an existing returnShipment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_return_shipment_file_by_url_with_http_info(body, return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_return_shipment_file_by_url_with_http_info(body, return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int return_shipment_id: Id of the returnShipment to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['body', 'return_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ReturnShipmentApi(object):
 
         Adds a tag to an existing returnShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_return_shipment_tag(return_shipment_id, return_shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_return_shipment_tag(return_shipment_id, return_shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to add a tag to (required)
         :param str return_shipment_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ReturnShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_return_shipment_tag_with_http_info(return_shipment_id, return_shipment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_return_shipment_tag_with_http_info(return_shipment_id, return_shipment_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ReturnShipmentApi(object):
 
         Adds a tag to an existing returnShipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_return_shipment_tag_with_http_info(return_shipment_id, return_shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_return_shipment_tag_with_http_info(return_shipment_id, return_shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to add a tag to (required)
         :param str return_shipment_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['return_shipment_id', 'return_shipment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class ReturnShipmentApi(object):
 
         Deletes an existing returnShipment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_return_shipment_file(return_shipment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_return_shipment_file(return_shipment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class ReturnShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_return_shipment_file_with_http_info(return_shipment_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_return_shipment_file_with_http_info(return_shipment_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class ReturnShipmentApi(object):
 
         Deletes an existing returnShipment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_return_shipment_file_with_http_info(return_shipment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_return_shipment_file_with_http_info(return_shipment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['return_shipment_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class ReturnShipmentApi(object):
 
         Deletes an existing returnShipment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_return_shipment_tag(return_shipment_id, return_shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_return_shipment_tag(return_shipment_id, return_shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to remove tag from (required)
         :param str return_shipment_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class ReturnShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_return_shipment_tag_with_http_info(return_shipment_id, return_shipment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_return_shipment_tag_with_http_info(return_shipment_id, return_shipment_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class ReturnShipmentApi(object):
 
         Deletes an existing returnShipment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_return_shipment_tag_with_http_info(return_shipment_id, return_shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_return_shipment_tag_with_http_info(return_shipment_id, return_shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to remove tag from (required)
         :param str return_shipment_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['return_shipment_id', 'return_shipment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class ReturnShipmentApi(object):
 
         Returns a duplicated returnShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_return_shipment_by_id(return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_return_shipment_by_id(return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to be duplicated. (required)
         :return: ReturnShipment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_return_shipment_by_id_with_http_info(return_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_return_shipment_by_id_with_http_info(return_shipment_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class ReturnShipmentApi(object):
 
         Returns a duplicated returnShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_return_shipment_by_id_with_http_info(return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_return_shipment_by_id_with_http_info(return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to be duplicated. (required)
         :return: ReturnShipment
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['return_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type='ReturnShipment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class ReturnShipmentApi(object):
 
         Returns the list of returnShipments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_return_shipment_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_return_shipment_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class ReturnShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_return_shipment_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_return_shipment_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class ReturnShipmentApi(object):
 
         Returns the list of returnShipments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_return_shipment_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_return_shipment_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type='list[ReturnShipment]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class ReturnShipmentApi(object):
 
         Returns the returnShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_return_shipment_by_id(return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_return_shipment_by_id(return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to be returned. (required)
         :return: ReturnShipment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_return_shipment_by_id_with_http_info(return_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_return_shipment_by_id_with_http_info(return_shipment_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class ReturnShipmentApi(object):
 
         Returns the returnShipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_return_shipment_by_id_with_http_info(return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_return_shipment_by_id_with_http_info(return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to be returned. (required)
         :return: ReturnShipment
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['return_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type='ReturnShipment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ReturnShipmentApi(object):
 
         Get all existing returnShipment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_return_shipment_files(return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_return_shipment_files(return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_return_shipment_files_with_http_info(return_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_return_shipment_files_with_http_info(return_shipment_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ReturnShipmentApi(object):
 
         Get all existing returnShipment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_return_shipment_files_with_http_info(return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_return_shipment_files_with_http_info(return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['return_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ReturnShipmentApi(object):
 
         Get all existing returnShipment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_return_shipment_tags(return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_return_shipment_tags(return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_return_shipment_tags_with_http_info(return_shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_return_shipment_tags_with_http_info(return_shipment_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ReturnShipmentApi(object):
 
         Get all existing returnShipment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_return_shipment_tags_with_http_info(return_shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_return_shipment_tags_with_http_info(return_shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int return_shipment_id: Id of the returnShipment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['return_shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class ReturnShipmentApi(object):
 
         Updates an existing returnShipment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_return_shipment_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_return_shipment_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReturnShipment body: ReturnShipment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_return_shipment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_return_shipment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class ReturnShipmentApi(object):
 
         Updates an existing returnShipment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_return_shipment_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_return_shipment_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ReturnShipment body: ReturnShipment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class ReturnShipmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ReturnShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/scheduled_plan_log_api.py
+++ b/Infoplus/api/scheduled_plan_log_api.py
@@ -38,11 +38,11 @@ class ScheduledPlanLogApi(object):
 
         Adds an audit to an existing scheduledPlanLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_scheduled_plan_log_audit(scheduled_plan_log_id, scheduled_plan_log_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_scheduled_plan_log_audit(scheduled_plan_log_id, scheduled_plan_log_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to add an audit to (required)
         :param str scheduled_plan_log_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ScheduledPlanLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_scheduled_plan_log_audit_with_http_info(scheduled_plan_log_id, scheduled_plan_log_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_scheduled_plan_log_audit_with_http_info(scheduled_plan_log_id, scheduled_plan_log_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ScheduledPlanLogApi(object):
 
         Adds an audit to an existing scheduledPlanLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_scheduled_plan_log_audit_with_http_info(scheduled_plan_log_id, scheduled_plan_log_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_scheduled_plan_log_audit_with_http_info(scheduled_plan_log_id, scheduled_plan_log_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to add an audit to (required)
         :param str scheduled_plan_log_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['scheduled_plan_log_id', 'scheduled_plan_log_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ScheduledPlanLogApi(object):
 
         Adds a file to an existing scheduledPlanLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_scheduled_plan_log_file(scheduled_plan_log_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_scheduled_plan_log_file(scheduled_plan_log_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ScheduledPlanLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_scheduled_plan_log_file_with_http_info(scheduled_plan_log_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_scheduled_plan_log_file_with_http_info(scheduled_plan_log_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ScheduledPlanLogApi(object):
 
         Adds a file to an existing scheduledPlanLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_scheduled_plan_log_file_with_http_info(scheduled_plan_log_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_scheduled_plan_log_file_with_http_info(scheduled_plan_log_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['scheduled_plan_log_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ScheduledPlanLogApi(object):
 
         Adds a file to an existing scheduledPlanLog by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_scheduled_plan_log_file_by_url(body, scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_scheduled_plan_log_file_by_url(body, scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ScheduledPlanLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_scheduled_plan_log_file_by_url_with_http_info(body, scheduled_plan_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_scheduled_plan_log_file_by_url_with_http_info(body, scheduled_plan_log_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ScheduledPlanLogApi(object):
 
         Adds a file to an existing scheduledPlanLog by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_scheduled_plan_log_file_by_url_with_http_info(body, scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_scheduled_plan_log_file_by_url_with_http_info(body, scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['body', 'scheduled_plan_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ScheduledPlanLogApi(object):
 
         Adds a tag to an existing scheduledPlanLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_scheduled_plan_log_tag(scheduled_plan_log_id, scheduled_plan_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_scheduled_plan_log_tag(scheduled_plan_log_id, scheduled_plan_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to add a tag to (required)
         :param str scheduled_plan_log_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ScheduledPlanLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_scheduled_plan_log_tag_with_http_info(scheduled_plan_log_id, scheduled_plan_log_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_scheduled_plan_log_tag_with_http_info(scheduled_plan_log_id, scheduled_plan_log_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ScheduledPlanLogApi(object):
 
         Adds a tag to an existing scheduledPlanLog.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_scheduled_plan_log_tag_with_http_info(scheduled_plan_log_id, scheduled_plan_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_scheduled_plan_log_tag_with_http_info(scheduled_plan_log_id, scheduled_plan_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to add a tag to (required)
         :param str scheduled_plan_log_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['scheduled_plan_log_id', 'scheduled_plan_log_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class ScheduledPlanLogApi(object):
 
         Deletes an existing scheduledPlanLog file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_scheduled_plan_log_file(scheduled_plan_log_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_scheduled_plan_log_file(scheduled_plan_log_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class ScheduledPlanLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_scheduled_plan_log_file_with_http_info(scheduled_plan_log_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_scheduled_plan_log_file_with_http_info(scheduled_plan_log_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class ScheduledPlanLogApi(object):
 
         Deletes an existing scheduledPlanLog file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_scheduled_plan_log_file_with_http_info(scheduled_plan_log_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_scheduled_plan_log_file_with_http_info(scheduled_plan_log_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['scheduled_plan_log_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class ScheduledPlanLogApi(object):
 
         Deletes an existing scheduledPlanLog tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_scheduled_plan_log_tag(scheduled_plan_log_id, scheduled_plan_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_scheduled_plan_log_tag(scheduled_plan_log_id, scheduled_plan_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to remove tag from (required)
         :param str scheduled_plan_log_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class ScheduledPlanLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_scheduled_plan_log_tag_with_http_info(scheduled_plan_log_id, scheduled_plan_log_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_scheduled_plan_log_tag_with_http_info(scheduled_plan_log_id, scheduled_plan_log_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class ScheduledPlanLogApi(object):
 
         Deletes an existing scheduledPlanLog tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_scheduled_plan_log_tag_with_http_info(scheduled_plan_log_id, scheduled_plan_log_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_scheduled_plan_log_tag_with_http_info(scheduled_plan_log_id, scheduled_plan_log_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to remove tag from (required)
         :param str scheduled_plan_log_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['scheduled_plan_log_id', 'scheduled_plan_log_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class ScheduledPlanLogApi(object):
 
         Returns a duplicated scheduledPlanLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_scheduled_plan_log_by_id(scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_scheduled_plan_log_by_id(scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to be duplicated. (required)
         :return: ScheduledPlanLog
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_scheduled_plan_log_by_id_with_http_info(scheduled_plan_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_scheduled_plan_log_by_id_with_http_info(scheduled_plan_log_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class ScheduledPlanLogApi(object):
 
         Returns a duplicated scheduledPlanLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_scheduled_plan_log_by_id_with_http_info(scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_scheduled_plan_log_by_id_with_http_info(scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to be duplicated. (required)
         :return: ScheduledPlanLog
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['scheduled_plan_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type='ScheduledPlanLog',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class ScheduledPlanLogApi(object):
 
         Returns the list of scheduledPlanLogs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_scheduled_plan_log_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_scheduled_plan_log_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class ScheduledPlanLogApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_scheduled_plan_log_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_scheduled_plan_log_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class ScheduledPlanLogApi(object):
 
         Returns the list of scheduledPlanLogs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_scheduled_plan_log_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_scheduled_plan_log_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type='list[ScheduledPlanLog]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class ScheduledPlanLogApi(object):
 
         Returns the scheduledPlanLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_scheduled_plan_log_by_id(scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_scheduled_plan_log_by_id(scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to be returned. (required)
         :return: ScheduledPlanLog
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_scheduled_plan_log_by_id_with_http_info(scheduled_plan_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_scheduled_plan_log_by_id_with_http_info(scheduled_plan_log_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class ScheduledPlanLogApi(object):
 
         Returns the scheduledPlanLog identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_scheduled_plan_log_by_id_with_http_info(scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_scheduled_plan_log_by_id_with_http_info(scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to be returned. (required)
         :return: ScheduledPlanLog
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['scheduled_plan_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type='ScheduledPlanLog',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ScheduledPlanLogApi(object):
 
         Get all existing scheduledPlanLog files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_scheduled_plan_log_files(scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_scheduled_plan_log_files(scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_scheduled_plan_log_files_with_http_info(scheduled_plan_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_scheduled_plan_log_files_with_http_info(scheduled_plan_log_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ScheduledPlanLogApi(object):
 
         Get all existing scheduledPlanLog files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_scheduled_plan_log_files_with_http_info(scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_scheduled_plan_log_files_with_http_info(scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['scheduled_plan_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ScheduledPlanLogApi(object):
 
         Get all existing scheduledPlanLog tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_scheduled_plan_log_tags(scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_scheduled_plan_log_tags(scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_scheduled_plan_log_tags_with_http_info(scheduled_plan_log_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_scheduled_plan_log_tags_with_http_info(scheduled_plan_log_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ScheduledPlanLogApi(object):
 
         Get all existing scheduledPlanLog tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_scheduled_plan_log_tags_with_http_info(scheduled_plan_log_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_scheduled_plan_log_tags_with_http_info(scheduled_plan_log_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int scheduled_plan_log_id: Id of the scheduledPlanLog to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ScheduledPlanLogApi(object):
         """
 
         all_params = ['scheduled_plan_log_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ScheduledPlanLogApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/service_type_api.py
+++ b/Infoplus/api/service_type_api.py
@@ -38,18 +38,18 @@ class ServiceTypeApi(object):
 
         Returns the serviceType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_service_type_by_id(service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_service_type_by_id(service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str service_type_id: Id of serviceType to be returned. (required)
         :return: ServiceType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_service_type_by_id_with_http_info(service_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_service_type_by_id_with_http_info(service_type_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ServiceTypeApi(object):
 
         Returns the serviceType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_service_type_by_id_with_http_info(service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_service_type_by_id_with_http_info(service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str service_type_id: Id of serviceType to be returned. (required)
         :return: ServiceType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ServiceTypeApi(object):
         """
 
         all_params = ['service_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class ServiceTypeApi(object):
             files=local_var_files,
             response_type='ServiceType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class ServiceTypeApi(object):
 
         Returns the list of serviceTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_service_type_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_service_type_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class ServiceTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_service_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_service_type_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class ServiceTypeApi(object):
 
         Returns the list of serviceTypes that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_service_type_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_service_type_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class ServiceTypeApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class ServiceTypeApi(object):
             files=local_var_files,
             response_type='list[ServiceType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/shipment_api.py
+++ b/Infoplus/api/shipment_api.py
@@ -38,11 +38,11 @@ class ShipmentApi(object):
 
         Adds an audit to an existing shipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shipment_audit(shipment_id, shipment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shipment_audit(shipment_id, shipment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to add an audit to (required)
         :param str shipment_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class ShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_shipment_audit_with_http_info(shipment_id, shipment_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_shipment_audit_with_http_info(shipment_id, shipment_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class ShipmentApi(object):
 
         Adds an audit to an existing shipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shipment_audit_with_http_info(shipment_id, shipment_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shipment_audit_with_http_info(shipment_id, shipment_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to add an audit to (required)
         :param str shipment_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['shipment_id', 'shipment_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class ShipmentApi(object):
 
         Adds a file to an existing shipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shipment_file(shipment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shipment_file(shipment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class ShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_shipment_file_with_http_info(shipment_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_shipment_file_with_http_info(shipment_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class ShipmentApi(object):
 
         Adds a file to an existing shipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shipment_file_with_http_info(shipment_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shipment_file_with_http_info(shipment_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['shipment_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class ShipmentApi(object):
 
         Adds a file to an existing shipment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shipment_file_by_url(body, shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shipment_file_by_url(body, shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int shipment_id: Id of the shipment to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class ShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_shipment_file_by_url_with_http_info(body, shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_shipment_file_by_url_with_http_info(body, shipment_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class ShipmentApi(object):
 
         Adds a file to an existing shipment by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shipment_file_by_url_with_http_info(body, shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shipment_file_by_url_with_http_info(body, shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int shipment_id: Id of the shipment to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['body', 'shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class ShipmentApi(object):
 
         Adds a tag to an existing shipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shipment_tag(shipment_id, shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shipment_tag(shipment_id, shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to add a tag to (required)
         :param str shipment_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class ShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_shipment_tag_with_http_info(shipment_id, shipment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_shipment_tag_with_http_info(shipment_id, shipment_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class ShipmentApi(object):
 
         Adds a tag to an existing shipment.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shipment_tag_with_http_info(shipment_id, shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shipment_tag_with_http_info(shipment_id, shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to add a tag to (required)
         :param str shipment_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['shipment_id', 'shipment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class ShipmentApi(object):
 
         Deletes an existing shipment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shipment_file(shipment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shipment_file(shipment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class ShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_shipment_file_with_http_info(shipment_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_shipment_file_with_http_info(shipment_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class ShipmentApi(object):
 
         Deletes an existing shipment file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shipment_file_with_http_info(shipment_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shipment_file_with_http_info(shipment_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['shipment_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class ShipmentApi(object):
 
         Deletes an existing shipment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shipment_tag(shipment_id, shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shipment_tag(shipment_id, shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to remove tag from (required)
         :param str shipment_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class ShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_shipment_tag_with_http_info(shipment_id, shipment_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_shipment_tag_with_http_info(shipment_id, shipment_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class ShipmentApi(object):
 
         Deletes an existing shipment tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shipment_tag_with_http_info(shipment_id, shipment_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shipment_tag_with_http_info(shipment_id, shipment_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to remove tag from (required)
         :param str shipment_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['shipment_id', 'shipment_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class ShipmentApi(object):
 
         Returns a duplicated shipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_shipment_by_id(shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_shipment_by_id(shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to be duplicated. (required)
         :return: Shipment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_shipment_by_id_with_http_info(shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_shipment_by_id_with_http_info(shipment_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class ShipmentApi(object):
 
         Returns a duplicated shipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_shipment_by_id_with_http_info(shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_shipment_by_id_with_http_info(shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to be duplicated. (required)
         :return: Shipment
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type='Shipment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class ShipmentApi(object):
 
         Returns the list of shipments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shipment_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shipment_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class ShipmentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_shipment_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_shipment_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class ShipmentApi(object):
 
         Returns the list of shipments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shipment_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shipment_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type='list[Shipment]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class ShipmentApi(object):
 
         Returns the shipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shipment_by_id(shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shipment_by_id(shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to be returned. (required)
         :return: Shipment
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_shipment_by_id_with_http_info(shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_shipment_by_id_with_http_info(shipment_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class ShipmentApi(object):
 
         Returns the shipment identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shipment_by_id_with_http_info(shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shipment_by_id_with_http_info(shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to be returned. (required)
         :return: Shipment
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type='Shipment',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class ShipmentApi(object):
 
         Get all existing shipment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shipment_files(shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shipment_files(shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_shipment_files_with_http_info(shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_shipment_files_with_http_info(shipment_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class ShipmentApi(object):
 
         Get all existing shipment files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shipment_files_with_http_info(shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shipment_files_with_http_info(shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class ShipmentApi(object):
 
         Get all existing shipment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shipment_tags(shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shipment_tags(shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_shipment_tags_with_http_info(shipment_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_shipment_tags_with_http_info(shipment_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class ShipmentApi(object):
 
         Get all existing shipment tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shipment_tags_with_http_info(shipment_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shipment_tags_with_http_info(shipment_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shipment_id: Id of the shipment to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['shipment_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class ShipmentApi(object):
 
         Updates an existing shipment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_shipment_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_shipment_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Shipment body: Shipment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_shipment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_shipment_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class ShipmentApi(object):
 
         Updates an existing shipment custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_shipment_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_shipment_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Shipment body: Shipment to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class ShipmentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ShipmentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/shopping_cart_connection_api.py
+++ b/Infoplus/api/shopping_cart_connection_api.py
@@ -38,18 +38,18 @@ class ShoppingCartConnectionApi(object):
 
         Inserts a new shoppingCartConnection using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ShoppingCartConnection body: ShoppingCartConnection to be inserted. (required)
         :return: ShoppingCartConnection
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_shopping_cart_connection_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_shopping_cart_connection_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ShoppingCartConnectionApi(object):
 
         Inserts a new shoppingCartConnection using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ShoppingCartConnection body: ShoppingCartConnection to be inserted. (required)
         :return: ShoppingCartConnection
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type='ShoppingCartConnection',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ShoppingCartConnectionApi(object):
 
         Adds an audit to an existing shoppingCartConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection_audit(shopping_cart_connection_id, shopping_cart_connection_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection_audit(shopping_cart_connection_id, shopping_cart_connection_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to add an audit to (required)
         :param str shopping_cart_connection_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ShoppingCartConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_shopping_cart_connection_audit_with_http_info(shopping_cart_connection_id, shopping_cart_connection_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_shopping_cart_connection_audit_with_http_info(shopping_cart_connection_id, shopping_cart_connection_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ShoppingCartConnectionApi(object):
 
         Adds an audit to an existing shoppingCartConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection_audit_with_http_info(shopping_cart_connection_id, shopping_cart_connection_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection_audit_with_http_info(shopping_cart_connection_id, shopping_cart_connection_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to add an audit to (required)
         :param str shopping_cart_connection_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id', 'shopping_cart_connection_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ShoppingCartConnectionApi(object):
 
         Adds a file to an existing shoppingCartConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection_file(shopping_cart_connection_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection_file(shopping_cart_connection_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ShoppingCartConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_shopping_cart_connection_file_with_http_info(shopping_cart_connection_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_shopping_cart_connection_file_with_http_info(shopping_cart_connection_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ShoppingCartConnectionApi(object):
 
         Adds a file to an existing shoppingCartConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection_file_with_http_info(shopping_cart_connection_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection_file_with_http_info(shopping_cart_connection_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ShoppingCartConnectionApi(object):
 
         Adds a file to an existing shoppingCartConnection by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection_file_by_url(body, shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection_file_by_url(body, shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ShoppingCartConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_shopping_cart_connection_file_by_url_with_http_info(body, shopping_cart_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_shopping_cart_connection_file_by_url_with_http_info(body, shopping_cart_connection_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ShoppingCartConnectionApi(object):
 
         Adds a file to an existing shoppingCartConnection by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection_file_by_url_with_http_info(body, shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection_file_by_url_with_http_info(body, shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['body', 'shopping_cart_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ShoppingCartConnectionApi(object):
 
         Adds a tag to an existing shoppingCartConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection_tag(shopping_cart_connection_id, shopping_cart_connection_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection_tag(shopping_cart_connection_id, shopping_cart_connection_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to add a tag to (required)
         :param str shopping_cart_connection_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ShoppingCartConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_shopping_cart_connection_tag_with_http_info(shopping_cart_connection_id, shopping_cart_connection_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_shopping_cart_connection_tag_with_http_info(shopping_cart_connection_id, shopping_cart_connection_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ShoppingCartConnectionApi(object):
 
         Adds a tag to an existing shoppingCartConnection.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_shopping_cart_connection_tag_with_http_info(shopping_cart_connection_id, shopping_cart_connection_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_shopping_cart_connection_tag_with_http_info(shopping_cart_connection_id, shopping_cart_connection_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to add a tag to (required)
         :param str shopping_cart_connection_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id', 'shopping_cart_connection_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ShoppingCartConnectionApi(object):
 
         Deletes the shoppingCartConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shopping_cart_connection(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shopping_cart_connection(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_shopping_cart_connection_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_shopping_cart_connection_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ShoppingCartConnectionApi(object):
 
         Deletes the shoppingCartConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shopping_cart_connection_with_http_info(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shopping_cart_connection_with_http_info(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ShoppingCartConnectionApi(object):
 
         Deletes an existing shoppingCartConnection file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shopping_cart_connection_file(shopping_cart_connection_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shopping_cart_connection_file(shopping_cart_connection_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ShoppingCartConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_shopping_cart_connection_file_with_http_info(shopping_cart_connection_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_shopping_cart_connection_file_with_http_info(shopping_cart_connection_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ShoppingCartConnectionApi(object):
 
         Deletes an existing shoppingCartConnection file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shopping_cart_connection_file_with_http_info(shopping_cart_connection_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shopping_cart_connection_file_with_http_info(shopping_cart_connection_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ShoppingCartConnectionApi(object):
 
         Deletes an existing shoppingCartConnection tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shopping_cart_connection_tag(shopping_cart_connection_id, shopping_cart_connection_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shopping_cart_connection_tag(shopping_cart_connection_id, shopping_cart_connection_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to remove tag from (required)
         :param str shopping_cart_connection_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ShoppingCartConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_shopping_cart_connection_tag_with_http_info(shopping_cart_connection_id, shopping_cart_connection_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_shopping_cart_connection_tag_with_http_info(shopping_cart_connection_id, shopping_cart_connection_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ShoppingCartConnectionApi(object):
 
         Deletes an existing shoppingCartConnection tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_shopping_cart_connection_tag_with_http_info(shopping_cart_connection_id, shopping_cart_connection_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_shopping_cart_connection_tag_with_http_info(shopping_cart_connection_id, shopping_cart_connection_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to remove tag from (required)
         :param str shopping_cart_connection_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id', 'shopping_cart_connection_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ShoppingCartConnectionApi(object):
 
         Returns a duplicated shoppingCartConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_shopping_cart_connection_by_id(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_shopping_cart_connection_by_id(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to be duplicated. (required)
         :return: ShoppingCartConnection
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_shopping_cart_connection_by_id_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_shopping_cart_connection_by_id_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ShoppingCartConnectionApi(object):
 
         Returns a duplicated shoppingCartConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_shopping_cart_connection_by_id_with_http_info(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_shopping_cart_connection_by_id_with_http_info(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to be duplicated. (required)
         :return: ShoppingCartConnection
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type='ShoppingCartConnection',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ShoppingCartConnectionApi(object):
 
         Returns the list of shoppingCartConnections that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shopping_cart_connection_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shopping_cart_connection_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ShoppingCartConnectionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_shopping_cart_connection_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_shopping_cart_connection_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ShoppingCartConnectionApi(object):
 
         Returns the list of shoppingCartConnections that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shopping_cart_connection_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shopping_cart_connection_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type='list[ShoppingCartConnection]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ShoppingCartConnectionApi(object):
 
         Returns the shoppingCartConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shopping_cart_connection_by_id(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shopping_cart_connection_by_id(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to be returned. (required)
         :return: ShoppingCartConnection
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_shopping_cart_connection_by_id_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_shopping_cart_connection_by_id_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ShoppingCartConnectionApi(object):
 
         Returns the shoppingCartConnection identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shopping_cart_connection_by_id_with_http_info(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shopping_cart_connection_by_id_with_http_info(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to be returned. (required)
         :return: ShoppingCartConnection
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type='ShoppingCartConnection',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ShoppingCartConnectionApi(object):
 
         Get all existing shoppingCartConnection files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shopping_cart_connection_files(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shopping_cart_connection_files(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_shopping_cart_connection_files_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_shopping_cart_connection_files_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ShoppingCartConnectionApi(object):
 
         Get all existing shoppingCartConnection files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shopping_cart_connection_files_with_http_info(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shopping_cart_connection_files_with_http_info(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ShoppingCartConnectionApi(object):
 
         Get all existing shoppingCartConnection tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shopping_cart_connection_tags(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shopping_cart_connection_tags(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_shopping_cart_connection_tags_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_shopping_cart_connection_tags_with_http_info(shopping_cart_connection_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ShoppingCartConnectionApi(object):
 
         Get all existing shoppingCartConnection tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_shopping_cart_connection_tags_with_http_info(shopping_cart_connection_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_shopping_cart_connection_tags_with_http_info(shopping_cart_connection_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int shopping_cart_connection_id: Id of the shoppingCartConnection to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['shopping_cart_connection_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ShoppingCartConnectionApi(object):
 
         Updates an existing shoppingCartConnection using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_shopping_cart_connection(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_shopping_cart_connection(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ShoppingCartConnection body: ShoppingCartConnection to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_shopping_cart_connection_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_shopping_cart_connection_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ShoppingCartConnectionApi(object):
 
         Updates an existing shoppingCartConnection using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_shopping_cart_connection_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_shopping_cart_connection_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ShoppingCartConnection body: ShoppingCartConnection to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class ShoppingCartConnectionApi(object):
 
         Updates an existing shoppingCartConnection custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_shopping_cart_connection_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_shopping_cart_connection_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ShoppingCartConnection body: ShoppingCartConnection to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_shopping_cart_connection_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_shopping_cart_connection_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class ShoppingCartConnectionApi(object):
 
         Updates an existing shoppingCartConnection custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_shopping_cart_connection_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_shopping_cart_connection_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ShoppingCartConnection body: ShoppingCartConnection to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class ShoppingCartConnectionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class ShoppingCartConnectionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/standard_business_days_api.py
+++ b/Infoplus/api/standard_business_days_api.py
@@ -38,18 +38,18 @@ class StandardBusinessDaysApi(object):
 
         Inserts a new standardBusinessDays using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param StandardBusinessDays body: StandardBusinessDays to be inserted. (required)
         :return: StandardBusinessDays
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_standard_business_days_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_standard_business_days_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class StandardBusinessDaysApi(object):
 
         Inserts a new standardBusinessDays using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param StandardBusinessDays body: StandardBusinessDays to be inserted. (required)
         :return: StandardBusinessDays
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type='StandardBusinessDays',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class StandardBusinessDaysApi(object):
 
         Adds an audit to an existing standardBusinessDays.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days_audit(standard_business_days_id, standard_business_days_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days_audit(standard_business_days_id, standard_business_days_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to add an audit to (required)
         :param str standard_business_days_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class StandardBusinessDaysApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_standard_business_days_audit_with_http_info(standard_business_days_id, standard_business_days_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_standard_business_days_audit_with_http_info(standard_business_days_id, standard_business_days_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class StandardBusinessDaysApi(object):
 
         Adds an audit to an existing standardBusinessDays.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days_audit_with_http_info(standard_business_days_id, standard_business_days_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days_audit_with_http_info(standard_business_days_id, standard_business_days_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to add an audit to (required)
         :param str standard_business_days_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id', 'standard_business_days_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class StandardBusinessDaysApi(object):
 
         Adds a file to an existing standardBusinessDays.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days_file(standard_business_days_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days_file(standard_business_days_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class StandardBusinessDaysApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_standard_business_days_file_with_http_info(standard_business_days_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_standard_business_days_file_with_http_info(standard_business_days_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class StandardBusinessDaysApi(object):
 
         Adds a file to an existing standardBusinessDays.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days_file_with_http_info(standard_business_days_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days_file_with_http_info(standard_business_days_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class StandardBusinessDaysApi(object):
 
         Adds a file to an existing standardBusinessDays by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days_file_by_url(body, standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days_file_by_url(body, standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int standard_business_days_id: Id of the standardBusinessDays to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class StandardBusinessDaysApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_standard_business_days_file_by_url_with_http_info(body, standard_business_days_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_standard_business_days_file_by_url_with_http_info(body, standard_business_days_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class StandardBusinessDaysApi(object):
 
         Adds a file to an existing standardBusinessDays by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days_file_by_url_with_http_info(body, standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days_file_by_url_with_http_info(body, standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int standard_business_days_id: Id of the standardBusinessDays to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['body', 'standard_business_days_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class StandardBusinessDaysApi(object):
 
         Adds a tag to an existing standardBusinessDays.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days_tag(standard_business_days_id, standard_business_days_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days_tag(standard_business_days_id, standard_business_days_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to add a tag to (required)
         :param str standard_business_days_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class StandardBusinessDaysApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_standard_business_days_tag_with_http_info(standard_business_days_id, standard_business_days_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_standard_business_days_tag_with_http_info(standard_business_days_id, standard_business_days_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class StandardBusinessDaysApi(object):
 
         Adds a tag to an existing standardBusinessDays.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_standard_business_days_tag_with_http_info(standard_business_days_id, standard_business_days_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_standard_business_days_tag_with_http_info(standard_business_days_id, standard_business_days_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to add a tag to (required)
         :param str standard_business_days_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id', 'standard_business_days_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class StandardBusinessDaysApi(object):
 
         Deletes the standardBusinessDays identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_standard_business_days(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_standard_business_days(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_standard_business_days_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_standard_business_days_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class StandardBusinessDaysApi(object):
 
         Deletes the standardBusinessDays identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_standard_business_days_with_http_info(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_standard_business_days_with_http_info(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class StandardBusinessDaysApi(object):
 
         Deletes an existing standardBusinessDays file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_standard_business_days_file(standard_business_days_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_standard_business_days_file(standard_business_days_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class StandardBusinessDaysApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_standard_business_days_file_with_http_info(standard_business_days_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_standard_business_days_file_with_http_info(standard_business_days_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class StandardBusinessDaysApi(object):
 
         Deletes an existing standardBusinessDays file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_standard_business_days_file_with_http_info(standard_business_days_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_standard_business_days_file_with_http_info(standard_business_days_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class StandardBusinessDaysApi(object):
 
         Deletes an existing standardBusinessDays tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_standard_business_days_tag(standard_business_days_id, standard_business_days_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_standard_business_days_tag(standard_business_days_id, standard_business_days_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to remove tag from (required)
         :param str standard_business_days_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class StandardBusinessDaysApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_standard_business_days_tag_with_http_info(standard_business_days_id, standard_business_days_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_standard_business_days_tag_with_http_info(standard_business_days_id, standard_business_days_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class StandardBusinessDaysApi(object):
 
         Deletes an existing standardBusinessDays tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_standard_business_days_tag_with_http_info(standard_business_days_id, standard_business_days_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_standard_business_days_tag_with_http_info(standard_business_days_id, standard_business_days_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to remove tag from (required)
         :param str standard_business_days_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id', 'standard_business_days_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class StandardBusinessDaysApi(object):
 
         Returns a duplicated standardBusinessDays identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_standard_business_days_by_id(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_standard_business_days_by_id(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to be duplicated. (required)
         :return: StandardBusinessDays
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_standard_business_days_by_id_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_standard_business_days_by_id_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class StandardBusinessDaysApi(object):
 
         Returns a duplicated standardBusinessDays identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_standard_business_days_by_id_with_http_info(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_standard_business_days_by_id_with_http_info(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to be duplicated. (required)
         :return: StandardBusinessDays
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type='StandardBusinessDays',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class StandardBusinessDaysApi(object):
 
         Returns the list of standardBusinessDayses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_standard_business_days_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_standard_business_days_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class StandardBusinessDaysApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_standard_business_days_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_standard_business_days_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class StandardBusinessDaysApi(object):
 
         Returns the list of standardBusinessDayses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_standard_business_days_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_standard_business_days_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type='list[StandardBusinessDays]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class StandardBusinessDaysApi(object):
 
         Returns the standardBusinessDays identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_standard_business_days_by_id(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_standard_business_days_by_id(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to be returned. (required)
         :return: StandardBusinessDays
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_standard_business_days_by_id_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_standard_business_days_by_id_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class StandardBusinessDaysApi(object):
 
         Returns the standardBusinessDays identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_standard_business_days_by_id_with_http_info(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_standard_business_days_by_id_with_http_info(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to be returned. (required)
         :return: StandardBusinessDays
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type='StandardBusinessDays',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class StandardBusinessDaysApi(object):
 
         Get all existing standardBusinessDays files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_standard_business_days_files(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_standard_business_days_files(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_standard_business_days_files_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_standard_business_days_files_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class StandardBusinessDaysApi(object):
 
         Get all existing standardBusinessDays files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_standard_business_days_files_with_http_info(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_standard_business_days_files_with_http_info(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class StandardBusinessDaysApi(object):
 
         Get all existing standardBusinessDays tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_standard_business_days_tags(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_standard_business_days_tags(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_standard_business_days_tags_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_standard_business_days_tags_with_http_info(standard_business_days_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class StandardBusinessDaysApi(object):
 
         Get all existing standardBusinessDays tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_standard_business_days_tags_with_http_info(standard_business_days_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_standard_business_days_tags_with_http_info(standard_business_days_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int standard_business_days_id: Id of the standardBusinessDays to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['standard_business_days_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class StandardBusinessDaysApi(object):
 
         Updates an existing standardBusinessDays using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_standard_business_days(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_standard_business_days(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param StandardBusinessDays body: StandardBusinessDays to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_standard_business_days_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_standard_business_days_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class StandardBusinessDaysApi(object):
 
         Updates an existing standardBusinessDays using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_standard_business_days_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_standard_business_days_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param StandardBusinessDays body: StandardBusinessDays to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class StandardBusinessDaysApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class StandardBusinessDaysApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/substitution_api.py
+++ b/Infoplus/api/substitution_api.py
@@ -38,18 +38,18 @@ class SubstitutionApi(object):
 
         Inserts a new substitution using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Substitution body: Substitution to be inserted. (required)
         :return: Substitution
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_substitution_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_substitution_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class SubstitutionApi(object):
 
         Inserts a new substitution using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Substitution body: Substitution to be inserted. (required)
         :return: Substitution
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type='Substitution',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class SubstitutionApi(object):
 
         Adds an audit to an existing substitution.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution_audit(substitution_id, substitution_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution_audit(substitution_id, substitution_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to add an audit to (required)
         :param str substitution_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class SubstitutionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_substitution_audit_with_http_info(substitution_id, substitution_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_substitution_audit_with_http_info(substitution_id, substitution_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class SubstitutionApi(object):
 
         Adds an audit to an existing substitution.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution_audit_with_http_info(substitution_id, substitution_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution_audit_with_http_info(substitution_id, substitution_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to add an audit to (required)
         :param str substitution_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id', 'substitution_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class SubstitutionApi(object):
 
         Adds a file to an existing substitution.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution_file(substitution_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution_file(substitution_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class SubstitutionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_substitution_file_with_http_info(substitution_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_substitution_file_with_http_info(substitution_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class SubstitutionApi(object):
 
         Adds a file to an existing substitution.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution_file_with_http_info(substitution_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution_file_with_http_info(substitution_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class SubstitutionApi(object):
 
         Adds a file to an existing substitution by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution_file_by_url(body, substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution_file_by_url(body, substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int substitution_id: Id of the substitution to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class SubstitutionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_substitution_file_by_url_with_http_info(body, substitution_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_substitution_file_by_url_with_http_info(body, substitution_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class SubstitutionApi(object):
 
         Adds a file to an existing substitution by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution_file_by_url_with_http_info(body, substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution_file_by_url_with_http_info(body, substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int substitution_id: Id of the substitution to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['body', 'substitution_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class SubstitutionApi(object):
 
         Adds a tag to an existing substitution.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution_tag(substitution_id, substitution_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution_tag(substitution_id, substitution_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to add a tag to (required)
         :param str substitution_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class SubstitutionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_substitution_tag_with_http_info(substitution_id, substitution_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_substitution_tag_with_http_info(substitution_id, substitution_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class SubstitutionApi(object):
 
         Adds a tag to an existing substitution.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_substitution_tag_with_http_info(substitution_id, substitution_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_substitution_tag_with_http_info(substitution_id, substitution_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to add a tag to (required)
         :param str substitution_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id', 'substitution_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class SubstitutionApi(object):
 
         Deletes the substitution identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_substitution(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_substitution(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_substitution_with_http_info(substitution_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_substitution_with_http_info(substitution_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class SubstitutionApi(object):
 
         Deletes the substitution identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_substitution_with_http_info(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_substitution_with_http_info(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class SubstitutionApi(object):
 
         Deletes an existing substitution file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_substitution_file(substitution_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_substitution_file(substitution_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class SubstitutionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_substitution_file_with_http_info(substitution_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_substitution_file_with_http_info(substitution_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class SubstitutionApi(object):
 
         Deletes an existing substitution file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_substitution_file_with_http_info(substitution_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_substitution_file_with_http_info(substitution_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class SubstitutionApi(object):
 
         Deletes an existing substitution tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_substitution_tag(substitution_id, substitution_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_substitution_tag(substitution_id, substitution_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to remove tag from (required)
         :param str substitution_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class SubstitutionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_substitution_tag_with_http_info(substitution_id, substitution_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_substitution_tag_with_http_info(substitution_id, substitution_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class SubstitutionApi(object):
 
         Deletes an existing substitution tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_substitution_tag_with_http_info(substitution_id, substitution_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_substitution_tag_with_http_info(substitution_id, substitution_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to remove tag from (required)
         :param str substitution_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id', 'substitution_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class SubstitutionApi(object):
 
         Returns a duplicated substitution identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_substitution_by_id(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_substitution_by_id(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to be duplicated. (required)
         :return: Substitution
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_substitution_by_id_with_http_info(substitution_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_substitution_by_id_with_http_info(substitution_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class SubstitutionApi(object):
 
         Returns a duplicated substitution identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_substitution_by_id_with_http_info(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_substitution_by_id_with_http_info(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to be duplicated. (required)
         :return: Substitution
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type='Substitution',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class SubstitutionApi(object):
 
         Returns the list of substitutions that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_substitution_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_substitution_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class SubstitutionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_substitution_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_substitution_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class SubstitutionApi(object):
 
         Returns the list of substitutions that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_substitution_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_substitution_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type='list[Substitution]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class SubstitutionApi(object):
 
         Returns the substitution identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_substitution_by_id(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_substitution_by_id(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to be returned. (required)
         :return: Substitution
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_substitution_by_id_with_http_info(substitution_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_substitution_by_id_with_http_info(substitution_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class SubstitutionApi(object):
 
         Returns the substitution identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_substitution_by_id_with_http_info(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_substitution_by_id_with_http_info(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to be returned. (required)
         :return: Substitution
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type='Substitution',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class SubstitutionApi(object):
 
         Get all existing substitution files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_substitution_files(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_substitution_files(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_substitution_files_with_http_info(substitution_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_substitution_files_with_http_info(substitution_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class SubstitutionApi(object):
 
         Get all existing substitution files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_substitution_files_with_http_info(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_substitution_files_with_http_info(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class SubstitutionApi(object):
 
         Get all existing substitution tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_substitution_tags(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_substitution_tags(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_substitution_tags_with_http_info(substitution_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_substitution_tags_with_http_info(substitution_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class SubstitutionApi(object):
 
         Get all existing substitution tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_substitution_tags_with_http_info(substitution_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_substitution_tags_with_http_info(substitution_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int substitution_id: Id of the substitution to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['substitution_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class SubstitutionApi(object):
 
         Updates an existing substitution using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_substitution(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_substitution(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Substitution body: Substitution to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_substitution_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_substitution_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class SubstitutionApi(object):
 
         Updates an existing substitution using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_substitution_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_substitution_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Substitution body: Substitution to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class SubstitutionApi(object):
 
         Updates an existing substitution custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_substitution_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_substitution_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Substitution body: Substitution to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_substitution_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_substitution_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class SubstitutionApi(object):
 
         Updates an existing substitution custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_substitution_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_substitution_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Substitution body: Substitution to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class SubstitutionApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class SubstitutionApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/supplement_api.py
+++ b/Infoplus/api/supplement_api.py
@@ -38,18 +38,18 @@ class SupplementApi(object):
 
         Inserts a new supplement using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Supplement body: Supplement to be inserted. (required)
         :return: Supplement
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_supplement_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_supplement_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class SupplementApi(object):
 
         Inserts a new supplement using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Supplement body: Supplement to be inserted. (required)
         :return: Supplement
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class SupplementApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type='Supplement',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class SupplementApi(object):
 
         Adds an audit to an existing supplement.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement_audit(supplement_id, supplement_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement_audit(supplement_id, supplement_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to add an audit to (required)
         :param str supplement_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class SupplementApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_supplement_audit_with_http_info(supplement_id, supplement_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_supplement_audit_with_http_info(supplement_id, supplement_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class SupplementApi(object):
 
         Adds an audit to an existing supplement.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement_audit_with_http_info(supplement_id, supplement_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement_audit_with_http_info(supplement_id, supplement_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to add an audit to (required)
         :param str supplement_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id', 'supplement_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class SupplementApi(object):
 
         Adds a file to an existing supplement.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement_file(supplement_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement_file(supplement_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class SupplementApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_supplement_file_with_http_info(supplement_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_supplement_file_with_http_info(supplement_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class SupplementApi(object):
 
         Adds a file to an existing supplement.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement_file_with_http_info(supplement_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement_file_with_http_info(supplement_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class SupplementApi(object):
 
         Adds a file to an existing supplement by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement_file_by_url(body, supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement_file_by_url(body, supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int supplement_id: Id of the supplement to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class SupplementApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_supplement_file_by_url_with_http_info(body, supplement_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_supplement_file_by_url_with_http_info(body, supplement_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class SupplementApi(object):
 
         Adds a file to an existing supplement by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement_file_by_url_with_http_info(body, supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement_file_by_url_with_http_info(body, supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int supplement_id: Id of the supplement to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class SupplementApi(object):
         """
 
         all_params = ['body', 'supplement_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class SupplementApi(object):
 
         Adds a tag to an existing supplement.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement_tag(supplement_id, supplement_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement_tag(supplement_id, supplement_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to add a tag to (required)
         :param str supplement_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class SupplementApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_supplement_tag_with_http_info(supplement_id, supplement_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_supplement_tag_with_http_info(supplement_id, supplement_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class SupplementApi(object):
 
         Adds a tag to an existing supplement.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_supplement_tag_with_http_info(supplement_id, supplement_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_supplement_tag_with_http_info(supplement_id, supplement_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to add a tag to (required)
         :param str supplement_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id', 'supplement_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class SupplementApi(object):
 
         Deletes the supplement identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_supplement(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_supplement(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_supplement_with_http_info(supplement_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_supplement_with_http_info(supplement_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class SupplementApi(object):
 
         Deletes the supplement identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_supplement_with_http_info(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_supplement_with_http_info(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class SupplementApi(object):
 
         Deletes an existing supplement file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_supplement_file(supplement_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_supplement_file(supplement_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class SupplementApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_supplement_file_with_http_info(supplement_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_supplement_file_with_http_info(supplement_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class SupplementApi(object):
 
         Deletes an existing supplement file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_supplement_file_with_http_info(supplement_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_supplement_file_with_http_info(supplement_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class SupplementApi(object):
 
         Deletes an existing supplement tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_supplement_tag(supplement_id, supplement_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_supplement_tag(supplement_id, supplement_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to remove tag from (required)
         :param str supplement_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class SupplementApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_supplement_tag_with_http_info(supplement_id, supplement_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_supplement_tag_with_http_info(supplement_id, supplement_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class SupplementApi(object):
 
         Deletes an existing supplement tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_supplement_tag_with_http_info(supplement_id, supplement_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_supplement_tag_with_http_info(supplement_id, supplement_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to remove tag from (required)
         :param str supplement_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id', 'supplement_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class SupplementApi(object):
 
         Returns a duplicated supplement identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_supplement_by_id(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_supplement_by_id(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to be duplicated. (required)
         :return: Supplement
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_supplement_by_id_with_http_info(supplement_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_supplement_by_id_with_http_info(supplement_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class SupplementApi(object):
 
         Returns a duplicated supplement identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_supplement_by_id_with_http_info(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_supplement_by_id_with_http_info(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to be duplicated. (required)
         :return: Supplement
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type='Supplement',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class SupplementApi(object):
 
         Returns the list of supplements that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_supplement_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_supplement_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class SupplementApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_supplement_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_supplement_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class SupplementApi(object):
 
         Returns the list of supplements that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_supplement_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_supplement_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class SupplementApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type='list[Supplement]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class SupplementApi(object):
 
         Returns the supplement identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_supplement_by_id(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_supplement_by_id(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to be returned. (required)
         :return: Supplement
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_supplement_by_id_with_http_info(supplement_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_supplement_by_id_with_http_info(supplement_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class SupplementApi(object):
 
         Returns the supplement identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_supplement_by_id_with_http_info(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_supplement_by_id_with_http_info(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to be returned. (required)
         :return: Supplement
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type='Supplement',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class SupplementApi(object):
 
         Get all existing supplement files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_supplement_files(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_supplement_files(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_supplement_files_with_http_info(supplement_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_supplement_files_with_http_info(supplement_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class SupplementApi(object):
 
         Get all existing supplement files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_supplement_files_with_http_info(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_supplement_files_with_http_info(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class SupplementApi(object):
 
         Get all existing supplement tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_supplement_tags(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_supplement_tags(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_supplement_tags_with_http_info(supplement_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_supplement_tags_with_http_info(supplement_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class SupplementApi(object):
 
         Get all existing supplement tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_supplement_tags_with_http_info(supplement_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_supplement_tags_with_http_info(supplement_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int supplement_id: Id of the supplement to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class SupplementApi(object):
         """
 
         all_params = ['supplement_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class SupplementApi(object):
 
         Updates an existing supplement using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_supplement(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_supplement(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Supplement body: Supplement to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_supplement_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_supplement_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class SupplementApi(object):
 
         Updates an existing supplement using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_supplement_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_supplement_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Supplement body: Supplement to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class SupplementApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class SupplementApi(object):
 
         Updates an existing supplement custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_supplement_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_supplement_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Supplement body: Supplement to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_supplement_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_supplement_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class SupplementApi(object):
 
         Updates an existing supplement custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_supplement_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_supplement_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Supplement body: Supplement to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class SupplementApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class SupplementApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/third_party_parcel_account_api.py
+++ b/Infoplus/api/third_party_parcel_account_api.py
@@ -38,18 +38,18 @@ class ThirdPartyParcelAccountApi(object):
 
         Inserts a new thirdPartyParcelAccount using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ThirdPartyParcelAccount body: ThirdPartyParcelAccount to be inserted. (required)
         :return: ThirdPartyParcelAccount
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_third_party_parcel_account_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_third_party_parcel_account_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Inserts a new thirdPartyParcelAccount using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ThirdPartyParcelAccount body: ThirdPartyParcelAccount to be inserted. (required)
         :return: ThirdPartyParcelAccount
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type='ThirdPartyParcelAccount',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Adds an audit to an existing thirdPartyParcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account_audit(third_party_parcel_account_id, third_party_parcel_account_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account_audit(third_party_parcel_account_id, third_party_parcel_account_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to add an audit to (required)
         :param str third_party_parcel_account_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ThirdPartyParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_third_party_parcel_account_audit_with_http_info(third_party_parcel_account_id, third_party_parcel_account_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_third_party_parcel_account_audit_with_http_info(third_party_parcel_account_id, third_party_parcel_account_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Adds an audit to an existing thirdPartyParcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account_audit_with_http_info(third_party_parcel_account_id, third_party_parcel_account_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account_audit_with_http_info(third_party_parcel_account_id, third_party_parcel_account_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to add an audit to (required)
         :param str third_party_parcel_account_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id', 'third_party_parcel_account_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Adds a file to an existing thirdPartyParcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account_file(third_party_parcel_account_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account_file(third_party_parcel_account_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ThirdPartyParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_third_party_parcel_account_file_with_http_info(third_party_parcel_account_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_third_party_parcel_account_file_with_http_info(third_party_parcel_account_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Adds a file to an existing thirdPartyParcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account_file_with_http_info(third_party_parcel_account_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account_file_with_http_info(third_party_parcel_account_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Adds a file to an existing thirdPartyParcelAccount by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account_file_by_url(body, third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account_file_by_url(body, third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ThirdPartyParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_third_party_parcel_account_file_by_url_with_http_info(body, third_party_parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_third_party_parcel_account_file_by_url_with_http_info(body, third_party_parcel_account_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Adds a file to an existing thirdPartyParcelAccount by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account_file_by_url_with_http_info(body, third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account_file_by_url_with_http_info(body, third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['body', 'third_party_parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Adds a tag to an existing thirdPartyParcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account_tag(third_party_parcel_account_id, third_party_parcel_account_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account_tag(third_party_parcel_account_id, third_party_parcel_account_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to add a tag to (required)
         :param str third_party_parcel_account_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ThirdPartyParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_third_party_parcel_account_tag_with_http_info(third_party_parcel_account_id, third_party_parcel_account_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_third_party_parcel_account_tag_with_http_info(third_party_parcel_account_id, third_party_parcel_account_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Adds a tag to an existing thirdPartyParcelAccount.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_third_party_parcel_account_tag_with_http_info(third_party_parcel_account_id, third_party_parcel_account_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_third_party_parcel_account_tag_with_http_info(third_party_parcel_account_id, third_party_parcel_account_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to add a tag to (required)
         :param str third_party_parcel_account_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id', 'third_party_parcel_account_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ThirdPartyParcelAccountApi(object):
 
         Deletes the thirdPartyParcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_third_party_parcel_account(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_third_party_parcel_account(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_third_party_parcel_account_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_third_party_parcel_account_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Deletes the thirdPartyParcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_third_party_parcel_account_with_http_info(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_third_party_parcel_account_with_http_info(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Deletes an existing thirdPartyParcelAccount file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_third_party_parcel_account_file(third_party_parcel_account_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_third_party_parcel_account_file(third_party_parcel_account_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ThirdPartyParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_third_party_parcel_account_file_with_http_info(third_party_parcel_account_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_third_party_parcel_account_file_with_http_info(third_party_parcel_account_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Deletes an existing thirdPartyParcelAccount file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_third_party_parcel_account_file_with_http_info(third_party_parcel_account_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_third_party_parcel_account_file_with_http_info(third_party_parcel_account_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Deletes an existing thirdPartyParcelAccount tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_third_party_parcel_account_tag(third_party_parcel_account_id, third_party_parcel_account_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_third_party_parcel_account_tag(third_party_parcel_account_id, third_party_parcel_account_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to remove tag from (required)
         :param str third_party_parcel_account_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ThirdPartyParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_third_party_parcel_account_tag_with_http_info(third_party_parcel_account_id, third_party_parcel_account_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_third_party_parcel_account_tag_with_http_info(third_party_parcel_account_id, third_party_parcel_account_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Deletes an existing thirdPartyParcelAccount tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_third_party_parcel_account_tag_with_http_info(third_party_parcel_account_id, third_party_parcel_account_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_third_party_parcel_account_tag_with_http_info(third_party_parcel_account_id, third_party_parcel_account_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to remove tag from (required)
         :param str third_party_parcel_account_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id', 'third_party_parcel_account_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ThirdPartyParcelAccountApi(object):
 
         Returns a duplicated thirdPartyParcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_third_party_parcel_account_by_id(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_third_party_parcel_account_by_id(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to be duplicated. (required)
         :return: ThirdPartyParcelAccount
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_third_party_parcel_account_by_id_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_third_party_parcel_account_by_id_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Returns a duplicated thirdPartyParcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_third_party_parcel_account_by_id_with_http_info(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_third_party_parcel_account_by_id_with_http_info(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to be duplicated. (required)
         :return: ThirdPartyParcelAccount
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type='ThirdPartyParcelAccount',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Returns the list of thirdPartyParcelAccounts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_third_party_parcel_account_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_third_party_parcel_account_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ThirdPartyParcelAccountApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_third_party_parcel_account_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_third_party_parcel_account_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Returns the list of thirdPartyParcelAccounts that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_third_party_parcel_account_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_third_party_parcel_account_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type='list[ThirdPartyParcelAccount]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ThirdPartyParcelAccountApi(object):
 
         Returns the thirdPartyParcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_third_party_parcel_account_by_id(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_third_party_parcel_account_by_id(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to be returned. (required)
         :return: ThirdPartyParcelAccount
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_third_party_parcel_account_by_id_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_third_party_parcel_account_by_id_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Returns the thirdPartyParcelAccount identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_third_party_parcel_account_by_id_with_http_info(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_third_party_parcel_account_by_id_with_http_info(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to be returned. (required)
         :return: ThirdPartyParcelAccount
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type='ThirdPartyParcelAccount',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ThirdPartyParcelAccountApi(object):
 
         Get all existing thirdPartyParcelAccount files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_third_party_parcel_account_files(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_third_party_parcel_account_files(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_third_party_parcel_account_files_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_third_party_parcel_account_files_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Get all existing thirdPartyParcelAccount files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_third_party_parcel_account_files_with_http_info(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_third_party_parcel_account_files_with_http_info(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ThirdPartyParcelAccountApi(object):
 
         Get all existing thirdPartyParcelAccount tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_third_party_parcel_account_tags(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_third_party_parcel_account_tags(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_third_party_parcel_account_tags_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_third_party_parcel_account_tags_with_http_info(third_party_parcel_account_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Get all existing thirdPartyParcelAccount tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_third_party_parcel_account_tags_with_http_info(third_party_parcel_account_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_third_party_parcel_account_tags_with_http_info(third_party_parcel_account_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int third_party_parcel_account_id: Id of the thirdPartyParcelAccount to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['third_party_parcel_account_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ThirdPartyParcelAccountApi(object):
 
         Updates an existing thirdPartyParcelAccount using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_third_party_parcel_account(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_third_party_parcel_account(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ThirdPartyParcelAccount body: ThirdPartyParcelAccount to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_third_party_parcel_account_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_third_party_parcel_account_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Updates an existing thirdPartyParcelAccount using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_third_party_parcel_account_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_third_party_parcel_account_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ThirdPartyParcelAccount body: ThirdPartyParcelAccount to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class ThirdPartyParcelAccountApi(object):
 
         Updates an existing thirdPartyParcelAccount custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_third_party_parcel_account_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_third_party_parcel_account_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ThirdPartyParcelAccount body: ThirdPartyParcelAccount to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_third_party_parcel_account_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_third_party_parcel_account_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class ThirdPartyParcelAccountApi(object):
 
         Updates an existing thirdPartyParcelAccount custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_third_party_parcel_account_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_third_party_parcel_account_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param ThirdPartyParcelAccount body: ThirdPartyParcelAccount to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class ThirdPartyParcelAccountApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class ThirdPartyParcelAccountApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/user_api.py
+++ b/Infoplus/api/user_api.py
@@ -38,18 +38,18 @@ class UserApi(object):
 
         Returns the user identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_user_by_id(user_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_user_by_id(user_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str user_id: Id of user to be returned. (required)
         :return: User
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_user_by_id_with_http_info(user_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_user_by_id_with_http_info(user_id, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class UserApi(object):
 
         Returns the user identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_user_by_id_with_http_info(user_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_user_by_id_with_http_info(user_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str user_id: Id of user to be returned. (required)
         :return: User
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class UserApi(object):
         """
 
         all_params = ['user_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -122,7 +122,7 @@ class UserApi(object):
             files=local_var_files,
             response_type='User',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -133,11 +133,11 @@ class UserApi(object):
 
         Returns the list of users that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_user_by_search_text(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_user_by_search_text(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -146,7 +146,7 @@ class UserApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_user_by_search_text_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_user_by_search_text_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class UserApi(object):
 
         Returns the list of users that match the given searchText.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_user_by_search_text_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_user_by_search_text_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str search_text: Search text, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -171,7 +171,7 @@ class UserApi(object):
         """
 
         all_params = ['search_text', 'page', 'limit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class UserApi(object):
             files=local_var_files,
             response_type='list[User]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/vendor_api.py
+++ b/Infoplus/api/vendor_api.py
@@ -38,18 +38,18 @@ class VendorApi(object):
 
         Inserts a new vendor using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Vendor body: Vendor to be inserted. (required)
         :return: Vendor
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class VendorApi(object):
 
         Inserts a new vendor using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Vendor body: Vendor to be inserted. (required)
         :return: Vendor
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class VendorApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type='Vendor',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class VendorApi(object):
 
         Adds an audit to an existing vendor.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_audit(vendor_id, vendor_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_audit(vendor_id, vendor_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to add an audit to (required)
         :param str vendor_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class VendorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_audit_with_http_info(vendor_id, vendor_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_audit_with_http_info(vendor_id, vendor_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class VendorApi(object):
 
         Adds an audit to an existing vendor.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_audit_with_http_info(vendor_id, vendor_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_audit_with_http_info(vendor_id, vendor_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to add an audit to (required)
         :param str vendor_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id', 'vendor_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class VendorApi(object):
 
         Adds a file to an existing vendor.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_file(vendor_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_file(vendor_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class VendorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_file_with_http_info(vendor_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_file_with_http_info(vendor_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class VendorApi(object):
 
         Adds a file to an existing vendor.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_file_with_http_info(vendor_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_file_with_http_info(vendor_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class VendorApi(object):
 
         Adds a file to an existing vendor by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_file_by_url(body, vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_file_by_url(body, vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int vendor_id: Id of the vendor to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class VendorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_file_by_url_with_http_info(body, vendor_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_file_by_url_with_http_info(body, vendor_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class VendorApi(object):
 
         Adds a file to an existing vendor by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_file_by_url_with_http_info(body, vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_file_by_url_with_http_info(body, vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int vendor_id: Id of the vendor to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class VendorApi(object):
         """
 
         all_params = ['body', 'vendor_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class VendorApi(object):
 
         Adds a tag to an existing vendor.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_tag(vendor_id, vendor_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_tag(vendor_id, vendor_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to add a tag to (required)
         :param str vendor_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class VendorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_tag_with_http_info(vendor_id, vendor_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_tag_with_http_info(vendor_id, vendor_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class VendorApi(object):
 
         Adds a tag to an existing vendor.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_tag_with_http_info(vendor_id, vendor_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_tag_with_http_info(vendor_id, vendor_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to add a tag to (required)
         :param str vendor_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id', 'vendor_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class VendorApi(object):
 
         Deletes the vendor identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_vendor_with_http_info(vendor_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_vendor_with_http_info(vendor_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class VendorApi(object):
 
         Deletes the vendor identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_with_http_info(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_with_http_info(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class VendorApi(object):
 
         Deletes an existing vendor file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_file(vendor_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_file(vendor_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class VendorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_vendor_file_with_http_info(vendor_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_vendor_file_with_http_info(vendor_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class VendorApi(object):
 
         Deletes an existing vendor file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_file_with_http_info(vendor_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_file_with_http_info(vendor_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class VendorApi(object):
 
         Deletes an existing vendor tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_tag(vendor_id, vendor_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_tag(vendor_id, vendor_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to remove tag from (required)
         :param str vendor_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class VendorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_vendor_tag_with_http_info(vendor_id, vendor_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_vendor_tag_with_http_info(vendor_id, vendor_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class VendorApi(object):
 
         Deletes an existing vendor tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_tag_with_http_info(vendor_id, vendor_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_tag_with_http_info(vendor_id, vendor_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to remove tag from (required)
         :param str vendor_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id', 'vendor_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class VendorApi(object):
 
         Returns a duplicated vendor identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_vendor_by_id(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_vendor_by_id(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to be duplicated. (required)
         :return: Vendor
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_vendor_by_id_with_http_info(vendor_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_vendor_by_id_with_http_info(vendor_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class VendorApi(object):
 
         Returns a duplicated vendor identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_vendor_by_id_with_http_info(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_vendor_by_id_with_http_info(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to be duplicated. (required)
         :return: Vendor
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type='Vendor',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class VendorApi(object):
 
         Returns the list of vendors that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class VendorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_vendor_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_vendor_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class VendorApi(object):
 
         Returns the list of vendors that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class VendorApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type='list[Vendor]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class VendorApi(object):
 
         Returns the vendor identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_by_id(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_by_id(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to be returned. (required)
         :return: Vendor
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_vendor_by_id_with_http_info(vendor_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_vendor_by_id_with_http_info(vendor_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class VendorApi(object):
 
         Returns the vendor identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_by_id_with_http_info(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_by_id_with_http_info(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to be returned. (required)
         :return: Vendor
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type='Vendor',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class VendorApi(object):
 
         Get all existing vendor files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_files(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_files(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_vendor_files_with_http_info(vendor_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_vendor_files_with_http_info(vendor_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class VendorApi(object):
 
         Get all existing vendor files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_files_with_http_info(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_files_with_http_info(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class VendorApi(object):
 
         Get all existing vendor tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_tags(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_tags(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_vendor_tags_with_http_info(vendor_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_vendor_tags_with_http_info(vendor_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class VendorApi(object):
 
         Get all existing vendor tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_tags_with_http_info(vendor_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_tags_with_http_info(vendor_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_id: Id of the vendor to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class VendorApi(object):
         """
 
         all_params = ['vendor_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class VendorApi(object):
 
         Updates an existing vendor using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_vendor(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_vendor(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Vendor body: Vendor to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_vendor_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_vendor_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class VendorApi(object):
 
         Updates an existing vendor using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_vendor_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_vendor_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Vendor body: Vendor to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class VendorApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class VendorApi(object):
 
         Updates an existing vendor custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_vendor_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_vendor_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Vendor body: Vendor to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_vendor_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_vendor_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class VendorApi(object):
 
         Updates an existing vendor custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_vendor_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_vendor_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Vendor body: Vendor to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class VendorApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class VendorApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/vendor_compliance_survey_api.py
+++ b/Infoplus/api/vendor_compliance_survey_api.py
@@ -38,18 +38,18 @@ class VendorComplianceSurveyApi(object):
 
         Inserts a new vendorComplianceSurvey using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param VendorComplianceSurvey body: VendorComplianceSurvey to be inserted. (required)
         :return: VendorComplianceSurvey
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_compliance_survey_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_compliance_survey_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class VendorComplianceSurveyApi(object):
 
         Inserts a new vendorComplianceSurvey using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param VendorComplianceSurvey body: VendorComplianceSurvey to be inserted. (required)
         :return: VendorComplianceSurvey
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type='VendorComplianceSurvey',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class VendorComplianceSurveyApi(object):
 
         Adds an audit to an existing vendorComplianceSurvey.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey_audit(vendor_compliance_survey_id, vendor_compliance_survey_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey_audit(vendor_compliance_survey_id, vendor_compliance_survey_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to add an audit to (required)
         :param str vendor_compliance_survey_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class VendorComplianceSurveyApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_compliance_survey_audit_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_compliance_survey_audit_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class VendorComplianceSurveyApi(object):
 
         Adds an audit to an existing vendorComplianceSurvey.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey_audit_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey_audit_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to add an audit to (required)
         :param str vendor_compliance_survey_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id', 'vendor_compliance_survey_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class VendorComplianceSurveyApi(object):
 
         Adds a file to an existing vendorComplianceSurvey.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey_file(vendor_compliance_survey_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey_file(vendor_compliance_survey_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class VendorComplianceSurveyApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_compliance_survey_file_with_http_info(vendor_compliance_survey_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_compliance_survey_file_with_http_info(vendor_compliance_survey_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class VendorComplianceSurveyApi(object):
 
         Adds a file to an existing vendorComplianceSurvey.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey_file_with_http_info(vendor_compliance_survey_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey_file_with_http_info(vendor_compliance_survey_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class VendorComplianceSurveyApi(object):
 
         Adds a file to an existing vendorComplianceSurvey by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey_file_by_url(body, vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey_file_by_url(body, vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class VendorComplianceSurveyApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_compliance_survey_file_by_url_with_http_info(body, vendor_compliance_survey_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_compliance_survey_file_by_url_with_http_info(body, vendor_compliance_survey_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class VendorComplianceSurveyApi(object):
 
         Adds a file to an existing vendorComplianceSurvey by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey_file_by_url_with_http_info(body, vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey_file_by_url_with_http_info(body, vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['body', 'vendor_compliance_survey_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class VendorComplianceSurveyApi(object):
 
         Adds a tag to an existing vendorComplianceSurvey.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey_tag(vendor_compliance_survey_id, vendor_compliance_survey_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey_tag(vendor_compliance_survey_id, vendor_compliance_survey_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to add a tag to (required)
         :param str vendor_compliance_survey_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class VendorComplianceSurveyApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_vendor_compliance_survey_tag_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_vendor_compliance_survey_tag_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class VendorComplianceSurveyApi(object):
 
         Adds a tag to an existing vendorComplianceSurvey.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_vendor_compliance_survey_tag_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_vendor_compliance_survey_tag_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to add a tag to (required)
         :param str vendor_compliance_survey_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id', 'vendor_compliance_survey_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class VendorComplianceSurveyApi(object):
 
         Deletes the vendorComplianceSurvey identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_compliance_survey(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_compliance_survey(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_vendor_compliance_survey_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_vendor_compliance_survey_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class VendorComplianceSurveyApi(object):
 
         Deletes the vendorComplianceSurvey identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_compliance_survey_with_http_info(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_compliance_survey_with_http_info(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class VendorComplianceSurveyApi(object):
 
         Deletes an existing vendorComplianceSurvey file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_compliance_survey_file(vendor_compliance_survey_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_compliance_survey_file(vendor_compliance_survey_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class VendorComplianceSurveyApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_vendor_compliance_survey_file_with_http_info(vendor_compliance_survey_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_vendor_compliance_survey_file_with_http_info(vendor_compliance_survey_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class VendorComplianceSurveyApi(object):
 
         Deletes an existing vendorComplianceSurvey file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_compliance_survey_file_with_http_info(vendor_compliance_survey_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_compliance_survey_file_with_http_info(vendor_compliance_survey_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class VendorComplianceSurveyApi(object):
 
         Deletes an existing vendorComplianceSurvey tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_compliance_survey_tag(vendor_compliance_survey_id, vendor_compliance_survey_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_compliance_survey_tag(vendor_compliance_survey_id, vendor_compliance_survey_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to remove tag from (required)
         :param str vendor_compliance_survey_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class VendorComplianceSurveyApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_vendor_compliance_survey_tag_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_vendor_compliance_survey_tag_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class VendorComplianceSurveyApi(object):
 
         Deletes an existing vendorComplianceSurvey tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vendor_compliance_survey_tag_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_vendor_compliance_survey_tag_with_http_info(vendor_compliance_survey_id, vendor_compliance_survey_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to remove tag from (required)
         :param str vendor_compliance_survey_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id', 'vendor_compliance_survey_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class VendorComplianceSurveyApi(object):
 
         Returns a duplicated vendorComplianceSurvey identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_vendor_compliance_survey_by_id(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_vendor_compliance_survey_by_id(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to be duplicated. (required)
         :return: VendorComplianceSurvey
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_vendor_compliance_survey_by_id_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_vendor_compliance_survey_by_id_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class VendorComplianceSurveyApi(object):
 
         Returns a duplicated vendorComplianceSurvey identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_vendor_compliance_survey_by_id_with_http_info(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_vendor_compliance_survey_by_id_with_http_info(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to be duplicated. (required)
         :return: VendorComplianceSurvey
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type='VendorComplianceSurvey',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class VendorComplianceSurveyApi(object):
 
         Returns the list of vendorComplianceSurveys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_compliance_survey_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_compliance_survey_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class VendorComplianceSurveyApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_vendor_compliance_survey_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_vendor_compliance_survey_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class VendorComplianceSurveyApi(object):
 
         Returns the list of vendorComplianceSurveys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_compliance_survey_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_compliance_survey_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type='list[VendorComplianceSurvey]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class VendorComplianceSurveyApi(object):
 
         Returns the vendorComplianceSurvey identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_compliance_survey_by_id(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_compliance_survey_by_id(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to be returned. (required)
         :return: VendorComplianceSurvey
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_vendor_compliance_survey_by_id_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_vendor_compliance_survey_by_id_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class VendorComplianceSurveyApi(object):
 
         Returns the vendorComplianceSurvey identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_compliance_survey_by_id_with_http_info(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_compliance_survey_by_id_with_http_info(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to be returned. (required)
         :return: VendorComplianceSurvey
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type='VendorComplianceSurvey',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class VendorComplianceSurveyApi(object):
 
         Get all existing vendorComplianceSurvey files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_compliance_survey_files(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_compliance_survey_files(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_vendor_compliance_survey_files_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_vendor_compliance_survey_files_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class VendorComplianceSurveyApi(object):
 
         Get all existing vendorComplianceSurvey files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_compliance_survey_files_with_http_info(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_compliance_survey_files_with_http_info(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class VendorComplianceSurveyApi(object):
 
         Get all existing vendorComplianceSurvey tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_compliance_survey_tags(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_compliance_survey_tags(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_vendor_compliance_survey_tags_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_vendor_compliance_survey_tags_with_http_info(vendor_compliance_survey_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class VendorComplianceSurveyApi(object):
 
         Get all existing vendorComplianceSurvey tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vendor_compliance_survey_tags_with_http_info(vendor_compliance_survey_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_vendor_compliance_survey_tags_with_http_info(vendor_compliance_survey_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int vendor_compliance_survey_id: Id of the vendorComplianceSurvey to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['vendor_compliance_survey_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class VendorComplianceSurveyApi(object):
 
         Updates an existing vendorComplianceSurvey using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_vendor_compliance_survey(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_vendor_compliance_survey(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param VendorComplianceSurvey body: VendorComplianceSurvey to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_vendor_compliance_survey_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_vendor_compliance_survey_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class VendorComplianceSurveyApi(object):
 
         Updates an existing vendorComplianceSurvey using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_vendor_compliance_survey_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_vendor_compliance_survey_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param VendorComplianceSurvey body: VendorComplianceSurvey to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class VendorComplianceSurveyApi(object):
 
         Updates an existing vendorComplianceSurvey custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_vendor_compliance_survey_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_vendor_compliance_survey_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param VendorComplianceSurvey body: VendorComplianceSurvey to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_vendor_compliance_survey_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_vendor_compliance_survey_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class VendorComplianceSurveyApi(object):
 
         Updates an existing vendorComplianceSurvey custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_vendor_compliance_survey_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_vendor_compliance_survey_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param VendorComplianceSurvey body: VendorComplianceSurvey to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class VendorComplianceSurveyApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class VendorComplianceSurveyApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/warehouse_api.py
+++ b/Infoplus/api/warehouse_api.py
@@ -38,18 +38,18 @@ class WarehouseApi(object):
 
         Inserts a new warehouse using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Warehouse body: Warehouse to be inserted. (required)
         :return: Warehouse
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class WarehouseApi(object):
 
         Inserts a new warehouse using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Warehouse body: Warehouse to be inserted. (required)
         :return: Warehouse
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type='Warehouse',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class WarehouseApi(object):
 
         Adds an audit to an existing warehouse.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_audit(warehouse_id, warehouse_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_audit(warehouse_id, warehouse_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to add an audit to (required)
         :param str warehouse_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class WarehouseApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_audit_with_http_info(warehouse_id, warehouse_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_audit_with_http_info(warehouse_id, warehouse_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class WarehouseApi(object):
 
         Adds an audit to an existing warehouse.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_audit_with_http_info(warehouse_id, warehouse_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_audit_with_http_info(warehouse_id, warehouse_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to add an audit to (required)
         :param str warehouse_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['warehouse_id', 'warehouse_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class WarehouseApi(object):
 
         Adds a file to an existing warehouse.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_file(warehouse_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_file(warehouse_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class WarehouseApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_file_with_http_info(warehouse_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_file_with_http_info(warehouse_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class WarehouseApi(object):
 
         Adds a file to an existing warehouse.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_file_with_http_info(warehouse_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_file_with_http_info(warehouse_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['warehouse_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class WarehouseApi(object):
 
         Adds a file to an existing warehouse by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_file_by_url(body, warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_file_by_url(body, warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_id: Id of the warehouse to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class WarehouseApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_file_by_url_with_http_info(body, warehouse_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_file_by_url_with_http_info(body, warehouse_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class WarehouseApi(object):
 
         Adds a file to an existing warehouse by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_file_by_url_with_http_info(body, warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_file_by_url_with_http_info(body, warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_id: Id of the warehouse to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['body', 'warehouse_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class WarehouseApi(object):
 
         Adds a tag to an existing warehouse.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_tag(warehouse_id, warehouse_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_tag(warehouse_id, warehouse_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to add a tag to (required)
         :param str warehouse_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class WarehouseApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_tag_with_http_info(warehouse_id, warehouse_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_tag_with_http_info(warehouse_id, warehouse_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class WarehouseApi(object):
 
         Adds a tag to an existing warehouse.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_tag_with_http_info(warehouse_id, warehouse_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_tag_with_http_info(warehouse_id, warehouse_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to add a tag to (required)
         :param str warehouse_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['warehouse_id', 'warehouse_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,11 +561,11 @@ class WarehouseApi(object):
 
         Deletes an existing warehouse file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_file(warehouse_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_file(warehouse_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -573,7 +573,7 @@ class WarehouseApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_file_with_http_info(warehouse_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_file_with_http_info(warehouse_id, file_id, **kwargs)  # noqa: E501
@@ -584,11 +584,11 @@ class WarehouseApi(object):
 
         Deletes an existing warehouse file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_file_with_http_info(warehouse_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_file_with_http_info(warehouse_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -597,7 +597,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['warehouse_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -653,7 +653,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -664,11 +664,11 @@ class WarehouseApi(object):
 
         Deletes an existing warehouse tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_tag(warehouse_id, warehouse_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_tag(warehouse_id, warehouse_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to remove tag from (required)
         :param str warehouse_tag: The tag to delete (required)
         :return: None
@@ -676,7 +676,7 @@ class WarehouseApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_tag_with_http_info(warehouse_id, warehouse_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_tag_with_http_info(warehouse_id, warehouse_tag, **kwargs)  # noqa: E501
@@ -687,11 +687,11 @@ class WarehouseApi(object):
 
         Deletes an existing warehouse tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_tag_with_http_info(warehouse_id, warehouse_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_tag_with_http_info(warehouse_id, warehouse_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to remove tag from (required)
         :param str warehouse_tag: The tag to delete (required)
         :return: None
@@ -700,7 +700,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['warehouse_id', 'warehouse_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -756,7 +756,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -767,18 +767,18 @@ class WarehouseApi(object):
 
         Returns a duplicated warehouse identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_by_id(warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_by_id(warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to be duplicated. (required)
         :return: Warehouse
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_warehouse_by_id_with_http_info(warehouse_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_warehouse_by_id_with_http_info(warehouse_id, **kwargs)  # noqa: E501
@@ -789,11 +789,11 @@ class WarehouseApi(object):
 
         Returns a duplicated warehouse identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_by_id_with_http_info(warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_by_id_with_http_info(warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to be duplicated. (required)
         :return: Warehouse
                  If the method is called asynchronously,
@@ -801,7 +801,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['warehouse_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type='Warehouse',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,11 +862,11 @@ class WarehouseApi(object):
 
         Returns the list of warehouses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -876,7 +876,7 @@ class WarehouseApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -887,11 +887,11 @@ class WarehouseApi(object):
 
         Returns the list of warehouses that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -902,7 +902,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -954,7 +954,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type='list[Warehouse]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -965,18 +965,18 @@ class WarehouseApi(object):
 
         Returns the warehouse identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_by_id(warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_by_id(warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to be returned. (required)
         :return: Warehouse
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_by_id_with_http_info(warehouse_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_by_id_with_http_info(warehouse_id, **kwargs)  # noqa: E501
@@ -987,11 +987,11 @@ class WarehouseApi(object):
 
         Returns the warehouse identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_by_id_with_http_info(warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_by_id_with_http_info(warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to be returned. (required)
         :return: Warehouse
                  If the method is called asynchronously,
@@ -999,7 +999,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['warehouse_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type='Warehouse',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class WarehouseApi(object):
 
         Get all existing warehouse files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_files(warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_files(warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_files_with_http_info(warehouse_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_files_with_http_info(warehouse_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class WarehouseApi(object):
 
         Get all existing warehouse files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_files_with_http_info(warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_files_with_http_info(warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['warehouse_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class WarehouseApi(object):
 
         Get all existing warehouse tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_tags(warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_tags(warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_tags_with_http_info(warehouse_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_tags_with_http_info(warehouse_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class WarehouseApi(object):
 
         Get all existing warehouse tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_tags_with_http_info(warehouse_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_tags_with_http_info(warehouse_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_id: Id of the warehouse to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['warehouse_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class WarehouseApi(object):
 
         Updates an existing warehouse using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Warehouse body: Warehouse to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_warehouse_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_warehouse_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class WarehouseApi(object):
 
         Updates an existing warehouse using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Warehouse body: Warehouse to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1349,18 +1349,18 @@ class WarehouseApi(object):
 
         Updates an existing warehouse custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Warehouse body: Warehouse to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_warehouse_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_warehouse_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1371,11 +1371,11 @@ class WarehouseApi(object):
 
         Updates an existing warehouse custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Warehouse body: Warehouse to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1383,7 +1383,7 @@ class WarehouseApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1437,7 +1437,7 @@ class WarehouseApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/warehouse_document_api.py
+++ b/Infoplus/api/warehouse_document_api.py
@@ -38,11 +38,11 @@ class WarehouseDocumentApi(object):
 
         Adds an audit to an existing warehouseDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_audit(warehouse_document_id, warehouse_document_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_audit(warehouse_document_id, warehouse_document_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to add an audit to (required)
         :param str warehouse_document_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class WarehouseDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_document_audit_with_http_info(warehouse_document_id, warehouse_document_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_document_audit_with_http_info(warehouse_document_id, warehouse_document_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class WarehouseDocumentApi(object):
 
         Adds an audit to an existing warehouseDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_audit_with_http_info(warehouse_document_id, warehouse_document_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_audit_with_http_info(warehouse_document_id, warehouse_document_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to add an audit to (required)
         :param str warehouse_document_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['warehouse_document_id', 'warehouse_document_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class WarehouseDocumentApi(object):
 
         Adds a file to an existing warehouseDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_file(warehouse_document_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_file(warehouse_document_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class WarehouseDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_document_file_with_http_info(warehouse_document_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_document_file_with_http_info(warehouse_document_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class WarehouseDocumentApi(object):
 
         Adds a file to an existing warehouseDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_file_with_http_info(warehouse_document_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_file_with_http_info(warehouse_document_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['warehouse_document_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class WarehouseDocumentApi(object):
 
         Adds a file to an existing warehouseDocument by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_file_by_url(body, warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_file_by_url(body, warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_document_id: Id of the warehouseDocument to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class WarehouseDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_document_file_by_url_with_http_info(body, warehouse_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_document_file_by_url_with_http_info(body, warehouse_document_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class WarehouseDocumentApi(object):
 
         Adds a file to an existing warehouseDocument by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_file_by_url_with_http_info(body, warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_file_by_url_with_http_info(body, warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_document_id: Id of the warehouseDocument to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['body', 'warehouse_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class WarehouseDocumentApi(object):
 
         Adds a tag to an existing warehouseDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_tag(warehouse_document_id, warehouse_document_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_tag(warehouse_document_id, warehouse_document_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to add a tag to (required)
         :param str warehouse_document_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class WarehouseDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_document_tag_with_http_info(warehouse_document_id, warehouse_document_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_document_tag_with_http_info(warehouse_document_id, warehouse_document_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class WarehouseDocumentApi(object):
 
         Adds a tag to an existing warehouseDocument.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_tag_with_http_info(warehouse_document_id, warehouse_document_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_tag_with_http_info(warehouse_document_id, warehouse_document_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to add a tag to (required)
         :param str warehouse_document_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['warehouse_document_id', 'warehouse_document_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class WarehouseDocumentApi(object):
 
         Deletes an existing warehouseDocument file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_document_file(warehouse_document_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_document_file(warehouse_document_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class WarehouseDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_document_file_with_http_info(warehouse_document_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_document_file_with_http_info(warehouse_document_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class WarehouseDocumentApi(object):
 
         Deletes an existing warehouseDocument file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_document_file_with_http_info(warehouse_document_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_document_file_with_http_info(warehouse_document_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['warehouse_document_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class WarehouseDocumentApi(object):
 
         Deletes an existing warehouseDocument tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_document_tag(warehouse_document_id, warehouse_document_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_document_tag(warehouse_document_id, warehouse_document_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to remove tag from (required)
         :param str warehouse_document_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class WarehouseDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_document_tag_with_http_info(warehouse_document_id, warehouse_document_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_document_tag_with_http_info(warehouse_document_id, warehouse_document_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class WarehouseDocumentApi(object):
 
         Deletes an existing warehouseDocument tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_document_tag_with_http_info(warehouse_document_id, warehouse_document_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_document_tag_with_http_info(warehouse_document_id, warehouse_document_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to remove tag from (required)
         :param str warehouse_document_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['warehouse_document_id', 'warehouse_document_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class WarehouseDocumentApi(object):
 
         Returns a duplicated warehouseDocument identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_document_by_id(warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_document_by_id(warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to be duplicated. (required)
         :return: WarehouseDocument
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_warehouse_document_by_id_with_http_info(warehouse_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_warehouse_document_by_id_with_http_info(warehouse_document_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class WarehouseDocumentApi(object):
 
         Returns a duplicated warehouseDocument identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_document_by_id_with_http_info(warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_document_by_id_with_http_info(warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to be duplicated. (required)
         :return: WarehouseDocument
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['warehouse_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type='WarehouseDocument',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class WarehouseDocumentApi(object):
 
         Returns the list of warehouseDocuments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class WarehouseDocumentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_document_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_document_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class WarehouseDocumentApi(object):
 
         Returns the list of warehouseDocuments that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type='list[WarehouseDocument]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class WarehouseDocumentApi(object):
 
         Returns the warehouseDocument identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_by_id(warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_by_id(warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to be returned. (required)
         :return: WarehouseDocument
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_document_by_id_with_http_info(warehouse_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_document_by_id_with_http_info(warehouse_document_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class WarehouseDocumentApi(object):
 
         Returns the warehouseDocument identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_by_id_with_http_info(warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_by_id_with_http_info(warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to be returned. (required)
         :return: WarehouseDocument
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['warehouse_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type='WarehouseDocument',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class WarehouseDocumentApi(object):
 
         Get all existing warehouseDocument files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_files(warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_files(warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_document_files_with_http_info(warehouse_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_document_files_with_http_info(warehouse_document_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class WarehouseDocumentApi(object):
 
         Get all existing warehouseDocument files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_files_with_http_info(warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_files_with_http_info(warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['warehouse_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class WarehouseDocumentApi(object):
 
         Get all existing warehouseDocument tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_tags(warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_tags(warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_document_tags_with_http_info(warehouse_document_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_document_tags_with_http_info(warehouse_document_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class WarehouseDocumentApi(object):
 
         Get all existing warehouseDocument tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_tags_with_http_info(warehouse_document_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_tags_with_http_info(warehouse_document_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_id: Id of the warehouseDocument to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['warehouse_document_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class WarehouseDocumentApi(object):
 
         Updates an existing warehouseDocument custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse_document_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse_document_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WarehouseDocument body: WarehouseDocument to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_warehouse_document_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_warehouse_document_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class WarehouseDocumentApi(object):
 
         Updates an existing warehouseDocument custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse_document_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse_document_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WarehouseDocument body: WarehouseDocument to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class WarehouseDocumentApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class WarehouseDocumentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/warehouse_document_type_api.py
+++ b/Infoplus/api/warehouse_document_type_api.py
@@ -38,11 +38,11 @@ class WarehouseDocumentTypeApi(object):
 
         Adds an audit to an existing warehouseDocumentType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_type_audit(warehouse_document_type_id, warehouse_document_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_type_audit(warehouse_document_type_id, warehouse_document_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to add an audit to (required)
         :param str warehouse_document_type_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class WarehouseDocumentTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_document_type_audit_with_http_info(warehouse_document_type_id, warehouse_document_type_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_document_type_audit_with_http_info(warehouse_document_type_id, warehouse_document_type_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class WarehouseDocumentTypeApi(object):
 
         Adds an audit to an existing warehouseDocumentType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_type_audit_with_http_info(warehouse_document_type_id, warehouse_document_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_type_audit_with_http_info(warehouse_document_type_id, warehouse_document_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to add an audit to (required)
         :param str warehouse_document_type_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['warehouse_document_type_id', 'warehouse_document_type_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class WarehouseDocumentTypeApi(object):
 
         Adds a file to an existing warehouseDocumentType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_type_file(warehouse_document_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_type_file(warehouse_document_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class WarehouseDocumentTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_document_type_file_with_http_info(warehouse_document_type_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_document_type_file_with_http_info(warehouse_document_type_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class WarehouseDocumentTypeApi(object):
 
         Adds a file to an existing warehouseDocumentType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_type_file_with_http_info(warehouse_document_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_type_file_with_http_info(warehouse_document_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['warehouse_document_type_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class WarehouseDocumentTypeApi(object):
 
         Adds a file to an existing warehouseDocumentType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_type_file_by_url(body, warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_type_file_by_url(body, warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class WarehouseDocumentTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_document_type_file_by_url_with_http_info(body, warehouse_document_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_document_type_file_by_url_with_http_info(body, warehouse_document_type_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class WarehouseDocumentTypeApi(object):
 
         Adds a file to an existing warehouseDocumentType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_type_file_by_url_with_http_info(body, warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_type_file_by_url_with_http_info(body, warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['body', 'warehouse_document_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class WarehouseDocumentTypeApi(object):
 
         Adds a tag to an existing warehouseDocumentType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_type_tag(warehouse_document_type_id, warehouse_document_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_type_tag(warehouse_document_type_id, warehouse_document_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to add a tag to (required)
         :param str warehouse_document_type_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class WarehouseDocumentTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_document_type_tag_with_http_info(warehouse_document_type_id, warehouse_document_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_document_type_tag_with_http_info(warehouse_document_type_id, warehouse_document_type_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class WarehouseDocumentTypeApi(object):
 
         Adds a tag to an existing warehouseDocumentType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_document_type_tag_with_http_info(warehouse_document_type_id, warehouse_document_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_document_type_tag_with_http_info(warehouse_document_type_id, warehouse_document_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to add a tag to (required)
         :param str warehouse_document_type_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['warehouse_document_type_id', 'warehouse_document_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class WarehouseDocumentTypeApi(object):
 
         Deletes an existing warehouseDocumentType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_document_type_file(warehouse_document_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_document_type_file(warehouse_document_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class WarehouseDocumentTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_document_type_file_with_http_info(warehouse_document_type_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_document_type_file_with_http_info(warehouse_document_type_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class WarehouseDocumentTypeApi(object):
 
         Deletes an existing warehouseDocumentType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_document_type_file_with_http_info(warehouse_document_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_document_type_file_with_http_info(warehouse_document_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['warehouse_document_type_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class WarehouseDocumentTypeApi(object):
 
         Deletes an existing warehouseDocumentType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_document_type_tag(warehouse_document_type_id, warehouse_document_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_document_type_tag(warehouse_document_type_id, warehouse_document_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to remove tag from (required)
         :param str warehouse_document_type_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class WarehouseDocumentTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_document_type_tag_with_http_info(warehouse_document_type_id, warehouse_document_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_document_type_tag_with_http_info(warehouse_document_type_id, warehouse_document_type_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class WarehouseDocumentTypeApi(object):
 
         Deletes an existing warehouseDocumentType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_document_type_tag_with_http_info(warehouse_document_type_id, warehouse_document_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_document_type_tag_with_http_info(warehouse_document_type_id, warehouse_document_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to remove tag from (required)
         :param str warehouse_document_type_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['warehouse_document_type_id', 'warehouse_document_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class WarehouseDocumentTypeApi(object):
 
         Returns a duplicated warehouseDocumentType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_document_type_by_id(warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_document_type_by_id(warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to be duplicated. (required)
         :return: WarehouseDocumentType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_warehouse_document_type_by_id_with_http_info(warehouse_document_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_warehouse_document_type_by_id_with_http_info(warehouse_document_type_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class WarehouseDocumentTypeApi(object):
 
         Returns a duplicated warehouseDocumentType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_document_type_by_id_with_http_info(warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_document_type_by_id_with_http_info(warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to be duplicated. (required)
         :return: WarehouseDocumentType
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['warehouse_document_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type='WarehouseDocumentType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class WarehouseDocumentTypeApi(object):
 
         Returns the list of warehouseDocumentTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_type_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_type_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class WarehouseDocumentTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_document_type_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_document_type_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class WarehouseDocumentTypeApi(object):
 
         Returns the list of warehouseDocumentTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_type_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_type_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type='list[WarehouseDocumentType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class WarehouseDocumentTypeApi(object):
 
         Returns the warehouseDocumentType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_type_by_id(warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_type_by_id(warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to be returned. (required)
         :return: WarehouseDocumentType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_document_type_by_id_with_http_info(warehouse_document_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_document_type_by_id_with_http_info(warehouse_document_type_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class WarehouseDocumentTypeApi(object):
 
         Returns the warehouseDocumentType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_type_by_id_with_http_info(warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_type_by_id_with_http_info(warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to be returned. (required)
         :return: WarehouseDocumentType
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['warehouse_document_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type='WarehouseDocumentType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class WarehouseDocumentTypeApi(object):
 
         Get all existing warehouseDocumentType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_type_files(warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_type_files(warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_document_type_files_with_http_info(warehouse_document_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_document_type_files_with_http_info(warehouse_document_type_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class WarehouseDocumentTypeApi(object):
 
         Get all existing warehouseDocumentType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_type_files_with_http_info(warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_type_files_with_http_info(warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['warehouse_document_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class WarehouseDocumentTypeApi(object):
 
         Get all existing warehouseDocumentType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_type_tags(warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_type_tags(warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_document_type_tags_with_http_info(warehouse_document_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_document_type_tags_with_http_info(warehouse_document_type_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class WarehouseDocumentTypeApi(object):
 
         Get all existing warehouseDocumentType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_document_type_tags_with_http_info(warehouse_document_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_document_type_tags_with_http_info(warehouse_document_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_document_type_id: Id of the warehouseDocumentType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class WarehouseDocumentTypeApi(object):
         """
 
         all_params = ['warehouse_document_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class WarehouseDocumentTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/warehouse_inventory_api.py
+++ b/Infoplus/api/warehouse_inventory_api.py
@@ -38,11 +38,11 @@ class WarehouseInventoryApi(object):
 
         Adds an audit to an existing warehouseInventory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_inventory_audit(warehouse_inventory_id, warehouse_inventory_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_inventory_audit(warehouse_inventory_id, warehouse_inventory_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to add an audit to (required)
         :param str warehouse_inventory_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class WarehouseInventoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_inventory_audit_with_http_info(warehouse_inventory_id, warehouse_inventory_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_inventory_audit_with_http_info(warehouse_inventory_id, warehouse_inventory_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class WarehouseInventoryApi(object):
 
         Adds an audit to an existing warehouseInventory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_inventory_audit_with_http_info(warehouse_inventory_id, warehouse_inventory_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_inventory_audit_with_http_info(warehouse_inventory_id, warehouse_inventory_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to add an audit to (required)
         :param str warehouse_inventory_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['warehouse_inventory_id', 'warehouse_inventory_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class WarehouseInventoryApi(object):
 
         Adds a file to an existing warehouseInventory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_inventory_file(warehouse_inventory_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_inventory_file(warehouse_inventory_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class WarehouseInventoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_inventory_file_with_http_info(warehouse_inventory_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_inventory_file_with_http_info(warehouse_inventory_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class WarehouseInventoryApi(object):
 
         Adds a file to an existing warehouseInventory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_inventory_file_with_http_info(warehouse_inventory_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_inventory_file_with_http_info(warehouse_inventory_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['warehouse_inventory_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class WarehouseInventoryApi(object):
 
         Adds a file to an existing warehouseInventory by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_inventory_file_by_url(body, warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_inventory_file_by_url(body, warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_inventory_id: Id of the warehouseInventory to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class WarehouseInventoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_inventory_file_by_url_with_http_info(body, warehouse_inventory_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_inventory_file_by_url_with_http_info(body, warehouse_inventory_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class WarehouseInventoryApi(object):
 
         Adds a file to an existing warehouseInventory by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_inventory_file_by_url_with_http_info(body, warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_inventory_file_by_url_with_http_info(body, warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_inventory_id: Id of the warehouseInventory to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['body', 'warehouse_inventory_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class WarehouseInventoryApi(object):
 
         Adds a tag to an existing warehouseInventory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_inventory_tag(warehouse_inventory_id, warehouse_inventory_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_inventory_tag(warehouse_inventory_id, warehouse_inventory_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to add a tag to (required)
         :param str warehouse_inventory_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class WarehouseInventoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_inventory_tag_with_http_info(warehouse_inventory_id, warehouse_inventory_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_inventory_tag_with_http_info(warehouse_inventory_id, warehouse_inventory_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class WarehouseInventoryApi(object):
 
         Adds a tag to an existing warehouseInventory.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_inventory_tag_with_http_info(warehouse_inventory_id, warehouse_inventory_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_inventory_tag_with_http_info(warehouse_inventory_id, warehouse_inventory_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to add a tag to (required)
         :param str warehouse_inventory_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['warehouse_inventory_id', 'warehouse_inventory_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class WarehouseInventoryApi(object):
 
         Deletes an existing warehouseInventory file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_inventory_file(warehouse_inventory_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_inventory_file(warehouse_inventory_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class WarehouseInventoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_inventory_file_with_http_info(warehouse_inventory_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_inventory_file_with_http_info(warehouse_inventory_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class WarehouseInventoryApi(object):
 
         Deletes an existing warehouseInventory file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_inventory_file_with_http_info(warehouse_inventory_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_inventory_file_with_http_info(warehouse_inventory_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['warehouse_inventory_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class WarehouseInventoryApi(object):
 
         Deletes an existing warehouseInventory tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_inventory_tag(warehouse_inventory_id, warehouse_inventory_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_inventory_tag(warehouse_inventory_id, warehouse_inventory_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to remove tag from (required)
         :param str warehouse_inventory_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class WarehouseInventoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_inventory_tag_with_http_info(warehouse_inventory_id, warehouse_inventory_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_inventory_tag_with_http_info(warehouse_inventory_id, warehouse_inventory_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class WarehouseInventoryApi(object):
 
         Deletes an existing warehouseInventory tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_inventory_tag_with_http_info(warehouse_inventory_id, warehouse_inventory_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_inventory_tag_with_http_info(warehouse_inventory_id, warehouse_inventory_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to remove tag from (required)
         :param str warehouse_inventory_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['warehouse_inventory_id', 'warehouse_inventory_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class WarehouseInventoryApi(object):
 
         Returns a duplicated warehouseInventory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_inventory_by_id(warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_inventory_by_id(warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to be duplicated. (required)
         :return: WarehouseInventory
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_warehouse_inventory_by_id_with_http_info(warehouse_inventory_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_warehouse_inventory_by_id_with_http_info(warehouse_inventory_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class WarehouseInventoryApi(object):
 
         Returns a duplicated warehouseInventory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_inventory_by_id_with_http_info(warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_inventory_by_id_with_http_info(warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to be duplicated. (required)
         :return: WarehouseInventory
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['warehouse_inventory_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type='WarehouseInventory',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class WarehouseInventoryApi(object):
 
         Returns the list of warehouseInventorys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_inventory_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_inventory_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class WarehouseInventoryApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_inventory_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_inventory_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class WarehouseInventoryApi(object):
 
         Returns the list of warehouseInventorys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_inventory_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_inventory_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type='list[WarehouseInventory]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class WarehouseInventoryApi(object):
 
         Returns the warehouseInventory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_inventory_by_id(warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_inventory_by_id(warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to be returned. (required)
         :return: WarehouseInventory
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_inventory_by_id_with_http_info(warehouse_inventory_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_inventory_by_id_with_http_info(warehouse_inventory_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class WarehouseInventoryApi(object):
 
         Returns the warehouseInventory identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_inventory_by_id_with_http_info(warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_inventory_by_id_with_http_info(warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to be returned. (required)
         :return: WarehouseInventory
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['warehouse_inventory_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type='WarehouseInventory',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class WarehouseInventoryApi(object):
 
         Get all existing warehouseInventory files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_inventory_files(warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_inventory_files(warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_inventory_files_with_http_info(warehouse_inventory_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_inventory_files_with_http_info(warehouse_inventory_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class WarehouseInventoryApi(object):
 
         Get all existing warehouseInventory files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_inventory_files_with_http_info(warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_inventory_files_with_http_info(warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['warehouse_inventory_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class WarehouseInventoryApi(object):
 
         Get all existing warehouseInventory tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_inventory_tags(warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_inventory_tags(warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_inventory_tags_with_http_info(warehouse_inventory_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_inventory_tags_with_http_info(warehouse_inventory_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class WarehouseInventoryApi(object):
 
         Get all existing warehouseInventory tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_inventory_tags_with_http_info(warehouse_inventory_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_inventory_tags_with_http_info(warehouse_inventory_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_inventory_id: Id of the warehouseInventory to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class WarehouseInventoryApi(object):
         """
 
         all_params = ['warehouse_inventory_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class WarehouseInventoryApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/warehouse_service_type_api.py
+++ b/Infoplus/api/warehouse_service_type_api.py
@@ -38,18 +38,18 @@ class WarehouseServiceTypeApi(object):
 
         Inserts a new warehouseServiceType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WarehouseServiceType body: WarehouseServiceType to be inserted. (required)
         :return: WarehouseServiceType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_service_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_service_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class WarehouseServiceTypeApi(object):
 
         Inserts a new warehouseServiceType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WarehouseServiceType body: WarehouseServiceType to be inserted. (required)
         :return: WarehouseServiceType
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type='WarehouseServiceType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class WarehouseServiceTypeApi(object):
 
         Adds an audit to an existing warehouseServiceType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type_audit(warehouse_service_type_id, warehouse_service_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type_audit(warehouse_service_type_id, warehouse_service_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to add an audit to (required)
         :param str warehouse_service_type_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class WarehouseServiceTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_service_type_audit_with_http_info(warehouse_service_type_id, warehouse_service_type_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_service_type_audit_with_http_info(warehouse_service_type_id, warehouse_service_type_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class WarehouseServiceTypeApi(object):
 
         Adds an audit to an existing warehouseServiceType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type_audit_with_http_info(warehouse_service_type_id, warehouse_service_type_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type_audit_with_http_info(warehouse_service_type_id, warehouse_service_type_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to add an audit to (required)
         :param str warehouse_service_type_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id', 'warehouse_service_type_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class WarehouseServiceTypeApi(object):
 
         Adds a file to an existing warehouseServiceType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type_file(warehouse_service_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type_file(warehouse_service_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class WarehouseServiceTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_service_type_file_with_http_info(warehouse_service_type_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_service_type_file_with_http_info(warehouse_service_type_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class WarehouseServiceTypeApi(object):
 
         Adds a file to an existing warehouseServiceType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type_file_with_http_info(warehouse_service_type_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type_file_with_http_info(warehouse_service_type_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class WarehouseServiceTypeApi(object):
 
         Adds a file to an existing warehouseServiceType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type_file_by_url(body, warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type_file_by_url(body, warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_service_type_id: Id of the warehouseServiceType to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class WarehouseServiceTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_service_type_file_by_url_with_http_info(body, warehouse_service_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_service_type_file_by_url_with_http_info(body, warehouse_service_type_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class WarehouseServiceTypeApi(object):
 
         Adds a file to an existing warehouseServiceType by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type_file_by_url_with_http_info(body, warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type_file_by_url_with_http_info(body, warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int warehouse_service_type_id: Id of the warehouseServiceType to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['body', 'warehouse_service_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class WarehouseServiceTypeApi(object):
 
         Adds a tag to an existing warehouseServiceType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type_tag(warehouse_service_type_id, warehouse_service_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type_tag(warehouse_service_type_id, warehouse_service_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to add a tag to (required)
         :param str warehouse_service_type_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class WarehouseServiceTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_warehouse_service_type_tag_with_http_info(warehouse_service_type_id, warehouse_service_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_warehouse_service_type_tag_with_http_info(warehouse_service_type_id, warehouse_service_type_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class WarehouseServiceTypeApi(object):
 
         Adds a tag to an existing warehouseServiceType.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_warehouse_service_type_tag_with_http_info(warehouse_service_type_id, warehouse_service_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_warehouse_service_type_tag_with_http_info(warehouse_service_type_id, warehouse_service_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to add a tag to (required)
         :param str warehouse_service_type_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id', 'warehouse_service_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class WarehouseServiceTypeApi(object):
 
         Deletes the warehouseServiceType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_service_type(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_service_type(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_service_type_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_service_type_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class WarehouseServiceTypeApi(object):
 
         Deletes the warehouseServiceType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_service_type_with_http_info(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_service_type_with_http_info(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class WarehouseServiceTypeApi(object):
 
         Deletes an existing warehouseServiceType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_service_type_file(warehouse_service_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_service_type_file(warehouse_service_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class WarehouseServiceTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_service_type_file_with_http_info(warehouse_service_type_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_service_type_file_with_http_info(warehouse_service_type_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class WarehouseServiceTypeApi(object):
 
         Deletes an existing warehouseServiceType file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_service_type_file_with_http_info(warehouse_service_type_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_service_type_file_with_http_info(warehouse_service_type_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class WarehouseServiceTypeApi(object):
 
         Deletes an existing warehouseServiceType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_service_type_tag(warehouse_service_type_id, warehouse_service_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_service_type_tag(warehouse_service_type_id, warehouse_service_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to remove tag from (required)
         :param str warehouse_service_type_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class WarehouseServiceTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_warehouse_service_type_tag_with_http_info(warehouse_service_type_id, warehouse_service_type_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_warehouse_service_type_tag_with_http_info(warehouse_service_type_id, warehouse_service_type_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class WarehouseServiceTypeApi(object):
 
         Deletes an existing warehouseServiceType tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_warehouse_service_type_tag_with_http_info(warehouse_service_type_id, warehouse_service_type_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_warehouse_service_type_tag_with_http_info(warehouse_service_type_id, warehouse_service_type_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to remove tag from (required)
         :param str warehouse_service_type_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id', 'warehouse_service_type_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class WarehouseServiceTypeApi(object):
 
         Returns a duplicated warehouseServiceType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_service_type_by_id(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_service_type_by_id(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to be duplicated. (required)
         :return: WarehouseServiceType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_warehouse_service_type_by_id_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_warehouse_service_type_by_id_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class WarehouseServiceTypeApi(object):
 
         Returns a duplicated warehouseServiceType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_warehouse_service_type_by_id_with_http_info(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_warehouse_service_type_by_id_with_http_info(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to be duplicated. (required)
         :return: WarehouseServiceType
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type='WarehouseServiceType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class WarehouseServiceTypeApi(object):
 
         Returns the list of warehouseServiceTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_service_type_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_service_type_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class WarehouseServiceTypeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_service_type_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_service_type_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class WarehouseServiceTypeApi(object):
 
         Returns the list of warehouseServiceTypes that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_service_type_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_service_type_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type='list[WarehouseServiceType]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class WarehouseServiceTypeApi(object):
 
         Returns the warehouseServiceType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_service_type_by_id(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_service_type_by_id(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to be returned. (required)
         :return: WarehouseServiceType
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_service_type_by_id_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_service_type_by_id_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class WarehouseServiceTypeApi(object):
 
         Returns the warehouseServiceType identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_service_type_by_id_with_http_info(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_service_type_by_id_with_http_info(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to be returned. (required)
         :return: WarehouseServiceType
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type='WarehouseServiceType',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class WarehouseServiceTypeApi(object):
 
         Get all existing warehouseServiceType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_service_type_files(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_service_type_files(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_service_type_files_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_service_type_files_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class WarehouseServiceTypeApi(object):
 
         Get all existing warehouseServiceType files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_service_type_files_with_http_info(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_service_type_files_with_http_info(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class WarehouseServiceTypeApi(object):
 
         Get all existing warehouseServiceType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_service_type_tags(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_service_type_tags(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_warehouse_service_type_tags_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_warehouse_service_type_tags_with_http_info(warehouse_service_type_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class WarehouseServiceTypeApi(object):
 
         Get all existing warehouseServiceType tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_warehouse_service_type_tags_with_http_info(warehouse_service_type_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_warehouse_service_type_tags_with_http_info(warehouse_service_type_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int warehouse_service_type_id: Id of the warehouseServiceType to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['warehouse_service_type_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class WarehouseServiceTypeApi(object):
 
         Updates an existing warehouseServiceType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse_service_type(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse_service_type(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WarehouseServiceType body: WarehouseServiceType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_warehouse_service_type_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_warehouse_service_type_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class WarehouseServiceTypeApi(object):
 
         Updates an existing warehouseServiceType using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse_service_type_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse_service_type_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WarehouseServiceType body: WarehouseServiceType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class WarehouseServiceTypeApi(object):
 
         Updates an existing warehouseServiceType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse_service_type_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse_service_type_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WarehouseServiceType body: WarehouseServiceType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_warehouse_service_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_warehouse_service_type_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class WarehouseServiceTypeApi(object):
 
         Updates an existing warehouseServiceType custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_warehouse_service_type_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_warehouse_service_type_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WarehouseServiceType body: WarehouseServiceType to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class WarehouseServiceTypeApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class WarehouseServiceTypeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/work_activity_api.py
+++ b/Infoplus/api/work_activity_api.py
@@ -38,18 +38,18 @@ class WorkActivityApi(object):
 
         Inserts a new workActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WorkActivity body: WorkActivity to be inserted. (required)
         :return: WorkActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class WorkActivityApi(object):
 
         Inserts a new workActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WorkActivity body: WorkActivity to be inserted. (required)
         :return: WorkActivity
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type='WorkActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class WorkActivityApi(object):
 
         Adds an audit to an existing workActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity_audit(work_activity_id, work_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity_audit(work_activity_id, work_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to add an audit to (required)
         :param str work_activity_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class WorkActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_activity_audit_with_http_info(work_activity_id, work_activity_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_activity_audit_with_http_info(work_activity_id, work_activity_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class WorkActivityApi(object):
 
         Adds an audit to an existing workActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity_audit_with_http_info(work_activity_id, work_activity_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity_audit_with_http_info(work_activity_id, work_activity_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to add an audit to (required)
         :param str work_activity_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id', 'work_activity_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class WorkActivityApi(object):
 
         Adds a file to an existing workActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity_file(work_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity_file(work_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class WorkActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_activity_file_with_http_info(work_activity_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_activity_file_with_http_info(work_activity_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class WorkActivityApi(object):
 
         Adds a file to an existing workActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity_file_with_http_info(work_activity_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity_file_with_http_info(work_activity_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class WorkActivityApi(object):
 
         Adds a file to an existing workActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity_file_by_url(body, work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity_file_by_url(body, work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int work_activity_id: Id of the workActivity to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class WorkActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_activity_file_by_url_with_http_info(body, work_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_activity_file_by_url_with_http_info(body, work_activity_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class WorkActivityApi(object):
 
         Adds a file to an existing workActivity by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity_file_by_url_with_http_info(body, work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity_file_by_url_with_http_info(body, work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int work_activity_id: Id of the workActivity to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['body', 'work_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class WorkActivityApi(object):
 
         Adds a tag to an existing workActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity_tag(work_activity_id, work_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity_tag(work_activity_id, work_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to add a tag to (required)
         :param str work_activity_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class WorkActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_activity_tag_with_http_info(work_activity_id, work_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_activity_tag_with_http_info(work_activity_id, work_activity_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class WorkActivityApi(object):
 
         Adds a tag to an existing workActivity.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_activity_tag_with_http_info(work_activity_id, work_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_activity_tag_with_http_info(work_activity_id, work_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to add a tag to (required)
         :param str work_activity_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id', 'work_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class WorkActivityApi(object):
 
         Deletes the workActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_activity(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_activity(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_work_activity_with_http_info(work_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_work_activity_with_http_info(work_activity_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class WorkActivityApi(object):
 
         Deletes the workActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_activity_with_http_info(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_activity_with_http_info(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class WorkActivityApi(object):
 
         Deletes an existing workActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_activity_file(work_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_activity_file(work_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class WorkActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_work_activity_file_with_http_info(work_activity_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_work_activity_file_with_http_info(work_activity_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class WorkActivityApi(object):
 
         Deletes an existing workActivity file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_activity_file_with_http_info(work_activity_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_activity_file_with_http_info(work_activity_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class WorkActivityApi(object):
 
         Deletes an existing workActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_activity_tag(work_activity_id, work_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_activity_tag(work_activity_id, work_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to remove tag from (required)
         :param str work_activity_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class WorkActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_work_activity_tag_with_http_info(work_activity_id, work_activity_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_work_activity_tag_with_http_info(work_activity_id, work_activity_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class WorkActivityApi(object):
 
         Deletes an existing workActivity tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_activity_tag_with_http_info(work_activity_id, work_activity_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_activity_tag_with_http_info(work_activity_id, work_activity_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to remove tag from (required)
         :param str work_activity_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id', 'work_activity_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class WorkActivityApi(object):
 
         Returns a duplicated workActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_work_activity_by_id(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_work_activity_by_id(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to be duplicated. (required)
         :return: WorkActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_work_activity_by_id_with_http_info(work_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_work_activity_by_id_with_http_info(work_activity_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class WorkActivityApi(object):
 
         Returns a duplicated workActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_work_activity_by_id_with_http_info(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_work_activity_by_id_with_http_info(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to be duplicated. (required)
         :return: WorkActivity
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type='WorkActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class WorkActivityApi(object):
 
         Returns the list of workActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_activity_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_activity_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class WorkActivityApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_work_activity_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class WorkActivityApi(object):
 
         Returns the list of workActivitys that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_activity_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_activity_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type='list[WorkActivity]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class WorkActivityApi(object):
 
         Returns the workActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_activity_by_id(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_activity_by_id(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to be returned. (required)
         :return: WorkActivity
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_activity_by_id_with_http_info(work_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_work_activity_by_id_with_http_info(work_activity_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class WorkActivityApi(object):
 
         Returns the workActivity identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_activity_by_id_with_http_info(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_activity_by_id_with_http_info(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to be returned. (required)
         :return: WorkActivity
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type='WorkActivity',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class WorkActivityApi(object):
 
         Get all existing workActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_activity_files(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_activity_files(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_activity_files_with_http_info(work_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_work_activity_files_with_http_info(work_activity_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class WorkActivityApi(object):
 
         Get all existing workActivity files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_activity_files_with_http_info(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_activity_files_with_http_info(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class WorkActivityApi(object):
 
         Get all existing workActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_activity_tags(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_activity_tags(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_activity_tags_with_http_info(work_activity_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_work_activity_tags_with_http_info(work_activity_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class WorkActivityApi(object):
 
         Get all existing workActivity tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_activity_tags_with_http_info(work_activity_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_activity_tags_with_http_info(work_activity_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_activity_id: Id of the workActivity to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['work_activity_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class WorkActivityApi(object):
 
         Updates an existing workActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work_activity(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work_activity(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WorkActivity body: WorkActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_work_activity_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_work_activity_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class WorkActivityApi(object):
 
         Updates an existing workActivity using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work_activity_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work_activity_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WorkActivity body: WorkActivity to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class WorkActivityApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class WorkActivityApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/work_api.py
+++ b/Infoplus/api/work_api.py
@@ -38,11 +38,11 @@ class WorkApi(object):
 
         Adds an audit to an existing work.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_audit(work_id, work_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_audit(work_id, work_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to add an audit to (required)
         :param str work_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class WorkApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_audit_with_http_info(work_id, work_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_audit_with_http_info(work_id, work_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class WorkApi(object):
 
         Adds an audit to an existing work.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_audit_with_http_info(work_id, work_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_audit_with_http_info(work_id, work_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to add an audit to (required)
         :param str work_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class WorkApi(object):
         """
 
         all_params = ['work_id', 'work_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class WorkApi(object):
 
         Adds a file to an existing work.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_file(work_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_file(work_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class WorkApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_file_with_http_info(work_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_file_with_http_info(work_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class WorkApi(object):
 
         Adds a file to an existing work.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_file_with_http_info(work_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_file_with_http_info(work_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class WorkApi(object):
         """
 
         all_params = ['work_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class WorkApi(object):
 
         Adds a file to an existing work by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_file_by_url(body, work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_file_by_url(body, work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int work_id: Id of the work to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class WorkApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_file_by_url_with_http_info(body, work_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_file_by_url_with_http_info(body, work_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class WorkApi(object):
 
         Adds a file to an existing work by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_file_by_url_with_http_info(body, work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_file_by_url_with_http_info(body, work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int work_id: Id of the work to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class WorkApi(object):
         """
 
         all_params = ['body', 'work_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class WorkApi(object):
 
         Adds a tag to an existing work.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_tag(work_id, work_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_tag(work_id, work_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to add a tag to (required)
         :param str work_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class WorkApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_tag_with_http_info(work_id, work_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_tag_with_http_info(work_id, work_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class WorkApi(object):
 
         Adds a tag to an existing work.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_tag_with_http_info(work_id, work_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_tag_with_http_info(work_id, work_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to add a tag to (required)
         :param str work_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class WorkApi(object):
         """
 
         all_params = ['work_id', 'work_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class WorkApi(object):
 
         Deletes an existing work file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_file(work_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_file(work_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class WorkApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_work_file_with_http_info(work_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_work_file_with_http_info(work_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class WorkApi(object):
 
         Deletes an existing work file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_file_with_http_info(work_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_file_with_http_info(work_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class WorkApi(object):
         """
 
         all_params = ['work_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class WorkApi(object):
 
         Deletes an existing work tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_tag(work_id, work_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_tag(work_id, work_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to remove tag from (required)
         :param str work_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class WorkApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_work_tag_with_http_info(work_id, work_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_work_tag_with_http_info(work_id, work_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class WorkApi(object):
 
         Deletes an existing work tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_tag_with_http_info(work_id, work_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_tag_with_http_info(work_id, work_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to remove tag from (required)
         :param str work_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class WorkApi(object):
         """
 
         all_params = ['work_id', 'work_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class WorkApi(object):
 
         Returns a duplicated work identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_work_by_id(work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_work_by_id(work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to be duplicated. (required)
         :return: Work
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_work_by_id_with_http_info(work_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_work_by_id_with_http_info(work_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class WorkApi(object):
 
         Returns a duplicated work identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_work_by_id_with_http_info(work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_work_by_id_with_http_info(work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to be duplicated. (required)
         :return: Work
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class WorkApi(object):
         """
 
         all_params = ['work_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type='Work',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class WorkApi(object):
 
         Returns the list of works that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class WorkApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_work_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class WorkApi(object):
 
         Returns the list of works that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class WorkApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type='list[Work]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class WorkApi(object):
 
         Returns the work identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_by_id(work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_by_id(work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to be returned. (required)
         :return: Work
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_by_id_with_http_info(work_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_work_by_id_with_http_info(work_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class WorkApi(object):
 
         Returns the work identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_by_id_with_http_info(work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_by_id_with_http_info(work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to be returned. (required)
         :return: Work
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class WorkApi(object):
         """
 
         all_params = ['work_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type='Work',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class WorkApi(object):
 
         Get all existing work files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_files(work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_files(work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_files_with_http_info(work_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_work_files_with_http_info(work_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class WorkApi(object):
 
         Get all existing work files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_files_with_http_info(work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_files_with_http_info(work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class WorkApi(object):
         """
 
         all_params = ['work_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class WorkApi(object):
 
         Get all existing work tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_tags(work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_tags(work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_tags_with_http_info(work_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_work_tags_with_http_info(work_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class WorkApi(object):
 
         Get all existing work tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_tags_with_http_info(work_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_tags_with_http_info(work_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_id: Id of the work to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class WorkApi(object):
         """
 
         all_params = ['work_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class WorkApi(object):
 
         Updates an existing work using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Work body: Work to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_work_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_work_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class WorkApi(object):
 
         Updates an existing work using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Work body: Work to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class WorkApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class WorkApi(object):
 
         Updates an existing work custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Work body: Work to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_work_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_work_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class WorkApi(object):
 
         Updates an existing work custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Work body: Work to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class WorkApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class WorkApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/work_batch_api.py
+++ b/Infoplus/api/work_batch_api.py
@@ -38,11 +38,11 @@ class WorkBatchApi(object):
 
         Adds an audit to an existing workBatch.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_batch_audit(work_batch_id, work_batch_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_batch_audit(work_batch_id, work_batch_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to add an audit to (required)
         :param str work_batch_audit: The audit to add (required)
         :return: None
@@ -50,7 +50,7 @@ class WorkBatchApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_batch_audit_with_http_info(work_batch_id, work_batch_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_batch_audit_with_http_info(work_batch_id, work_batch_audit, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class WorkBatchApi(object):
 
         Adds an audit to an existing workBatch.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_batch_audit_with_http_info(work_batch_id, work_batch_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_batch_audit_with_http_info(work_batch_id, work_batch_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to add an audit to (required)
         :param str work_batch_audit: The audit to add (required)
         :return: None
@@ -74,7 +74,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['work_batch_id', 'work_batch_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -134,7 +134,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -145,11 +145,11 @@ class WorkBatchApi(object):
 
         Adds a file to an existing workBatch.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_batch_file(work_batch_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_batch_file(work_batch_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -157,7 +157,7 @@ class WorkBatchApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_batch_file_with_http_info(work_batch_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_batch_file_with_http_info(work_batch_id, file_name, **kwargs)  # noqa: E501
@@ -168,11 +168,11 @@ class WorkBatchApi(object):
 
         Adds a file to an existing workBatch.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_batch_file_with_http_info(work_batch_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_batch_file_with_http_info(work_batch_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -181,7 +181,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['work_batch_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -248,11 +248,11 @@ class WorkBatchApi(object):
 
         Adds a file to an existing workBatch by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_batch_file_by_url(body, work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_batch_file_by_url(body, work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int work_batch_id: Id of the workBatch to add an file to (required)
         :return: None
@@ -260,7 +260,7 @@ class WorkBatchApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_batch_file_by_url_with_http_info(body, work_batch_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_batch_file_by_url_with_http_info(body, work_batch_id, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class WorkBatchApi(object):
 
         Adds a file to an existing workBatch by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_batch_file_by_url_with_http_info(body, work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_batch_file_by_url_with_http_info(body, work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int work_batch_id: Id of the workBatch to add an file to (required)
         :return: None
@@ -284,7 +284,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['body', 'work_batch_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +344,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -355,11 +355,11 @@ class WorkBatchApi(object):
 
         Adds a tag to an existing workBatch.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_batch_tag(work_batch_id, work_batch_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_batch_tag(work_batch_id, work_batch_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to add a tag to (required)
         :param str work_batch_tag: The tag to add (required)
         :return: None
@@ -367,7 +367,7 @@ class WorkBatchApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_work_batch_tag_with_http_info(work_batch_id, work_batch_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_work_batch_tag_with_http_info(work_batch_id, work_batch_tag, **kwargs)  # noqa: E501
@@ -378,11 +378,11 @@ class WorkBatchApi(object):
 
         Adds a tag to an existing workBatch.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_work_batch_tag_with_http_info(work_batch_id, work_batch_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_work_batch_tag_with_http_info(work_batch_id, work_batch_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to add a tag to (required)
         :param str work_batch_tag: The tag to add (required)
         :return: None
@@ -391,7 +391,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['work_batch_id', 'work_batch_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -451,7 +451,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -462,11 +462,11 @@ class WorkBatchApi(object):
 
         Deletes an existing workBatch file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_batch_file(work_batch_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_batch_file(work_batch_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -474,7 +474,7 @@ class WorkBatchApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_work_batch_file_with_http_info(work_batch_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_work_batch_file_with_http_info(work_batch_id, file_id, **kwargs)  # noqa: E501
@@ -485,11 +485,11 @@ class WorkBatchApi(object):
 
         Deletes an existing workBatch file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_batch_file_with_http_info(work_batch_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_batch_file_with_http_info(work_batch_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -498,7 +498,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['work_batch_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -554,7 +554,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -565,11 +565,11 @@ class WorkBatchApi(object):
 
         Deletes an existing workBatch tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_batch_tag(work_batch_id, work_batch_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_batch_tag(work_batch_id, work_batch_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to remove tag from (required)
         :param str work_batch_tag: The tag to delete (required)
         :return: None
@@ -577,7 +577,7 @@ class WorkBatchApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_work_batch_tag_with_http_info(work_batch_id, work_batch_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_work_batch_tag_with_http_info(work_batch_id, work_batch_tag, **kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class WorkBatchApi(object):
 
         Deletes an existing workBatch tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_work_batch_tag_with_http_info(work_batch_id, work_batch_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_work_batch_tag_with_http_info(work_batch_id, work_batch_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to remove tag from (required)
         :param str work_batch_tag: The tag to delete (required)
         :return: None
@@ -601,7 +601,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['work_batch_id', 'work_batch_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -668,18 +668,18 @@ class WorkBatchApi(object):
 
         Returns a duplicated workBatch identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_work_batch_by_id(work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_work_batch_by_id(work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to be duplicated. (required)
         :return: WorkBatch
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_work_batch_by_id_with_http_info(work_batch_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_work_batch_by_id_with_http_info(work_batch_id, **kwargs)  # noqa: E501
@@ -690,11 +690,11 @@ class WorkBatchApi(object):
 
         Returns a duplicated workBatch identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_work_batch_by_id_with_http_info(work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_work_batch_by_id_with_http_info(work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to be duplicated. (required)
         :return: WorkBatch
                  If the method is called asynchronously,
@@ -702,7 +702,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['work_batch_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -752,7 +752,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type='WorkBatch',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -763,11 +763,11 @@ class WorkBatchApi(object):
 
         Returns the list of workBatchs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_batch_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_batch_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -777,7 +777,7 @@ class WorkBatchApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_batch_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_work_batch_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -788,11 +788,11 @@ class WorkBatchApi(object):
 
         Returns the list of workBatchs that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_batch_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_batch_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -803,7 +803,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -855,7 +855,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type='list[WorkBatch]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -866,18 +866,18 @@ class WorkBatchApi(object):
 
         Returns the workBatch identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_batch_by_id(work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_batch_by_id(work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to be returned. (required)
         :return: WorkBatch
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_batch_by_id_with_http_info(work_batch_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_work_batch_by_id_with_http_info(work_batch_id, **kwargs)  # noqa: E501
@@ -888,11 +888,11 @@ class WorkBatchApi(object):
 
         Returns the workBatch identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_batch_by_id_with_http_info(work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_batch_by_id_with_http_info(work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to be returned. (required)
         :return: WorkBatch
                  If the method is called asynchronously,
@@ -900,7 +900,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['work_batch_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type='WorkBatch',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -961,18 +961,18 @@ class WorkBatchApi(object):
 
         Get all existing workBatch files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_batch_files(work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_batch_files(work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_batch_files_with_http_info(work_batch_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_work_batch_files_with_http_info(work_batch_id, **kwargs)  # noqa: E501
@@ -983,11 +983,11 @@ class WorkBatchApi(object):
 
         Get all existing workBatch files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_batch_files_with_http_info(work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_batch_files_with_http_info(work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -995,7 +995,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['work_batch_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1045,7 +1045,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1056,18 +1056,18 @@ class WorkBatchApi(object):
 
         Get all existing workBatch tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_batch_tags(work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_batch_tags(work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_work_batch_tags_with_http_info(work_batch_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_work_batch_tags_with_http_info(work_batch_id, **kwargs)  # noqa: E501
@@ -1078,11 +1078,11 @@ class WorkBatchApi(object):
 
         Get all existing workBatch tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_work_batch_tags_with_http_info(work_batch_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_work_batch_tags_with_http_info(work_batch_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int work_batch_id: Id of the workBatch to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1090,7 +1090,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['work_batch_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1140,7 +1140,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1151,18 +1151,18 @@ class WorkBatchApi(object):
 
         Updates an existing workBatch using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work_batch(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work_batch(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WorkBatch body: WorkBatch to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_work_batch_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_work_batch_with_http_info(body, **kwargs)  # noqa: E501
@@ -1173,11 +1173,11 @@ class WorkBatchApi(object):
 
         Updates an existing workBatch using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work_batch_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work_batch_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WorkBatch body: WorkBatch to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1185,7 +1185,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class WorkBatchApi(object):
 
         Updates an existing workBatch custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work_batch_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work_batch_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WorkBatch body: WorkBatch to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_work_batch_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_work_batch_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class WorkBatchApi(object):
 
         Updates an existing workBatch custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_work_batch_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_work_batch_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param WorkBatch body: WorkBatch to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class WorkBatchApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1338,7 +1338,7 @@ class WorkBatchApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api/zone_api.py
+++ b/Infoplus/api/zone_api.py
@@ -38,18 +38,18 @@ class ZoneApi(object):
 
         Inserts a new zone using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Zone body: Zone to be inserted. (required)
         :return: Zone
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_zone_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.add_zone_with_http_info(body, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ZoneApi(object):
 
         Inserts a new zone using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Zone body: Zone to be inserted. (required)
         :return: Zone
                  If the method is called asynchronously,
@@ -72,7 +72,7 @@ class ZoneApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -126,7 +126,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type='Zone',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -137,11 +137,11 @@ class ZoneApi(object):
 
         Adds an audit to an existing zone.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone_audit(zone_id, zone_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone_audit(zone_id, zone_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to add an audit to (required)
         :param str zone_audit: The audit to add (required)
         :return: None
@@ -149,7 +149,7 @@ class ZoneApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_zone_audit_with_http_info(zone_id, zone_audit, **kwargs)  # noqa: E501
         else:
             (data) = self.add_zone_audit_with_http_info(zone_id, zone_audit, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ZoneApi(object):
 
         Adds an audit to an existing zone.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone_audit_with_http_info(zone_id, zone_audit, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone_audit_with_http_info(zone_id, zone_audit, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to add an audit to (required)
         :param str zone_audit: The audit to add (required)
         :return: None
@@ -173,7 +173,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id', 'zone_audit']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -244,11 +244,11 @@ class ZoneApi(object):
 
         Adds a file to an existing zone.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone_file(zone_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone_file(zone_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -256,7 +256,7 @@ class ZoneApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_zone_file_with_http_info(zone_id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.add_zone_file_with_http_info(zone_id, file_name, **kwargs)  # noqa: E501
@@ -267,11 +267,11 @@ class ZoneApi(object):
 
         Adds a file to an existing zone.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone_file_with_http_info(zone_id, file_name, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone_file_with_http_info(zone_id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to add a file to (required)
         :param str file_name: Name of file (required)
         :return: None
@@ -280,7 +280,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -347,11 +347,11 @@ class ZoneApi(object):
 
         Adds a file to an existing zone by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone_file_by_url(body, zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone_file_by_url(body, zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int zone_id: Id of the zone to add an file to (required)
         :return: None
@@ -359,7 +359,7 @@ class ZoneApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_zone_file_by_url_with_http_info(body, zone_id, **kwargs)  # noqa: E501
         else:
             (data) = self.add_zone_file_by_url_with_http_info(body, zone_id, **kwargs)  # noqa: E501
@@ -370,11 +370,11 @@ class ZoneApi(object):
 
         Adds a file to an existing zone by URL.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone_file_by_url_with_http_info(body, zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone_file_by_url_with_http_info(body, zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param RecordFile body: The url and optionly fileName to be used. (required)
         :param int zone_id: Id of the zone to add an file to (required)
         :return: None
@@ -383,7 +383,7 @@ class ZoneApi(object):
         """
 
         all_params = ['body', 'zone_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -443,7 +443,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -454,11 +454,11 @@ class ZoneApi(object):
 
         Adds a tag to an existing zone.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone_tag(zone_id, zone_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone_tag(zone_id, zone_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to add a tag to (required)
         :param str zone_tag: The tag to add (required)
         :return: None
@@ -466,7 +466,7 @@ class ZoneApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.add_zone_tag_with_http_info(zone_id, zone_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.add_zone_tag_with_http_info(zone_id, zone_tag, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ZoneApi(object):
 
         Adds a tag to an existing zone.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_zone_tag_with_http_info(zone_id, zone_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.add_zone_tag_with_http_info(zone_id, zone_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to add a tag to (required)
         :param str zone_tag: The tag to add (required)
         :return: None
@@ -490,7 +490,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id', 'zone_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -550,7 +550,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -561,18 +561,18 @@ class ZoneApi(object):
 
         Deletes the zone identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_zone(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_zone(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_zone_with_http_info(zone_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_zone_with_http_info(zone_id, **kwargs)  # noqa: E501
@@ -583,11 +583,11 @@ class ZoneApi(object):
 
         Deletes the zone identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_zone_with_http_info(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_zone_with_http_info(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to be deleted. (required)
         :return: None
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -645,7 +645,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -656,11 +656,11 @@ class ZoneApi(object):
 
         Deletes an existing zone file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_zone_file(zone_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_zone_file(zone_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -668,7 +668,7 @@ class ZoneApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_zone_file_with_http_info(zone_id, file_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_zone_file_with_http_info(zone_id, file_id, **kwargs)  # noqa: E501
@@ -679,11 +679,11 @@ class ZoneApi(object):
 
         Deletes an existing zone file using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_zone_file_with_http_info(zone_id, file_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_zone_file_with_http_info(zone_id, file_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to remove file from (required)
         :param int file_id: Id of the file to delete (required)
         :return: None
@@ -692,7 +692,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id', 'file_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -748,7 +748,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -759,11 +759,11 @@ class ZoneApi(object):
 
         Deletes an existing zone tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_zone_tag(zone_id, zone_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_zone_tag(zone_id, zone_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to remove tag from (required)
         :param str zone_tag: The tag to delete (required)
         :return: None
@@ -771,7 +771,7 @@ class ZoneApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.delete_zone_tag_with_http_info(zone_id, zone_tag, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_zone_tag_with_http_info(zone_id, zone_tag, **kwargs)  # noqa: E501
@@ -782,11 +782,11 @@ class ZoneApi(object):
 
         Deletes an existing zone tag using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_zone_tag_with_http_info(zone_id, zone_tag, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.delete_zone_tag_with_http_info(zone_id, zone_tag, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to remove tag from (required)
         :param str zone_tag: The tag to delete (required)
         :return: None
@@ -795,7 +795,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id', 'zone_tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +851,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -862,18 +862,18 @@ class ZoneApi(object):
 
         Returns a duplicated zone identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_zone_by_id(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_zone_by_id(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to be duplicated. (required)
         :return: Zone
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_duplicate_zone_by_id_with_http_info(zone_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_duplicate_zone_by_id_with_http_info(zone_id, **kwargs)  # noqa: E501
@@ -884,11 +884,11 @@ class ZoneApi(object):
 
         Returns a duplicated zone identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_duplicate_zone_by_id_with_http_info(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_duplicate_zone_by_id_with_http_info(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to be duplicated. (required)
         :return: Zone
                  If the method is called asynchronously,
@@ -896,7 +896,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type='Zone',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -957,11 +957,11 @@ class ZoneApi(object):
 
         Returns the list of zones that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_zone_by_filter(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_zone_by_filter(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -971,7 +971,7 @@ class ZoneApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_zone_by_filter_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_zone_by_filter_with_http_info(**kwargs)  # noqa: E501
@@ -982,11 +982,11 @@ class ZoneApi(object):
 
         Returns the list of zones that match the given filter.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_zone_by_filter_with_http_info(async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_zone_by_filter_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str filter: Query string, used to filter results.
         :param int page: Result page number.  Defaults to 1.
         :param int limit: Maximum results per page.  Defaults to 20.  Max allowed value is 250.
@@ -997,7 +997,7 @@ class ZoneApi(object):
         """
 
         all_params = ['filter', 'page', 'limit', 'sort']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1049,7 +1049,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type='list[Zone]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1060,18 +1060,18 @@ class ZoneApi(object):
 
         Returns the zone identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_zone_by_id(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_zone_by_id(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to be returned. (required)
         :return: Zone
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_zone_by_id_with_http_info(zone_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_zone_by_id_with_http_info(zone_id, **kwargs)  # noqa: E501
@@ -1082,11 +1082,11 @@ class ZoneApi(object):
 
         Returns the zone identified by the specified id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_zone_by_id_with_http_info(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_zone_by_id_with_http_info(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to be returned. (required)
         :return: Zone
                  If the method is called asynchronously,
@@ -1094,7 +1094,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1144,7 +1144,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type='Zone',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1155,18 +1155,18 @@ class ZoneApi(object):
 
         Get all existing zone files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_zone_files(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_zone_files(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to get files for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_zone_files_with_http_info(zone_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_zone_files_with_http_info(zone_id, **kwargs)  # noqa: E501
@@ -1177,11 +1177,11 @@ class ZoneApi(object):
 
         Get all existing zone files.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_zone_files_with_http_info(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_zone_files_with_http_info(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to get files for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1189,7 +1189,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1239,7 +1239,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1250,18 +1250,18 @@ class ZoneApi(object):
 
         Get all existing zone tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_zone_tags(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_zone_tags(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to get tags for (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.get_zone_tags_with_http_info(zone_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_zone_tags_with_http_info(zone_id, **kwargs)  # noqa: E501
@@ -1272,11 +1272,11 @@ class ZoneApi(object):
 
         Get all existing zone tags.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_zone_tags_with_http_info(zone_id, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.get_zone_tags_with_http_info(zone_id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int zone_id: Id of the zone to get tags for (required)
         :return: None
                  If the method is called asynchronously,
@@ -1284,7 +1284,7 @@ class ZoneApi(object):
         """
 
         all_params = ['zone_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1334,7 +1334,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1345,18 +1345,18 @@ class ZoneApi(object):
 
         Updates an existing zone using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_zone(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_zone(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Zone body: Zone to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_zone_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_zone_with_http_info(body, **kwargs)  # noqa: E501
@@ -1367,11 +1367,11 @@ class ZoneApi(object):
 
         Updates an existing zone using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_zone_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_zone_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Zone body: Zone to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1379,7 +1379,7 @@ class ZoneApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1433,7 +1433,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1444,18 +1444,18 @@ class ZoneApi(object):
 
         Updates an existing zone custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_zone_custom_fields(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_zone_custom_fields(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Zone body: Zone to be updated. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.update_zone_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
         else:
             (data) = self.update_zone_custom_fields_with_http_info(body, **kwargs)  # noqa: E501
@@ -1466,11 +1466,11 @@ class ZoneApi(object):
 
         Updates an existing zone custom fields using the specified data.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_zone_custom_fields_with_http_info(body, async=True)
+        asynchronous HTTP request, please pass _async=True
+        >>> thread = api.update_zone_custom_fields_with_http_info(body, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param Zone body: Zone to be updated. (required)
         :return: None
                  If the method is called asynchronously,
@@ -1478,7 +1478,7 @@ class ZoneApi(object):
         """
 
         all_params = ['body']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1532,7 +1532,7 @@ class ZoneApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/Infoplus/api_client.py
+++ b/Infoplus/api_client.py
@@ -265,7 +265,7 @@ class ApiClient(object):
         elif klass == object:
             return self.__deserialize_object(data)
         elif klass == datetime.date:
-            return self.__deserialize_date(data)
+            return self.__deserialize_date(data)`
         elif klass == datetime.datetime:
             return self.__deserialize_datatime(data)
         else:
@@ -274,12 +274,12 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, async=None,
+                 response_type=None, auth_settings=None, _async=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
-        To make an async request, set the async parameter.
+        To make an async request, set the _asyn parameter.
 
         :param resource_path: Path to method endpoint.
         :param method: Method to call.
@@ -294,7 +294,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async bool: execute request asynchronously
+        :param _async bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param collection_formats: dict of collection formats for path, query,
@@ -307,13 +307,13 @@ class ApiClient(object):
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
         :return:
-            If async parameter is True,
+            If _asyn parameter is True,
             the request will be called asynchronously.
             The method will return the request thread.
-            If parameter async is False or missing,
+            If parameter _async is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not _async:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,

--- a/Infoplus/api_client.py
+++ b/Infoplus/api_client.py
@@ -265,7 +265,7 @@ class ApiClient(object):
         elif klass == object:
             return self.__deserialize_object(data)
         elif klass == datetime.date:
-            return self.__deserialize_date(data)`
+            return self.__deserialize_date(data)
         elif klass == datetime.datetime:
             return self.__deserialize_datatime(data)
         else:

--- a/Infoplus/models/packing_detail.py
+++ b/Infoplus/models/packing_detail.py
@@ -16,7 +16,6 @@ import re  # noqa: F401
 
 import six
 
-from Infoplus.models.gs1128_label_dto import GS1128LabelDTO  # noqa: F401,E501
 
 
 class PackingDetail(object):


### PR DESCRIPTION
1. `async` makes `py3.11` mad:
```bash
../../../../../../venv/lib/python3.11/site-packages/Infoplus/__init__.py:19: in <module>
    from Infoplus.api.aisle_api import AisleApi
../../../../../../venv/lib/python3.11/site-packages/Infoplus/api/__init__.py:6: in <module>
    from Infoplus.api.aisle_api import AisleApi
E     File "/Users/ericeisenberg/programming/backend/venv/lib/python3.11/site-packages/Infoplus/api/aisle_api.py", line 129
E       async=params.get('async'),
E       ^^^^^
E   SyntaxError: invalid syntax
```
we switch it to `_async` instead

2. removed the unused import:
```python
from Infoplus.models.gs1128_label_dto import GS1128LabelDTO  # noqa: F401,E501
```

------

after the fixes w/ `py3.11`:
```bash
...
============================== 5 passed in 2.63s ===============================
PASSED [ 20%]PASSED [ 40%]PASSED [ 60%]PASSED [ 80%]PASSED [100%]
Process finished with exit code 0
```